### PR TITLE
Create league from Drive template, schedules shortcut, hide timer nav

### DIFF
--- a/app/api/create-league/route.ts
+++ b/app/api/create-league/route.ts
@@ -1,14 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server'
 import * as XLSX from 'xlsx'
+import { parseTeamCountFromTemplateName } from '@/app/lib/parseTemplateTeamCount'
+import { exportGoogleSpreadsheetAsXlsx } from '@/app/lib/driveExportSpreadsheet'
+import {
+  applyTeamRenamesToWorkbook,
+  buildTeamRenamePairs,
+  extractTemplateTeams,
+  findTemplateTeamsNeverInGame01,
+} from '@/app/lib/mutateLeagueTemplate'
 
 interface CreateLeagueRequest {
   leagueName: string
-  numTeams: 4 | 6
+  /** Prefer deriving from `templateName`; optional for callers without a template. */
+  numTeams?: number
   teams: string[]
   numWeeks: number
   /** Team that should not play in the very first game slot (setup constraint) */
   avoidFirstRound?: string
-  /** Google Drive sheet ID of the template the user selected (metadata only) */
+  /** Google Drive spreadsheet id — when set, workbook is exported from Drive and team names are replaced */
   templateId?: string
   /** Human-readable name of the selected template (written into the workbook) */
   templateName?: string
@@ -51,7 +60,7 @@ function buildHeadToHeadCellFormula(
   return `=${parts.join('+')}`
 }
 
-function createLeagueWorkbook(data: CreateLeagueRequest) {
+function createLeagueWorkbook(data: CreateLeagueRequest & { numTeams: 4 | 6 | 7 }) {
   const { numTeams, teams, numWeeks, avoidFirstRound, templateName } = data
 
   // Create a new workbook
@@ -100,22 +109,15 @@ function createLeagueWorkbook(data: CreateLeagueRequest) {
   }
 
   // 3. League Standings Sheet
-  const standingsRows = numTeams === 4 ? 4 : 6
+  const standingsRows = numTeams
   const standingsData: (string | number)[][] = [
     ['LEAGUE STANDINGS', '', '', '', ''],
     ['Team Name', 'Points For', 'Points Against', 'Point Differential', ''],
-    ['', '', '', '', ''], // Row 3 - 1st place
-    ['', '', '', '', ''], // Row 4 - 2nd place
-    ['', '', '', '', ''], // Row 5 - 3rd place
-    ['', '', '', '', ''], // Row 6 - 4th place
   ]
-  
-  // Add rows 7-8 only for 6 teams
-  if (numTeams === 6) {
-    standingsData.push(['', '', '', '', ''], // Row 7 - 5th place
-                       ['', '', '', '', '']) // Row 8 - 6th place
+  for (let r = 0; r < numTeams; r++) {
+    standingsData.push(['', '', '', '', ''])
   }
-  
+
   standingsData.push(
     ['', '', '', '', ''],
     ['', '', '', '', ''],
@@ -136,12 +138,8 @@ function createLeagueWorkbook(data: CreateLeagueRequest) {
     // Build wins formula (sum from all week sheets)
     // Row calculation: 
     // - Row 1: Header "Court 1"
-    // - Rows 2-25 (4 teams) or 2-61 (6 teams): Games (12 or 30 games × 2 rows each = game + ref)
-    // - Row 26 or 62: Empty spacing
-    // - Row 27 or 63: "Team Wins/Losses This Week"
-    // - Row 28 or 64: "Team Name", "Wins", "Losses" header
-    // - Row 29+ or 65+: Team rows
-    const gamesPerWeek = numTeams === 4 ? 12 : 30
+    // - Games block: n(n−1) games/week × 2 rows (game + ref), then win/loss block
+    const gamesPerWeek = numTeams * (numTeams - 1)
     const teamFormulaStartRow = 1 + gamesPerWeek * 2 + 3 + 1 // 1 header + games*2 + spacing(1) + header(1) + header(1) + 1
     const winsParts: string[] = []
     for (let week = 1; week <= numWeeks; week++) {
@@ -603,9 +601,162 @@ function createLeagueWorkbook(data: CreateLeagueRequest) {
     return distributedGames
   }
 
+  // 7-TEAM SCHEDULE: Each team plays each opponent twice per week
+  // 42 games per week (21 unique pairs × 2 games each); each team plays 12 games and refs 6
+  function generate7TeamSchedule(teams: string[]): Array<{ team1: string; team2: string; ref?: string }> {
+    const gamePairs: Array<{ team1: string; team2: string; homeTeam: string }> = []
+
+    for (let i = 0; i < teams.length; i++) {
+      for (let j = i + 1; j < teams.length; j++) {
+        gamePairs.push({ team1: teams[i], team2: teams[j], homeTeam: teams[i] })
+        gamePairs.push({ team1: teams[i], team2: teams[j], homeTeam: teams[j] })
+      }
+    }
+
+    const teamGameCount: Map<string, number> = new Map()
+    const teamLastPosition: Map<string, number> = new Map()
+    const teamLargeGapCount: Map<string, number> = new Map()
+    const maxWaitThreshold = 5
+    teams.forEach((team) => {
+      teamGameCount.set(team, 0)
+      teamLastPosition.set(team, -1)
+      teamLargeGapCount.set(team, 0)
+    })
+
+    const distributedGames: Array<{ team1: string; team2: string; ref?: string }> = []
+    const remainingGames = [...gamePairs]
+
+    while (remainingGames.length > 0) {
+      let bestGameIndex = -1
+      let bestScore = -Infinity
+
+      const teamWaitTimes: Map<string, number> = new Map()
+      const currentLength: number = distributedGames.length as number
+      teams.forEach((team) => {
+        const lastPos = teamLastPosition.get(team) || -1
+        const waitTime = lastPos === -1 ? currentLength : currentLength - lastPos
+        teamWaitTimes.set(team, waitTime)
+      })
+
+      const urgentTeams = new Set<string>()
+      teamWaitTimes.forEach((waitTime, team) => {
+        if (waitTime >= maxWaitThreshold) {
+          urgentTeams.add(team)
+        }
+      })
+
+      remainingGames.forEach((gamePair, index) => {
+        const team1 = gamePair.team1
+        const team2 = gamePair.team2
+
+        const team1Games = teamGameCount.get(team1) || 0
+        const team2Games = teamGameCount.get(team2) || 0
+        const wait1 = teamWaitTimes.get(team1) || 0
+        const wait2 = teamWaitTimes.get(team2) || 0
+        const largeGapCount1 = teamLargeGapCount.get(team1) || 0
+        const largeGapCount2 = teamLargeGapCount.get(team2) || 0
+
+        const addressesUrgent = urgentTeams.has(team1) || urgentTeams.has(team2)
+
+        const urgency1 =
+          wait1 >= maxWaitThreshold
+            ? Math.pow(2, wait1 - maxWaitThreshold + 2) * 50000
+            : wait1 * 200
+        const urgency2 =
+          wait2 >= maxWaitThreshold
+            ? Math.pow(2, wait2 - maxWaitThreshold + 2) * 50000
+            : wait2 * 200
+
+        const largeGapPenalty1 = largeGapCount1 > 0 ? largeGapCount1 * 5000 : 0
+        const largeGapPenalty2 = largeGapCount2 > 0 ? largeGapCount2 * 5000 : 0
+
+        const score =
+          urgency1 +
+          urgency2 +
+          (12 - team1Games) * 5 +
+          (12 - team2Games) * 5 +
+          (addressesUrgent ? 1000 : 0) -
+          largeGapPenalty1 -
+          largeGapPenalty2
+
+        if (score > bestScore) {
+          bestScore = score
+          bestGameIndex = index
+        }
+      })
+
+      const selectedGame = remainingGames.splice(bestGameIndex, 1)[0]
+
+      const game = {
+        team1: selectedGame.homeTeam,
+        team2: selectedGame.homeTeam === selectedGame.team1 ? selectedGame.team2 : selectedGame.team1,
+        ref: undefined as string | undefined,
+      }
+
+      distributedGames.push(game)
+
+      const gamesLength: number = distributedGames.length as number
+      ;[game.team1, game.team2].forEach((team) => {
+        const lastPos = teamLastPosition.get(team) || -1
+        if (lastPos !== -1) {
+          const gap = gamesLength - 1 - lastPos
+          if (gap >= maxWaitThreshold) {
+            teamLargeGapCount.set(team, (teamLargeGapCount.get(team) || 0) + 1)
+          }
+        }
+      })
+
+      teamGameCount.set(game.team1, (teamGameCount.get(game.team1) || 0) + 1)
+      teamGameCount.set(game.team2, (teamGameCount.get(game.team2) || 0) + 1)
+      teamLastPosition.set(game.team1, gamesLength - 1)
+      teamLastPosition.set(game.team2, gamesLength - 1)
+    }
+
+    const refPool: Map<string, number> = new Map()
+    teams.forEach((team) => refPool.set(team, 6))
+
+    let lastRef: string | undefined = undefined
+
+    distributedGames.forEach((game) => {
+      const allAvailableRefs = teams.filter(
+        (team) =>
+          team !== game.team1 && team !== game.team2 && (refPool.get(team) || 0) > 0
+      )
+
+      if (allAvailableRefs.length === 0) {
+        const anyAvailable = teams.find(
+          (team) =>
+            team !== game.team1 && team !== game.team2 && (refPool.get(team) || 0) > 0
+        )
+        if (anyAvailable) {
+          game.ref = anyAvailable
+          refPool.set(anyAvailable, (refPool.get(anyAvailable) || 0) - 1)
+          lastRef = anyAvailable
+        }
+        return
+      }
+
+      const preferredRefs = allAvailableRefs.filter((team) => team !== lastRef)
+      const refsToChooseFrom = preferredRefs.length > 0 ? preferredRefs : allAvailableRefs
+
+      const refIndex = Math.floor(Math.random() * refsToChooseFrom.length)
+      const selectedRef = refsToChooseFrom[refIndex]
+      game.ref = selectedRef
+      refPool.set(selectedRef, (refPool.get(selectedRef) || 0) - 1)
+      lastRef = selectedRef
+    })
+
+    return distributedGames
+  }
+
   // Generate games for each week using the appropriate schedule function
   const weekGames: Array<Array<{ team1: string; team2: string; ref?: string }>> = []
-  const generateSchedule = numTeams === 4 ? generate4TeamSchedule : generate6TeamSchedule
+  const generateSchedule =
+    numTeams === 4
+      ? generate4TeamSchedule
+      : numTeams === 7
+        ? generate7TeamSchedule
+        : generate6TeamSchedule
   for (let week = 0; week < numWeeks; week++) {
     const games = generateSchedule(teams)
 
@@ -673,25 +824,49 @@ export async function POST(request: NextRequest) {
   try {
     const body: CreateLeagueRequest = await request.json()
 
-    // Validation - support 4 or 6 teams and 6 weeks
-    if (!body.leagueName || !body.teams || !body.numTeams) {
+    if (!body.leagueName || !body.teams) {
       return NextResponse.json(
-        { error: 'League name, number of teams, and teams are required' },
+        { error: 'League name and teams are required' },
         { status: 400 }
       )
     }
 
-    if (body.numTeams !== 4 && body.numTeams !== 6) {
+    let numTeams: number
+    if (body.templateName?.trim()) {
+      const parsed = parseTeamCountFromTemplateName(body.templateName)
+      if (parsed === null) {
+        return NextResponse.json(
+          {
+            error:
+              'Could not determine team count from the template name. Use a name like "Six Team League" or "4 Team".',
+          },
+          { status: 400 },
+        )
+      }
+      numTeams = parsed
+    } else if (body.numTeams === 4 || body.numTeams === 6 || body.numTeams === 7) {
+      numTeams = body.numTeams
+    } else {
       return NextResponse.json(
-        { error: 'Number of teams must be 4 or 6' },
-        { status: 400 }
+        {
+          error:
+            'Select a league template (team count comes from its name), or send numTeams 4, 6, or 7 when calling the API without a template.',
+        },
+        { status: 400 },
       )
     }
 
-    if (body.teams.length !== body.numTeams) {
+    if (numTeams !== 4 && numTeams !== 6 && numTeams !== 7) {
       return NextResponse.json(
-        { error: `Number of teams must match: expected ${body.numTeams}, got ${body.teams.length}` },
-        { status: 400 }
+        { error: 'Only 4-, 6-, and 7-team leagues are supported.' },
+        { status: 400 },
+      )
+    }
+
+    if (body.teams.length !== numTeams) {
+      return NextResponse.json(
+        { error: `Number of teams must match: expected ${numTeams}, got ${body.teams.length}` },
+        { status: 400 },
       )
     }
 
@@ -702,13 +877,57 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    // Create workbook
-    const workbook = createLeagueWorkbook(body)
+    if (body.templateId?.trim()) {
+      try {
+        const xlsxBuf = await exportGoogleSpreadsheetAsXlsx(body.templateId.trim())
+        const wb = XLSX.read(xlsxBuf, { type: 'array', cellDates: true })
+        const templateTeams = extractTemplateTeams(wb)
+        if (templateTeams.length !== numTeams) {
+          return NextResponse.json(
+            {
+              error: `This sheet has ${templateTeams.length} teams in standings / roster, but the selected template name implies ${numTeams}. Align the Drive file with the template or pick the matching entry.`,
+            },
+            { status: 400 },
+          )
+        }
+        if (templateTeams.length !== body.teams.length) {
+          return NextResponse.json(
+            {
+              error: `Template has ${templateTeams.length} team rows; you entered ${body.teams.length} names.`,
+            },
+            { status: 400 },
+          )
+        }
 
-    // Convert workbook to buffer directly (no temp file needed)
+        const neverG01 = findTemplateTeamsNeverInGame01(wb, templateTeams)
+        const pairs = buildTeamRenamePairs(
+          templateTeams,
+          body.teams,
+          body.avoidFirstRound,
+          neverG01,
+        )
+        applyTeamRenamesToWorkbook(wb, pairs)
+
+        const fileBuffer = XLSX.write(wb, { type: 'buffer', bookType: 'xlsx' })
+        return new NextResponse(fileBuffer, {
+          headers: {
+            'Content-Type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            'Content-Disposition': `attachment; filename="${body.leagueName.replace(/\s+/g, '_')}.xlsx"`,
+          },
+        })
+      } catch (e) {
+        console.error('Template export/mutate failed:', e)
+        const message =
+          e instanceof Error
+            ? e.message
+            : 'Could not load the Google Sheet template. Check Drive sharing and GOOGLE_DRIVE_API_KEY.'
+        return NextResponse.json({ error: message }, { status: 502 })
+      }
+    }
+
+    const workbook = createLeagueWorkbook({ ...body, numTeams })
     const fileBuffer = XLSX.write(workbook, { type: 'buffer', bookType: 'xlsx' })
 
-    // Return as downloadable file
     return new NextResponse(fileBuffer, {
       headers: {
         'Content-Type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',

--- a/app/api/create-league/route.ts
+++ b/app/api/create-league/route.ts
@@ -23,6 +23,22 @@ interface CreateLeagueRequest {
   templateName?: string
 }
 
+/** 502 only for Drive HTTP failures; 500 for missing config or local/mutation errors. */
+function httpStatusForTemplateBranchError(e: unknown): number {
+  if (e instanceof Error) {
+    if (
+      e.message.includes('GOOGLE_DRIVE_API_KEY') ||
+      e.message === 'Missing file id'
+    ) {
+      return 500
+    }
+    if (e.message.startsWith('Drive export failed')) {
+      return 502
+    }
+  }
+  return 500
+}
+
 /** Sheet names with quotes for formulas (escaped apostrophe). */
 function escapeSheetTitleForFormula(name: string): string {
   return name.replace(/'/g, "''")
@@ -296,7 +312,7 @@ function createLeagueWorkbook(data: CreateLeagueRequest & { numTeams: 4 | 6 | 7 
       const teamWaitTimes: Map<string, number> = new Map()
       const currentLength: number = distributedGames.length
       teams.forEach(team => {
-        const lastPos = teamLastPosition.get(team) || -1
+        const lastPos = teamLastPosition.get(team) ?? -1
         const waitTime = lastPos === -1 ? currentLength : currentLength - lastPos
         teamWaitTimes.set(team, waitTime)
       })
@@ -362,7 +378,7 @@ function createLeagueWorkbook(data: CreateLeagueRequest & { numTeams: 4 | 6 | 7 
       
       const gamesLength: number = distributedGames.length as number
       [game.team1, game.team2].forEach(team => {
-        const lastPos = teamLastPosition.get(team) || -1
+        const lastPos = teamLastPosition.get(team) ?? -1
         if (lastPos !== -1) {
           const gap = gamesLength - 1 - lastPos
           if (gap >= maxWaitThreshold) {
@@ -458,7 +474,7 @@ function createLeagueWorkbook(data: CreateLeagueRequest & { numTeams: 4 | 6 | 7 
       const teamWaitTimes: Map<string, number> = new Map()
       const currentLength: number = distributedGames.length as number
       teams.forEach(team => {
-        const lastPos = teamLastPosition.get(team) || -1
+        const lastPos = teamLastPosition.get(team) ?? -1
         const waitTime = lastPos === -1 ? currentLength : currentLength - lastPos
         teamWaitTimes.set(team, waitTime)
       })
@@ -534,7 +550,7 @@ function createLeagueWorkbook(data: CreateLeagueRequest & { numTeams: 4 | 6 | 7 
       // Check if this game creates a large gap for either team
       const gamesLength: number = distributedGames.length as number
       [game.team1, game.team2].forEach(team => {
-        const lastPos = teamLastPosition.get(team) || -1
+        const lastPos = teamLastPosition.get(team) ?? -1
         if (lastPos !== -1) {
           const gap = gamesLength - 1 - lastPos
           if (gap >= maxWaitThreshold) {
@@ -633,7 +649,7 @@ function createLeagueWorkbook(data: CreateLeagueRequest & { numTeams: 4 | 6 | 7 
       const teamWaitTimes: Map<string, number> = new Map()
       const currentLength: number = distributedGames.length as number
       teams.forEach((team) => {
-        const lastPos = teamLastPosition.get(team) || -1
+        const lastPos = teamLastPosition.get(team) ?? -1
         const waitTime = lastPos === -1 ? currentLength : currentLength - lastPos
         teamWaitTimes.set(team, waitTime)
       })
@@ -697,7 +713,7 @@ function createLeagueWorkbook(data: CreateLeagueRequest & { numTeams: 4 | 6 | 7 
 
       const gamesLength: number = distributedGames.length as number
       ;[game.team1, game.team2].forEach((team) => {
-        const lastPos = teamLastPosition.get(team) || -1
+        const lastPos = teamLastPosition.get(team) ?? -1
         if (lastPos !== -1) {
           const gap = gamesLength - 1 - lastPos
           if (gap >= maxWaitThreshold) {
@@ -921,7 +937,8 @@ export async function POST(request: NextRequest) {
           e instanceof Error
             ? e.message
             : 'Could not load the Google Sheet template. Check Drive sharing and GOOGLE_DRIVE_API_KEY.'
-        return NextResponse.json({ error: message }, { status: 502 })
+        const status = httpStatusForTemplateBranchError(e)
+        return NextResponse.json({ error: message }, { status })
       }
     }
 

--- a/app/components/TopNav.tsx
+++ b/app/components/TopNav.tsx
@@ -10,12 +10,6 @@ export default function TopNav() {
         <Link href="/create-league" className="hover:underline">
           Create League
         </Link>
-        <Link href="/timer" className="hover:underline">
-          Round Timer
-        </Link>
-        <Link href="/timer-standalone" className="hover:underline">
-          Standalone Timer
-        </Link>
       </div>
     </nav>
   );

--- a/app/create-league/page.tsx
+++ b/app/create-league/page.tsx
@@ -1,6 +1,8 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { Suspense, useState, useEffect } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { parseTeamCountFromTemplateName } from '@/app/lib/parseTemplateTeamCount'
 
 interface DriveFile {
   id: string
@@ -13,7 +15,7 @@ interface FormData {
   templateId: string
   templateName: string
   leagueName: string
-  numTeams: 4 | 6
+  numTeams: number
   teams: string[]
   avoidFirstRound: string
 }
@@ -22,12 +24,32 @@ const INITIAL_FORM: FormData = {
   templateId: '',
   templateName: '',
   leagueName: '',
-  numTeams: 6,
-  teams: ['', '', '', '', '', ''],
+  numTeams: 0,
+  teams: [],
   avoidFirstRound: '',
 }
 
-export default function CreateLeaguePage() {
+/** Per-week stats shown in the UI. Seven-team Drive template uses 35 games (not full n(n−1)). */
+function scheduleSummary(n: number) {
+  if (n === 7) {
+    return { gamesPerWeek: 35, gamesPerTeamPerWeek: 10, refsPerTeamPerWeek: 5 }
+  }
+  const gamesPerWeek = n * (n - 1)
+  const gamesPerTeamPerWeek = (n - 1) * 2
+  const refsPerTeamPerWeek = gamesPerWeek / n
+  return { gamesPerWeek, gamesPerTeamPerWeek, refsPerTeamPerWeek }
+}
+
+function teamsStateFromTemplateName(templateName: string): Pick<FormData, 'numTeams' | 'teams'> {
+  const n = parseTeamCountFromTemplateName(templateName)
+  if (n === null) return { numTeams: 0, teams: [] }
+  return { numTeams: n, teams: Array(n).fill('') }
+}
+
+function CreateLeagueForm() {
+  const searchParams = useSearchParams()
+  const prefTemplateId = searchParams.get('templateId') ?? ''
+
   const [step, setStep] = useState<Step>(1)
   const [formData, setFormData] = useState<FormData>(INITIAL_FORM)
   const [templates, setTemplates] = useState<DriveFile[]>([])
@@ -47,25 +69,25 @@ export default function CreateLeaguePage() {
       })
       .then((data: DriveFile[]) => {
         setTemplates(data)
-        if (data.length > 0) {
-          setFormData((f) => ({
-            ...f,
-            templateId: data[0].id,
-            templateName: data[0].name,
-          }))
-        }
       })
       .catch((err) => setTemplatesError(err.message))
       .finally(() => setLoadingTemplates(false))
   }, [])
 
-  function handleNumTeamsChange(numTeams: 4 | 6) {
+  useEffect(() => {
+    if (templates.length === 0) return
+    const t = prefTemplateId ? templates.find((x) => x.id === prefTemplateId) : null
+    const sel = t ?? templates[0]
+    if (!sel) return
+    const { numTeams, teams } = teamsStateFromTemplateName(sel.name)
     setFormData((f) => ({
       ...f,
+      templateId: sel.id,
+      templateName: sel.name,
       numTeams,
-      teams: Array(numTeams).fill(''),
+      teams,
     }))
-  }
+  }, [templates, prefTemplateId])
 
   function updateTeam(index: number, value: string) {
     const newTeams = [...formData.teams]
@@ -76,6 +98,13 @@ export default function CreateLeaguePage() {
   function validateStep1(): string | null {
     if (!formData.templateId) return 'Please select a league template'
     if (!formData.leagueName.trim()) return 'Please enter a league name'
+    const n = parseTeamCountFromTemplateName(formData.templateName)
+    if (n === null) {
+      return (
+        'Could not determine team count from the template name. ' +
+        'Rename the template to include a pattern like "Six Team" or "4 Team".'
+      )
+    }
     return null
   }
 
@@ -186,11 +215,14 @@ export default function CreateLeaguePage() {
               <select
                 value={formData.templateId}
                 onChange={(e) => {
-                  const t = templates.find((t) => t.id === e.target.value)
+                  const t = templates.find((x) => x.id === e.target.value)
+                  const { numTeams, teams } = teamsStateFromTemplateName(t?.name ?? '')
                   setFormData((f) => ({
                     ...f,
                     templateId: e.target.value,
                     templateName: t?.name ?? '',
+                    numTeams,
+                    teams,
                   }))
                 }}
                 className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500"
@@ -203,29 +235,27 @@ export default function CreateLeaguePage() {
               </select>
             )}
             <p className="mt-1 text-xs text-gray-500">
-              Templates come from the shared Google Drive folder.
+              Templates come from the shared Google Drive folder. Team count is taken from the file
+              name. The downloaded workbook is that Google Sheet exported to Excel with your team
+              names filled in (same schedule layout as the template).
             </p>
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              Number of Teams *
-            </label>
-            <div className="flex gap-6">
-              {([4, 6] as const).map((n) => (
-                <label key={n} className="flex items-center cursor-pointer">
-                  <input
-                    type="radio"
-                    name="numTeams"
-                    value={n}
-                    checked={formData.numTeams === n}
-                    onChange={() => handleNumTeamsChange(n)}
-                    className="mr-2"
-                  />
-                  <span>{n} Teams</span>
-                </label>
-              ))}
-            </div>
+            {formData.templateName &&
+              (() => {
+                const n = parseTeamCountFromTemplateName(formData.templateName)
+                if (n === null) {
+                  return (
+                    <p className="mt-2 text-xs text-amber-700">
+                      Could not read team count from this file name — use a name that includes the number of
+                      teams.
+                    </p>
+                  )
+                }
+                return (
+                  <p className="mt-2 text-xs text-gray-600">
+                    This template is for <strong>{n} teams</strong>.
+                  </p>
+                )
+              })()}
           </div>
 
           <div>
@@ -338,8 +368,11 @@ export default function CreateLeaguePage() {
                 ))}
               </select>
               <p className="mt-1 text-xs text-gray-500">
-                This team will not be scheduled to play in game 1 of Week 1, useful if they need
-                setup time at the start of the season.
+                For templates exported from Google Drive, your choice here is matched to the team
+                that never appears in <strong>game 1</strong> on any week (e.g. the seven-team
+                template). Enter teams in step 2 in <strong>League Standings</strong> order, then
+                pick which of your names should take that “late start” slot. Leave blank to keep
+                the default name-to-slot mapping from step 2.
               </p>
             </div>
           </div>
@@ -348,17 +381,22 @@ export default function CreateLeaguePage() {
             <p className="font-semibold mb-2">Schedule summary:</p>
             <ul className="list-disc list-inside space-y-1">
               <li>{formData.numTeams} teams, 6 weeks</li>
-              <li>{formData.numTeams === 4 ? '12' : '30'} games per week</li>
-              <li>
-                Each team plays{' '}
-                {formData.numTeams === 4 ? '6' : '10'} games per week (every opponent twice)
-              </li>
-              <li>
-                Each team refs {formData.numTeams === 4 ? '3' : '5'} games per week
-              </li>
+              {(() => {
+                const s = scheduleSummary(formData.numTeams)
+                return (
+                  <>
+                    <li>{s.gamesPerWeek} games per week</li>
+                    <li>
+                      Each team plays {s.gamesPerTeamPerWeek} games per week (every opponent twice)
+                    </li>
+                    <li>Each team refs {s.refsPerTeamPerWeek} games per week</li>
+                  </>
+                )
+              })()}
               {formData.avoidFirstRound && (
                 <li>
-                  <strong>{formData.avoidFirstRound}</strong> will not appear in game 1 of Week 1
+                  <strong>{formData.avoidFirstRound}</strong> is matched to the template&rsquo;s
+                  &ldquo;never in game 1&rdquo; roster slot when that pattern exists (seven-team).
                 </li>
               )}
             </ul>
@@ -402,5 +440,17 @@ export default function CreateLeaguePage() {
         </form>
       )}
     </div>
+  )
+}
+
+export default function CreateLeaguePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="container mx-auto px-4 py-8 max-w-2xl text-gray-600">Loading…</div>
+      }
+    >
+      <CreateLeagueForm />
+    </Suspense>
   )
 }

--- a/app/lib/driveExportSpreadsheet.ts
+++ b/app/lib/driveExportSpreadsheet.ts
@@ -1,0 +1,28 @@
+/**
+ * Export a native Google Spreadsheet (Drive file) to .xlsx bytes using the Drive API.
+ * Requires GOOGLE_DRIVE_API_KEY and a file that is readable with that key (e.g. link-shared).
+ */
+export async function exportGoogleSpreadsheetAsXlsx(fileId: string): Promise<ArrayBuffer> {
+  const key = process.env.GOOGLE_DRIVE_API_KEY
+  if (!key) {
+    throw new Error('GOOGLE_DRIVE_API_KEY is not configured')
+  }
+  const id = fileId.trim()
+  if (!id) {
+    throw new Error('Missing file id')
+  }
+
+  const mime = encodeURIComponent(
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  )
+  const url = `https://www.googleapis.com/drive/v3/files/${encodeURIComponent(
+    id,
+  )}/export?mimeType=${mime}&key=${encodeURIComponent(key)}`
+
+  const res = await fetch(url)
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`Drive export failed (${res.status}): ${text.slice(0, 200)}`)
+  }
+  return res.arrayBuffer()
+}

--- a/app/lib/mutateLeagueTemplate.ts
+++ b/app/lib/mutateLeagueTemplate.ts
@@ -1,0 +1,172 @@
+import * as XLSX from 'xlsx'
+
+/** Week tabs like "Week 1 Schedule" */
+const WEEK_SCHEDULE_NAME_RE = /^Week\s+\d+\s+Schedule\s*$/i
+
+function sheetRows(sheet: XLSX.WorkSheet): string[][] {
+  return XLSX.utils.sheet_to_json(sheet, { header: 1, defval: '' }) as string[][]
+}
+
+/** Teams listed under League Standings — rows after "Teams | Wins | … | Losses". */
+export function extractTemplateTeamsFromStandings(wb: XLSX.WorkBook): string[] | null {
+  const sh = wb.Sheets['League Standings']
+  if (!sh) return null
+  const rows = sheetRows(sh)
+  let found = false
+  const teams: string[] = []
+  for (const row of rows) {
+    const a = String(row[0] ?? '').trim()
+    const b = String(row[1] ?? '').trim()
+    if (!found) {
+      if (a === 'Teams' && b === 'Wins') found = true
+      continue
+    }
+    if (!a) break
+    if (a.startsWith('=')) break
+    teams.push(a)
+  }
+  return teams.length ? teams : null
+}
+
+export function extractTemplateTeamsFromTeamsSheet(wb: XLSX.WorkBook): string[] | null {
+  const sh = wb.Sheets.Teams ?? wb.Sheets['Teams']
+  if (!sh) return null
+  const rows = sheetRows(sh)
+  const header = rows[0]
+  if (!header || String(header[0]).trim() !== 'Team Names') return null
+  const names = header.slice(2).map((c) => String(c ?? '').trim()).filter(Boolean)
+  return names.length ? names : null
+}
+
+export function extractTemplateTeamsFromScheduleGenerator(wb: XLSX.WorkBook): string[] | null {
+  const sh = wb.Sheets['Schedule Generator']
+  if (!sh) return null
+  const rows = sheetRows(sh)
+  const header = rows[0]
+  if (!header) return null
+  const names = header
+    .slice(1)
+    .map((c) => String(c ?? '').trim())
+    .filter((c) => c && c !== '-')
+  return names.length ? names : null
+}
+
+/** Ordered template team names (standings order preferred). */
+export function extractTemplateTeams(wb: XLSX.WorkBook): string[] {
+  const a = extractTemplateTeamsFromStandings(wb)
+  if (a?.length) return a
+  const b = extractTemplateTeamsFromTeamsSheet(wb)
+  if (b?.length) return b
+  const c = extractTemplateTeamsFromScheduleGenerator(wb)
+  if (c?.length) return c
+  throw new Error('Could not find team names in template (no standings / Teams / Schedule Generator).')
+}
+
+/** Teams that never appear on the first game row (two-court layout) in any week schedule tab. */
+export function findTemplateTeamsNeverInGame01(
+  wb: XLSX.WorkBook,
+  templateTeams: string[],
+): string[] {
+  const teamSet = new Set(templateTeams)
+  const weekNames = wb.SheetNames.filter((n) => WEEK_SCHEDULE_NAME_RE.test(n))
+  if (weekNames.length === 0) return []
+
+  let intersection: Set<string> | null = null
+
+  for (const name of weekNames) {
+    const sh = wb.Sheets[name]
+    if (!sh) continue
+    const rows = sheetRows(sh)
+    const row0 = rows[0]
+    if (!row0) continue
+    const inGame = new Set<string>()
+    for (let c = 1; c < row0.length; c++) {
+      const v = String(row0[c] ?? '').trim()
+      if (!v || v.startsWith('Game')) continue
+      if (teamSet.has(v)) inGame.add(v)
+    }
+    const missing = new Set(templateTeams.filter((t) => !inGame.has(t)))
+    if (intersection === null) {
+      intersection = missing
+    } else {
+      const next = new Set<string>()
+      for (const x of intersection) {
+        if (missing.has(x)) next.add(x)
+      }
+      intersection = next
+    }
+  }
+
+  return intersection ? [...intersection] : []
+}
+
+export function buildTeamRenamePairs(
+  templateTeams: string[],
+  userTeams: string[],
+  avoidFirstRound: string | undefined,
+  templateNeverGame01: string[],
+): Array<{ from: string; to: string }> {
+  if (userTeams.length !== templateTeams.length) {
+    throw new Error(
+      `Team count mismatch: template has ${templateTeams.length}, request has ${userTeams.length}`,
+    )
+  }
+
+  const perm = [...userTeams]
+  if (avoidFirstRound?.trim() && templateNeverGame01.length === 1) {
+    const templateAvoid = templateNeverGame01[0]
+    const tIdx = templateTeams.indexOf(templateAvoid)
+    const uIdx = userTeams.indexOf(avoidFirstRound.trim())
+    if (tIdx >= 0 && uIdx >= 0 && tIdx !== uIdx) {
+      const tmp = perm[tIdx]!
+      perm[tIdx] = perm[uIdx]!
+      perm[uIdx] = tmp
+    }
+  }
+
+  const pairs: Array<{ from: string; to: string }> = []
+  for (let i = 0; i < templateTeams.length; i++) {
+    pairs.push({ from: templateTeams[i]!, to: perm[i]! })
+  }
+  return pairs.sort((a, b) => b.from.length - a.from.length)
+}
+
+/** Apply replacements to literal values and formula strings. */
+export function applyTeamRenamesToWorkbook(wb: XLSX.WorkBook, pairs: Array<{ from: string; to: string }>) {
+  for (const sheetName of wb.SheetNames) {
+    const sheet = wb.Sheets[sheetName]
+    if (!sheet || !sheet['!ref']) continue
+    const range = XLSX.utils.decode_range(sheet['!ref'])
+    for (let R = range.s.r; R <= range.e.r; R++) {
+      for (let C = range.s.c; C <= range.e.c; C++) {
+        const addr = XLSX.utils.encode_cell({ r: R, c: C })
+        const cell = sheet[addr]
+        if (!cell) continue
+
+        if (cell.f) {
+          let f = cell.f
+          for (const { from, to } of pairs) {
+            if (from && f.includes(from)) f = f.split(from).join(to)
+          }
+          if (f !== cell.f) cell.f = f
+        }
+
+        if (typeof cell.v === 'string') {
+          let v = cell.v
+          for (const { from, to } of pairs) {
+            if (from && v.includes(from)) v = v.split(from).join(to)
+          }
+          if (v !== cell.v) cell.v = v
+        }
+
+        if (typeof cell.w === 'string') {
+          let w = cell.w
+          for (const { from, to } of pairs) {
+            if (from && w.includes(from)) w = w.split(from).join(to)
+          }
+          if (w !== cell.w) cell.w = w
+        }
+      }
+    }
+  }
+}

--- a/app/lib/parseTemplateTeamCount.ts
+++ b/app/lib/parseTemplateTeamCount.ts
@@ -1,0 +1,35 @@
+const WORD_TO_NUM: Record<string, number> = {
+  one: 1,
+  two: 2,
+  three: 3,
+  four: 4,
+  five: 5,
+  six: 6,
+  seven: 7,
+  eight: 8,
+  nine: 9,
+  ten: 10,
+  eleven: 11,
+  twelve: 12,
+}
+
+/**
+ * Reads team count from a league template file name, e.g. "Six Team League", "4-team roster".
+ * Returns null if no recognizable pattern.
+ */
+export function parseTeamCountFromTemplateName(filename: string): number | null {
+  const base = filename.replace(/\.[^.]+$/, '').trim()
+  if (!base) return null
+
+  const digit = base.match(/\b(\d{1,2})\s*[-_]?\s*teams?\b/i)
+  if (digit) {
+    const n = parseInt(digit[1], 10)
+    return n >= 1 && n <= 99 ? n : null
+  }
+
+  for (const [word, n] of Object.entries(WORD_TO_NUM)) {
+    if (new RegExp(`\\b${word}\\s+teams?\\b`, 'i').test(base)) return n
+  }
+
+  return null
+}

--- a/app/schedules/page.tsx
+++ b/app/schedules/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Link from 'next/link'
 import { useState, useEffect, useMemo } from 'react'
 import {
   GameCard,
@@ -79,19 +80,29 @@ export default function SchedulesPage() {
             ) : sheetsError ? (
               <span className="text-red-600">{sheetsError}</span>
             ) : (
-              <select
-                id="league-select"
-                value={selectedSheetId}
-                onChange={(e) => setSelectedSheetId(e.target.value)}
-                className="px-3 py-2 border border-gray-300 rounded-md min-w-[240px]"
-              >
-                {sheets.length === 0 && <option value="">No leagues found</option>}
-                {sheets.map((sheet) => (
-                  <option key={sheet.id} value={sheet.id}>
-                    {sheet.name}
-                  </option>
-                ))}
-              </select>
+              <>
+                <select
+                  id="league-select"
+                  value={selectedSheetId}
+                  onChange={(e) => setSelectedSheetId(e.target.value)}
+                  className="px-3 py-2 border border-gray-300 rounded-md min-w-[240px]"
+                >
+                  {sheets.length === 0 && <option value="">No leagues found</option>}
+                  {sheets.map((sheet) => (
+                    <option key={sheet.id} value={sheet.id}>
+                      {sheet.name}
+                    </option>
+                  ))}
+                </select>
+                {selectedSheetId ? (
+                  <Link
+                    href={`/create-league?templateId=${encodeURIComponent(selectedSheetId)}`}
+                    className="inline-flex items-center px-4 py-2 rounded-md bg-blue-600 text-white text-sm font-medium hover:bg-blue-700"
+                  >
+                    New league from this template
+                  </Link>
+                ) : null}
+              </>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
This PR updates the create-league flow to **export the selected Google Sheet from Drive** and **rename teams** (including formulas), instead of generating a blank workbook from scratch. Team count comes from the template file name.

## Changes
- **API:** `/api/create-league` uses `templateId` to export via Drive API and apply `mutateLeagueTemplate` renames; fallback remains the programmatic workbook when `templateId` is omitted.
- **Seven-team:** Detects the team that never appears on Game 01 across weeks and swaps mapping when the user picks **Avoid in first round**.
- **UI:** Create League reads `?templateId=` to preselect the template after the Drive list loads.
- **Schedules:** **New league from this template** button links to Create League with the current sheet id.
- **Nav:** Removes Round Timer and Standalone Timer links (routes unchanged).

## Requirements
- `GOOGLE_DRIVE_API_KEY` and shared Drive folder (existing setup).

## How to test
1. Open League Schedules, pick a template, click **New league from this template**.
2. Complete Create League and confirm download matches the Drive layout with new names.

Made with [Cursor](https://cursor.com)