### PR TITLE
Configurable tournament audio schedule

### DIFF
--- a/app/api/tournament-clips/route.ts
+++ b/app/api/tournament-clips/route.ts
@@ -107,8 +107,16 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
-    if (category !== 'teams' && category !== 'generic') {
-      return NextResponse.json({ error: 'category must be teams or generic' }, { status: 400 });
+    if (
+      category !== 'teams' &&
+      category !== 'generic' &&
+      category !== 'matchups' &&
+      category !== 'refs'
+    ) {
+      return NextResponse.json(
+        { error: 'category must be teams, generic, matchups, or refs' },
+        { status: 400 }
+      );
     }
     if (!slug || !/^[a-z0-9_-]+$/.test(slug)) {
       return NextResponse.json({ error: 'invalid slug' }, { status: 400 });

--- a/app/components/schedule/ConflictsAlert.tsx
+++ b/app/components/schedule/ConflictsAlert.tsx
@@ -20,6 +20,10 @@ const GROUP_ORDER: { type: ConflictType; title: string }[] = [
     type: 'duplicate-orientation-same-night',
     title: 'Same matchup & home/away twice in one night',
   },
+  {
+    type: 'incomplete-round-robin',
+    title: 'Round-robin not complete (6-team: each pair should play twice per week)',
+  },
   { type: 'home-away-imbalance', title: 'Home / away imbalance' },
   { type: 'unknown', title: 'Other' },
 ]

--- a/app/components/schedule/types.ts
+++ b/app/components/schedule/types.ts
@@ -56,6 +56,7 @@ export type ConflictType =
   | 'consecutive-without-playing'
   | 'consecutive-matchup'
   | 'duplicate-orientation-same-night'
+  | 'incomplete-round-robin'
   | 'home-away-imbalance'
   | 'unknown'
 

--- a/app/lib/__tests__/tournamentSchedule.test.ts
+++ b/app/lib/__tests__/tournamentSchedule.test.ts
@@ -4,6 +4,7 @@ import {
   buildTimeSlots,
   coalesceEventsAtSameTimestamp,
   DEFAULT_SCHEDULE_CONFIG,
+  getUniqueMatchupRefsFromSlots,
   getNoBlockingEndMs,
   isPlaceholderTeam,
   matchupSlug,
@@ -68,27 +69,36 @@ describe('tournamentSchedule', () => {
     );
   });
 
-  it('omits countdowns before no-blocking end that would collide with the next court call', () => {
+  it('does not schedule no-blocking end countdowns at/after the next court call', () => {
     const csv = `"Date","Court","Phase","Division","Group","Round","Home Team","Home Score","Away Team","Away Score","Referees","End Time"
 "2026-06-20 09:00 am","Court 1","Group Phase","Comp Mixed","Group A","1","Black Panther","undefined","Proud Family","undefined","Ref","2026-06-20 09:25"
 "2026-06-20 09:25 am","Court 1","Group Phase","Comp Mixed","Group A","2","Fresh Prince","undefined","Family Matters","undefined","Ref","2026-06-20 09:50"`;
     const slots = buildTimeSlots(parseTournamentCsv(csv));
-    const events = buildAudioEvents(slots, {
+    const config = {
       ...DEFAULT_SCHEDULE_CONFIG,
       noBlockingStartMin: 22,
       noBlockingDurationMin: 3,
       countdownsBeforeNoBlockingEnd: ['ninety_seconds'],
-    });
+    };
+    const events = buildAudioEvents(slots, config);
 
-    const round1NinetyBeforeEnd = events.find(
-      (e) => e.slotRound === '1' && e.label.includes('90 seconds') && e.label.includes('no blocking ends')
+    const nextCourtCallMs = slots.length > 1 ? Math.max(0, slots[1].startMs - config.courtAssignOffsetMs) : 0;
+    const round1CountdownBeforeEnd = events.find(
+      (e) =>
+        e.slotRound === '1' &&
+        e.clips.some((c) => c.category === 'generic' && c.slug === 'ninety_seconds') &&
+        e.label.includes('before no blocking ends')
     );
-    expect(round1NinetyBeforeEnd).toBeUndefined();
 
-    const round2Court = events.find(
-      (e) => e.slotRound === '2' && e.label.includes('court assignments')
-    );
-    expect(round2Court).toBeDefined();
+    // It’s OK if the countdown exists (it may even coalesce with no-blocking start),
+    // but it must never land at/after the next round’s court call, which would cause overlap/out-of-order audio.
+    if (round1CountdownBeforeEnd) {
+      expect(round1CountdownBeforeEnd.absoluteMs).toBeLessThan(nextCourtCallMs);
+    }
+
+    // (Events at the same timestamp may be coalesced, so slotRound can remain the earlier event’s round.)
+    const hasRound2Court = events.some((e) => e.label.includes('Round 2') && e.label.includes('court assignments'));
+    expect(hasRound2Court).toBe(true);
   });
 
   it('merges pre-round events at the same timestamp for the first slot', () => {
@@ -126,5 +136,45 @@ describe('tournamentSchedule', () => {
     for (let i = 1; i < events.length; i++) {
       expect(events[i].absoluteMs).toBeGreaterThanOrEqual(events[i - 1].absoluteMs);
     }
+  });
+
+  it('clamps no-blocking start and buzzer to not exceed the next round court call', () => {
+    const csv = `"Date","Court","Phase","Division","Group","Round","Home Team","Home Score","Away Team","Away Score","Referees","End Time"
+"2026-06-20 09:00 am","Court 1","Group Phase","Comp Mixed","Group A","1","Black Panther","undefined","Proud Family","undefined","Ref","2026-06-20 09:25"
+"2026-06-20 09:25 am","Court 1","Group Phase","Comp Mixed","Group A","2","Fresh Prince","undefined","Family Matters","undefined","Ref","2026-06-20 09:50"`;
+    const slots = buildTimeSlots(parseTournamentCsv(csv));
+    const config = {
+      ...DEFAULT_SCHEDULE_CONFIG,
+      courtAssignOffsetMs: 90_000,
+      noBlockingStartMin: 24,
+      noBlockingDurationMin: 3,
+    } as const;
+    const events = buildAudioEvents(slots, config);
+
+    const round1NoBlockingStart = events.find(
+      (e) => e.slotRound === '1' && e.label.includes('no blocking starts')
+    );
+    const round1Buzzer = events.find((e) => e.slotRound === '1' && e.label.includes('buzzer'));
+    const nextCourtCallMs =
+      slots.length > 1 ? Math.max(0, slots[1].startMs - config.courtAssignOffsetMs) : Number.POSITIVE_INFINITY;
+
+    expect(round1NoBlockingStart).toBeDefined();
+    expect(round1Buzzer).toBeDefined();
+    expect(round1NoBlockingStart!.absoluteMs).toBeLessThanOrEqual(nextCourtCallMs);
+    expect(round1Buzzer!.absoluteMs).toBeLessThanOrEqual(nextCourtCallMs);
+  });
+
+  it('only returns matchups/* refs in compound mode', () => {
+    const csv = `"Date","Court","Phase","Division","Group","Round","Home Team","Home Score","Away Team","Away Score","Referees","End Time"
+"2026-06-20 09:00 am","Court 1","Group Phase","Comp Mixed","Group A","1","Seed #1","undefined","Proud Family","undefined","Ref","2026-06-20 09:25"
+"2026-06-20 09:00 am","Court 2","Group Phase","Comp Mixed","Group A","1","Black Panther","undefined","Fresh Prince","undefined","Ref","2026-06-20 09:25"`;
+    const slots = buildTimeSlots(parseTournamentCsv(csv));
+    const refs = getUniqueMatchupRefsFromSlots(slots, {
+      ...DEFAULT_SCHEDULE_CONFIG,
+      teamNameMode: 'compound',
+    });
+
+    expect(refs.every((ref) => ref.category === 'matchups')).toBe(true);
+    expect(refs.some((ref) => ref.slug === 'playoff_match')).toBe(false);
   });
 });

--- a/app/lib/__tests__/tournamentSchedule.test.ts
+++ b/app/lib/__tests__/tournamentSchedule.test.ts
@@ -3,7 +3,10 @@ import {
   buildAudioEvents,
   buildTimeSlots,
   coalesceEventsAtSameTimestamp,
+  DEFAULT_SCHEDULE_CONFIG,
+  getNoBlockingEndMs,
   isPlaceholderTeam,
+  matchupSlug,
   parseTournamentCsv,
   teamNameToSlug,
 } from '../tournamentSchedule';
@@ -47,19 +50,40 @@ describe('tournamentSchedule', () => {
     expect(preRound?.label).toContain('court assignments');
     expect(preRound?.label).toContain('round start');
     expect(events.some((e) => e.label.includes('buzzer'))).toBe(true);
+    const buzzer = events.find((e) => e.label.includes('buzzer'));
+    expect(buzzer?.absoluteMs).toBe(getNoBlockingEndMs(slots[0], DEFAULT_SCHEDULE_CONFIG));
   });
 
-  it('omits late-slot warnings that would collide with the next round court call', () => {
+  it('uses compound matchup clips when configured', () => {
+    const rows = parseTournamentCsv(SAMPLE_ROW);
+    const slots = buildTimeSlots(rows);
+    const events = buildAudioEvents(slots, {
+      ...DEFAULT_SCHEDULE_CONFIG,
+      teamNameMode: 'compound',
+    });
+    const court = events.find((e) => e.label.includes('court assignments'));
+    expect(court?.clips.some((c) => c.category === 'matchups')).toBe(true);
+    expect(court?.clips.some((c) => c.slug === matchupSlug('Black Panther', 'Proud Family'))).toBe(
+      true
+    );
+  });
+
+  it('omits countdowns before no-blocking end that would collide with the next court call', () => {
     const csv = `"Date","Court","Phase","Division","Group","Round","Home Team","Home Score","Away Team","Away Score","Referees","End Time"
 "2026-06-20 09:00 am","Court 1","Group Phase","Comp Mixed","Group A","1","Black Panther","undefined","Proud Family","undefined","Ref","2026-06-20 09:25"
 "2026-06-20 09:25 am","Court 1","Group Phase","Comp Mixed","Group A","2","Fresh Prince","undefined","Family Matters","undefined","Ref","2026-06-20 09:50"`;
     const slots = buildTimeSlots(parseTournamentCsv(csv));
-    const events = buildAudioEvents(slots);
+    const events = buildAudioEvents(slots, {
+      ...DEFAULT_SCHEDULE_CONFIG,
+      noBlockingStartMin: 22,
+      noBlockingDurationMin: 3,
+      countdownsBeforeNoBlockingEnd: ['ninety_seconds'],
+    });
 
-    const round1Ninety = events.find(
-      (e) => e.slotRound === '1' && e.label.includes('90 seconds')
+    const round1NinetyBeforeEnd = events.find(
+      (e) => e.slotRound === '1' && e.label.includes('90 seconds') && e.label.includes('no blocking ends')
     );
-    expect(round1Ninety).toBeUndefined();
+    expect(round1NinetyBeforeEnd).toBeUndefined();
 
     const round2Court = events.find(
       (e) => e.slotRound === '2' && e.label.includes('court assignments')

--- a/app/lib/scheduleParser.ts
+++ b/app/lib/scheduleParser.ts
@@ -521,6 +521,65 @@ export function parseScheduleCSV(
     }
   }
 
+  // 6-team round-robin: every pair should play exactly twice per week
+  {
+    const rrByWeek = new Map<string, { games: Game[]; weekLabel: string }>();
+    for (const g of games) {
+      const wk = weekBucketKey(g.gameNumber);
+      if (!rrByWeek.has(wk)) {
+        const m = wk.match(/^week-(\d+)$/);
+        const label = m ? `Week ${m[1]}` : 'Week';
+        rrByWeek.set(wk, { games: [], weekLabel: label });
+      }
+      rrByWeek.get(wk)!.games.push(g);
+    }
+
+    for (const [, { games: weekGames, weekLabel }] of rrByWeek) {
+      const weekTeams = new Set<string>();
+      for (const g of weekGames) {
+        for (const t of [g.court1Team1, g.court1Team2, g.court2Team1, g.court2Team2]) {
+          if (t && t !== 'BYE' && t !== 'TBD') weekTeams.add(t);
+        }
+      }
+
+      if (weekTeams.size !== 6) continue;
+
+      const pairCount = new Map<string, number>();
+      for (const g of weekGames) {
+        const sides: [string, string][] = [
+          [g.court1Team1, g.court1Team2],
+          [g.court2Team1, g.court2Team2],
+        ];
+        for (const [a, b] of sides) {
+          if (!validMatchupSide(a, b)) continue;
+          const key = [a, b].sort().join('\0');
+          pairCount.set(key, (pairCount.get(key) ?? 0) + 1);
+        }
+      }
+
+      const teamList = [...weekTeams].sort();
+      for (let x = 0; x < teamList.length; x++) {
+        for (let y = x + 1; y < teamList.length; y++) {
+          const a = teamList[x], b = teamList[y];
+          const key = [a, b].sort().join('\0');
+          const count = pairCount.get(key) ?? 0;
+          if (count === 2) continue;
+          detectedConflicts.push({
+            gameNumber: weekLabel,
+            team: `${a} & ${b}`,
+            conflicts: [
+              count === 0
+                ? `Never played this week (expected 2 games)`
+                : `Played ${count} time${count === 1 ? '' : 's'} this week (expected 2)`,
+            ],
+            severity: count === 0 ? 'error' : 'warning',
+            conflictType: 'incomplete-round-robin',
+          });
+        }
+      }
+    }
+  }
+
   // Home/away imbalance over the selected scope (e.g. full season on "All weeks"):
   // - Strictly more than half of slots on one side, OR
   // - At least 2 more games on one side than the other (catches 6–4, 7–3, etc. on even totals

--- a/app/lib/tournamentSchedule.ts
+++ b/app/lib/tournamentSchedule.ts
@@ -9,6 +9,7 @@ export const GENERIC_CLIP_SLUGS = [
   'head_to_courts',
   'match_soon',
   'round_start',
+  'no_blocking_start',
   'two_minutes',
   'ninety_seconds',
   'one_minute',
@@ -18,6 +19,36 @@ export const GENERIC_CLIP_SLUGS = [
   'buzzer',
   'playoff_match',
 ] as const;
+
+/** Generic clips used as countdown warnings before phase markers. */
+export const COUNTDOWN_CLIP_SLUGS = [
+  'two_minutes',
+  'ninety_seconds',
+  'one_minute',
+  'thirty_seconds',
+  'twenty_seconds',
+  'no_blocking_countdown',
+] as const;
+
+export type CountdownClipSlug = (typeof COUNTDOWN_CLIP_SLUGS)[number];
+
+export const COUNTDOWN_SLUG_SECONDS: Record<CountdownClipSlug, number> = {
+  two_minutes: 120,
+  ninety_seconds: 90,
+  one_minute: 60,
+  thirty_seconds: 30,
+  twenty_seconds: 20,
+  no_blocking_countdown: 10,
+};
+
+const COUNTDOWN_SLUG_LABELS: Record<CountdownClipSlug, string> = {
+  two_minutes: '2 minutes',
+  ninety_seconds: '90 seconds',
+  one_minute: '1 minute',
+  thirty_seconds: '30 seconds',
+  twenty_seconds: '20 seconds',
+  no_blocking_countdown: 'No blocking countdown',
+};
 
 /** Group-phase teams for Throw Down 5 (known names). */
 export const TEAM_SLUGS = [
@@ -42,7 +73,41 @@ export const TEAM_SLUGS = [
 export type GenericClipSlug = (typeof GENERIC_CLIP_SLUGS)[number];
 export type TeamSlug = (typeof TEAM_SLUGS)[number];
 
-export type ClipCategory = 'teams' | 'generic';
+export type ClipCategory = 'teams' | 'generic' | 'matchups' | 'refs';
+
+export type TeamNameMode = 'separate' | 'compound';
+
+export interface ScheduleConfig {
+  /** Minutes from round start until no-blocking begins. */
+  noBlockingStartMin: number;
+  /** Minutes no-blocking lasts before buzzer. */
+  noBlockingDurationMin: number;
+  /** Ms before round start when court assignments play. */
+  courtAssignOffsetMs: number;
+  teamNameMode: TeamNameMode;
+  includeRefs: boolean;
+  countdownsBeforeNoBlockingStart: CountdownClipSlug[];
+  countdownsBeforeNoBlockingEnd: CountdownClipSlug[];
+  countdownsBeforeCourtCall: CountdownClipSlug[];
+}
+
+export const DEFAULT_SCHEDULE_CONFIG: ScheduleConfig = {
+  noBlockingStartMin: 15,
+  noBlockingDurationMin: 3,
+  courtAssignOffsetMs: 90_000,
+  teamNameMode: 'separate',
+  includeRefs: false,
+  countdownsBeforeNoBlockingStart: [
+    'two_minutes',
+    'ninety_seconds',
+    'one_minute',
+    'thirty_seconds',
+    'twenty_seconds',
+    'no_blocking_countdown',
+  ],
+  countdownsBeforeNoBlockingEnd: [],
+  countdownsBeforeCourtCall: [],
+};
 
 export interface ClipRef {
   category: ClipCategory;
@@ -56,7 +121,12 @@ export function clipKey(ref: ClipRef): string {
 export function parseClipKey(key: string): ClipRef {
   const [category, ...rest] = key.split('/');
   const slug = rest.join('/');
-  if (category !== 'teams' && category !== 'generic') {
+  if (
+    category !== 'teams' &&
+    category !== 'generic' &&
+    category !== 'matchups' &&
+    category !== 'refs'
+  ) {
     throw new Error(`Invalid clip key: ${key}`);
   }
   return { category, slug };
@@ -93,19 +163,7 @@ export interface AudioEvent {
   slotRound: string;
 }
 
-const COURT_ASSIGN_OFFSET_MS = 90_000;
 const MATCH_SOON_OFFSET_MS = 30_000;
-/** In-round warnings are suppressed in the last N ms so they do not collide with the next slot's T-90s court call. */
-const TRANSITION_RESERVE_MS = COURT_ASSIGN_OFFSET_MS;
-
-const WARNING_OFFSETS: { offsetMs: number; slug: GenericClipSlug; label: string }[] = [
-  { offsetMs: 120_000, slug: 'two_minutes', label: '2 minutes until no blocking' },
-  { offsetMs: 90_000, slug: 'ninety_seconds', label: '90 seconds until no blocking' },
-  { offsetMs: 60_000, slug: 'one_minute', label: '1 minute until no blocking' },
-  { offsetMs: 30_000, slug: 'thirty_seconds', label: '30 seconds until no blocking' },
-  { offsetMs: 20_000, slug: 'twenty_seconds', label: '20 seconds until no blocking' },
-  { offsetMs: 10_000, slug: 'no_blocking_countdown', label: 'No blocking countdown' },
-];
 
 export function teamNameToSlug(name: string): string {
   return name
@@ -202,6 +260,103 @@ function teamClipRef(teamName: string): ClipRef {
   return { category: 'teams', slug: teamNameToSlug(teamName) };
 }
 
+export function matchupSlug(homeTeam: string, awayTeam: string): string {
+  return `${teamNameToSlug(homeTeam)}-vs-${teamNameToSlug(awayTeam)}`;
+}
+
+function matchupClipRef(homeTeam: string, awayTeam: string): ClipRef {
+  if (isPlaceholderTeam(homeTeam) || isPlaceholderTeam(awayTeam)) {
+    return { category: 'generic', slug: 'playoff_match' };
+  }
+  return { category: 'matchups', slug: matchupSlug(homeTeam, awayTeam) };
+}
+
+function refClipRef(refName: string): ClipRef {
+  return { category: 'refs', slug: teamNameToSlug(refName) };
+}
+
+export function getNoBlockingStartMs(slot: TimeSlot, config: ScheduleConfig): number {
+  return slot.startMs + config.noBlockingStartMin * 60_000;
+}
+
+export function getNoBlockingEndMs(slot: TimeSlot, config: ScheduleConfig): number {
+  return getNoBlockingStartMs(slot, config) + config.noBlockingDurationMin * 60_000;
+}
+
+export function getCourtCallMs(slot: TimeSlot, config: ScheduleConfig): number {
+  return Math.max(0, slot.startMs - config.courtAssignOffsetMs);
+}
+
+export function getNextRoundStartMs(
+  slotIndex: number,
+  slots: TimeSlot[]
+): number | null {
+  const next = slots[slotIndex + 1];
+  return next ? next.startMs : null;
+}
+
+function emitCountdowns(
+  events: AudioEvent[],
+  markerMs: number,
+  slugs: CountdownClipSlug[],
+  roundLabel: string,
+  slotRound: string,
+  minMs: number,
+  maxMs: number,
+  phaseLabel: string
+): void {
+  for (const slug of slugs) {
+    const secs = COUNTDOWN_SLUG_SECONDS[slug];
+    const eventMs = markerMs - secs * 1000;
+    if (eventMs >= minMs && eventMs < maxMs) {
+      events.push({
+        absoluteMs: eventMs,
+        clips: [{ category: 'generic', slug }],
+        label: `${roundLabel} — ${COUNTDOWN_SLUG_LABELS[slug]} before ${phaseLabel}`,
+        slotRound,
+      });
+    }
+  }
+}
+
+export function getUniqueMatchupRefsFromSlots(
+  slots: TimeSlot[],
+  config: ScheduleConfig
+): ClipRef[] {
+  if (config.teamNameMode !== 'compound') return [];
+  const seen = new Set<string>();
+  const refs: ClipRef[] = [];
+  for (const slot of slots) {
+    for (const m of slot.matches) {
+      const ref = matchupClipRef(m.homeTeam, m.awayTeam);
+      const key = clipKey(ref);
+      if (!seen.has(key)) {
+        seen.add(key);
+        refs.push(ref);
+      }
+    }
+  }
+  return refs;
+}
+
+export function getUniqueRefRefsFromSlots(slots: TimeSlot[]): ClipRef[] {
+  const seen = new Set<string>();
+  const refs: ClipRef[] = [];
+  for (const slot of slots) {
+    for (const m of slot.matches) {
+      const name = m.referees.trim();
+      if (!name) continue;
+      const ref = refClipRef(name);
+      const key = clipKey(ref);
+      if (!seen.has(key)) {
+        seen.add(key);
+        refs.push(ref);
+      }
+    }
+  }
+  return refs;
+}
+
 export function buildTimeSlots(rows: ScheduleRow[]): TimeSlot[] {
   const byDate = new Map<string, ScheduleRow[]>();
   for (const row of rows) {
@@ -264,32 +419,57 @@ export function buildTimeSlots(rows: ScheduleRow[]): TimeSlot[] {
   return slots;
 }
 
-function courtAssignmentClips(matches: ScheduleRow[]): ClipRef[] {
+function courtAssignmentClips(matches: ScheduleRow[], config: ScheduleConfig): ClipRef[] {
   const clips: ClipRef[] = [];
   for (const m of matches) {
     const courtNum = courtNumberFromLabel(m.court);
     if (courtNum != null && courtNum >= 1 && courtNum <= 4) {
       clips.push({ category: 'generic', slug: `court_${courtNum}` as GenericClipSlug });
     }
-    clips.push(teamClipRef(m.homeTeam));
-    clips.push({ category: 'generic', slug: 'vs' });
-    clips.push(teamClipRef(m.awayTeam));
+    if (config.teamNameMode === 'compound') {
+      clips.push(matchupClipRef(m.homeTeam, m.awayTeam));
+    } else {
+      clips.push(teamClipRef(m.homeTeam));
+      clips.push({ category: 'generic', slug: 'vs' });
+      clips.push(teamClipRef(m.awayTeam));
+    }
+    if (config.includeRefs && m.referees.trim()) {
+      clips.push(refClipRef(m.referees));
+    }
   }
   clips.push({ category: 'generic', slug: 'head_to_courts' });
   return clips;
 }
 
-export function buildAudioEvents(slots: TimeSlot[]): AudioEvent[] {
+export function buildAudioEvents(
+  slots: TimeSlot[],
+  config: ScheduleConfig = DEFAULT_SCHEDULE_CONFIG
+): AudioEvent[] {
   const events: AudioEvent[] = [];
 
-  for (const slot of slots) {
-    const { startMs, durationMs, round, matches } = slot;
+  for (let i = 0; i < slots.length; i++) {
+    const slot = slots[i];
+    const { startMs, round, matches } = slot;
     const roundLabel = `Round ${round}`;
 
-    const courtAssignMs = Math.max(0, startMs - COURT_ASSIGN_OFFSET_MS);
+    const courtAssignMs = getCourtCallMs(slot, config);
+    const nextCourtCallMs =
+      i + 1 < slots.length ? getCourtCallMs(slots[i + 1], config) : Number.POSITIVE_INFINITY;
+
+    emitCountdowns(
+      events,
+      courtAssignMs,
+      config.countdownsBeforeCourtCall,
+      roundLabel,
+      round,
+      0,
+      courtAssignMs,
+      'court call'
+    );
+
     events.push({
       absoluteMs: courtAssignMs,
-      clips: courtAssignmentClips(matches),
+      clips: courtAssignmentClips(matches, config),
       label: `${roundLabel} — court assignments`,
       slotRound: round,
     });
@@ -309,23 +489,42 @@ export function buildAudioEvents(slots: TimeSlot[]): AudioEvent[] {
       slotRound: round,
     });
 
-    const warningsCutoffMs = startMs + durationMs - TRANSITION_RESERVE_MS;
-    for (const w of WARNING_OFFSETS) {
-      const eventMs = startMs + durationMs - w.offsetMs;
-      if (eventMs > startMs && eventMs < warningsCutoffMs) {
-        events.push({
-          absoluteMs: eventMs,
-          clips: [{ category: 'generic', slug: w.slug }],
-          label: `${roundLabel} — ${w.label}`,
-          slotRound: round,
-        });
-      }
-    }
+    const noBlockingStartMs = getNoBlockingStartMs(slot, config);
+    const noBlockingEndMs = getNoBlockingEndMs(slot, config);
+
+    emitCountdowns(
+      events,
+      noBlockingStartMs,
+      config.countdownsBeforeNoBlockingStart,
+      roundLabel,
+      round,
+      startMs,
+      Math.min(noBlockingStartMs, nextCourtCallMs),
+      'no blocking'
+    );
 
     events.push({
-      absoluteMs: startMs + durationMs,
+      absoluteMs: noBlockingStartMs,
+      clips: [{ category: 'generic', slug: 'no_blocking_start' }],
+      label: `${roundLabel} — no blocking starts`,
+      slotRound: round,
+    });
+
+    emitCountdowns(
+      events,
+      noBlockingEndMs,
+      config.countdownsBeforeNoBlockingEnd,
+      roundLabel,
+      round,
+      noBlockingStartMs,
+      Math.min(noBlockingEndMs, nextCourtCallMs),
+      'no blocking ends'
+    );
+
+    events.push({
+      absoluteMs: noBlockingEndMs,
       clips: [{ category: 'generic', slug: 'buzzer' }],
-      label: `${roundLabel} — buzzer`,
+      label: `${roundLabel} — buzzer (no blocking ends)`,
       slotRound: round,
     });
   }

--- a/app/lib/tournamentSchedule.ts
+++ b/app/lib/tournamentSchedule.ts
@@ -329,6 +329,7 @@ export function getUniqueMatchupRefsFromSlots(
   for (const slot of slots) {
     for (const m of slot.matches) {
       const ref = matchupClipRef(m.homeTeam, m.awayTeam);
+      if (ref.category !== 'matchups') continue;
       const key = clipKey(ref);
       if (!seen.has(key)) {
         seen.add(key);
@@ -490,21 +491,30 @@ export function buildAudioEvents(
     });
 
     const noBlockingStartMs = getNoBlockingStartMs(slot, config);
-    const noBlockingEndMs = getNoBlockingEndMs(slot, config);
+    const rawNoBlockingEndMs = getNoBlockingEndMs(slot, config);
+    const noBlockingWindowEndMs = Math.min(slot.endMs, nextCourtCallMs);
+    const noBlockingStartClampedMs = Math.min(
+      Math.max(noBlockingStartMs, startMs),
+      noBlockingWindowEndMs
+    );
+    const noBlockingEndClampedMs = Math.min(
+      Math.max(rawNoBlockingEndMs, noBlockingStartClampedMs),
+      noBlockingWindowEndMs
+    );
 
     emitCountdowns(
       events,
-      noBlockingStartMs,
+      noBlockingStartClampedMs,
       config.countdownsBeforeNoBlockingStart,
       roundLabel,
       round,
       startMs,
-      Math.min(noBlockingStartMs, nextCourtCallMs),
+      Math.min(noBlockingStartClampedMs, nextCourtCallMs),
       'no blocking'
     );
 
     events.push({
-      absoluteMs: noBlockingStartMs,
+      absoluteMs: noBlockingStartClampedMs,
       clips: [{ category: 'generic', slug: 'no_blocking_start' }],
       label: `${roundLabel} — no blocking starts`,
       slotRound: round,
@@ -512,17 +522,17 @@ export function buildAudioEvents(
 
     emitCountdowns(
       events,
-      noBlockingEndMs,
+      noBlockingEndClampedMs,
       config.countdownsBeforeNoBlockingEnd,
       roundLabel,
       round,
-      noBlockingStartMs,
-      Math.min(noBlockingEndMs, nextCourtCallMs),
+      noBlockingStartClampedMs,
+      Math.min(noBlockingEndClampedMs, nextCourtCallMs),
       'no blocking ends'
     );
 
     events.push({
-      absoluteMs: noBlockingEndMs,
+      absoluteMs: noBlockingEndClampedMs,
       clips: [{ category: 'generic', slug: 'buzzer' }],
       label: `${roundLabel} — buzzer (no blocking ends)`,
       slotRound: round,

--- a/app/tournament/components/AudioFileGrid.tsx
+++ b/app/tournament/components/AudioFileGrid.tsx
@@ -5,7 +5,11 @@ import {
   GENERIC_CLIP_SLUGS,
   TEAM_SLUGS,
   clipKey,
+  getUniqueMatchupRefsFromSlots,
+  getUniqueRefRefsFromSlots,
   type ClipRef,
+  type ScheduleConfig,
+  type TimeSlot,
 } from '@/app/lib/tournamentSchedule';
 import type { TournamentClip } from '../types';
 
@@ -66,6 +70,7 @@ function ClipCard({ ref_, clip, onUploaded }: ClipCardProps) {
   const remove = async () => {
     if (!clip?.url) return;
     setUploading(true);
+    setError(null);
     try {
       const res = await fetch('/api/tournament-clips', {
         method: 'DELETE',
@@ -151,13 +156,52 @@ function ClipCard({ ref_, clip, onUploaded }: ClipCardProps) {
   );
 }
 
+function ClipGridSection({
+  title,
+  refs,
+  clipByKey,
+  onRefresh,
+}: {
+  title: string;
+  refs: ClipRef[];
+  clipByKey: Map<string, TournamentClip>;
+  onRefresh: () => void;
+}) {
+  if (refs.length === 0) return null;
+  return (
+    <section>
+      <h3 className="font-semibold text-gray-900 mb-3">
+        {title} ({refs.length})
+      </h3>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+        {refs.map((ref_) => (
+          <ClipCard
+            key={clipKey(ref_)}
+            ref_={ref_}
+            clip={clipByKey.get(clipKey(ref_))}
+            onUploaded={onRefresh}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
 interface AudioFileGridProps {
   clips: TournamentClip[];
   requiredKeys: string[];
+  slots: TimeSlot[];
+  config: ScheduleConfig;
   onRefresh: () => void;
 }
 
-export default function AudioFileGrid({ clips, requiredKeys, onRefresh }: AudioFileGridProps) {
+export default function AudioFileGrid({
+  clips,
+  requiredKeys,
+  slots,
+  config,
+  onRefresh,
+}: AudioFileGridProps) {
   const clipByKey = new Map(clips.map((c) => [c.key, c]));
   const uploadedRequired = requiredKeys.filter((k) => clipByKey.has(k)).length;
 
@@ -166,6 +210,8 @@ export default function AudioFileGrid({ clips, requiredKeys, onRefresh }: AudioF
     category: 'generic',
     slug,
   }));
+  const matchupRefs = getUniqueMatchupRefsFromSlots(slots, config);
+  const refRefs = config.includeRefs ? getUniqueRefRefsFromSlots(slots) : [];
 
   return (
     <div className="space-y-6">
@@ -179,33 +225,53 @@ export default function AudioFileGrid({ clips, requiredKeys, onRefresh }: AudioF
         {uploadedRequired} / {requiredKeys.length} required clips uploaded
       </div>
 
-      <section>
-        <h3 className="font-semibold text-gray-900 mb-3">Team names ({TEAM_SLUGS.length})</h3>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-          {teamRefs.map((ref_) => (
-            <ClipCard
-              key={clipKey(ref_)}
-              ref_={ref_}
-              clip={clipByKey.get(clipKey(ref_))}
-              onUploaded={onRefresh}
-            />
-          ))}
-        </div>
-      </section>
+      {config.teamNameMode === 'compound' ? (
+        <ClipGridSection
+          title="Matchup clips (compound)"
+          refs={matchupRefs}
+          clipByKey={clipByKey}
+          onRefresh={onRefresh}
+        />
+      ) : (
+        <ClipGridSection
+          title="Team names"
+          refs={teamRefs}
+          clipByKey={clipByKey}
+          onRefresh={onRefresh}
+        />
+      )}
 
-      <section>
-        <h3 className="font-semibold text-gray-900 mb-3">Generic clips ({GENERIC_CLIP_SLUGS.length})</h3>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-          {genericRefs.map((ref_) => (
-            <ClipCard
-              key={clipKey(ref_)}
-              ref_={ref_}
-              clip={clipByKey.get(clipKey(ref_))}
-              onUploaded={onRefresh}
+      {config.includeRefs && (
+        <ClipGridSection
+          title="Referee names"
+          refs={refRefs}
+          clipByKey={clipByKey}
+          onRefresh={onRefresh}
+        />
+      )}
+
+      <ClipGridSection
+        title="Generic clips"
+        refs={genericRefs}
+        clipByKey={clipByKey}
+        onRefresh={onRefresh}
+      />
+
+      {config.teamNameMode === 'compound' && (
+        <details className="text-sm text-gray-500">
+          <summary className="cursor-pointer text-gray-700 font-medium">
+            Optional: individual team clips
+          </summary>
+          <div className="mt-3">
+            <ClipGridSection
+              title="Team names"
+              refs={teamRefs}
+              clipByKey={clipByKey}
+              onRefresh={onRefresh}
             />
-          ))}
-        </div>
-      </section>
+          </div>
+        </details>
+      )}
     </div>
   );
 }

--- a/app/tournament/components/SchedulePreview.tsx
+++ b/app/tournament/components/SchedulePreview.tsx
@@ -1,16 +1,87 @@
 'use client';
 
-import type { AudioEvent, TimeSlot } from '@/app/lib/tournamentSchedule';
-import { formatMsFromStart } from '@/app/lib/tournamentSchedule';
-import { clipKey } from '@/app/lib/tournamentSchedule';
+import {
+  COUNTDOWN_CLIP_SLUGS,
+  clipKey,
+  formatMsFromStart,
+  getCourtCallMs,
+  getNextRoundStartMs,
+  getNoBlockingEndMs,
+  getNoBlockingStartMs,
+  type AudioEvent,
+  type CountdownClipSlug,
+  type ScheduleConfig,
+  type TimeSlot,
+} from '@/app/lib/tournamentSchedule';
+
+function slugToLabel(slug: string): string {
+  return slug
+    .split(/[-_]+/)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
 
 interface SchedulePreviewProps {
   slots: TimeSlot[];
   events: AudioEvent[];
   filename: string;
+  config: ScheduleConfig;
+  onConfigChange: (c: ScheduleConfig) => void;
 }
 
-export default function SchedulePreview({ slots, events, filename }: SchedulePreviewProps) {
+function toggleCountdown(
+  list: CountdownClipSlug[],
+  slug: CountdownClipSlug,
+  checked: boolean
+): CountdownClipSlug[] {
+  if (checked) {
+    return list.includes(slug) ? list : [...list, slug];
+  }
+  return list.filter((s) => s !== slug);
+}
+
+function CountdownCheckboxes({
+  id,
+  label,
+  selected,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  selected: CountdownClipSlug[];
+  onChange: (next: CountdownClipSlug[]) => void;
+}) {
+  return (
+    <fieldset className="space-y-2">
+      <legend className="text-sm font-medium text-gray-900">{label}</legend>
+      <div className="flex flex-wrap gap-3">
+        {COUNTDOWN_CLIP_SLUGS.map((slug) => (
+          <label key={`${id}-${slug}`} className="flex items-center gap-1.5 text-sm text-gray-700">
+            <input
+              type="checkbox"
+              checked={selected.includes(slug)}
+              onChange={(e) =>
+                onChange(toggleCountdown(selected, slug, e.target.checked))
+              }
+              className="rounded border-gray-300"
+            />
+            {slugToLabel(slug)}
+          </label>
+        ))}
+      </div>
+    </fieldset>
+  );
+}
+
+export default function SchedulePreview({
+  slots,
+  events,
+  filename,
+  config,
+  onConfigChange,
+}: SchedulePreviewProps) {
+  const patch = (partial: Partial<ScheduleConfig>) => onConfigChange({ ...config, ...partial });
+
   return (
     <div className="space-y-6">
       <p className="text-gray-600 text-sm">
@@ -19,41 +90,181 @@ export default function SchedulePreview({ slots, events, filename }: SchedulePre
       </p>
 
       <div className="space-y-3">
-        <h3 className="font-semibold text-gray-900">Time slots</h3>
+        <h3 className="font-semibold text-gray-900">Round timeline</h3>
+        <p className="text-xs text-gray-500">
+          Key timestamps per round based on your configuration below.
+        </p>
         <div className="overflow-x-auto border border-gray-200 rounded-lg">
           <table className="min-w-full text-sm">
             <thead className="bg-gray-50">
               <tr>
-                <th className="px-3 py-2 text-left">Start</th>
                 <th className="px-3 py-2 text-left">Round</th>
-                <th className="px-3 py-2 text-left">Phase</th>
-                <th className="px-3 py-2 text-left">Courts</th>
-                <th className="px-3 py-2 text-left">Duration</th>
+                <th className="px-3 py-2 text-left">Round starts</th>
+                <th className="px-3 py-2 text-left">No-blocking starts</th>
+                <th className="px-3 py-2 text-left">No-blocking ends</th>
+                <th className="px-3 py-2 text-left">Next round</th>
                 <th className="px-3 py-2 text-left">Notes</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-100">
-              {slots.map((slot) => (
-                <tr key={`${slot.round}-${slot.startMs}`} className="hover:bg-gray-50">
-                  <td className="px-3 py-2 font-mono">{formatMsFromStart(slot.startMs)}</td>
-                  <td className="px-3 py-2">{slot.round}</td>
-                  <td className="px-3 py-2">{slot.phase}</td>
-                  <td className="px-3 py-2">{slot.matches.length}</td>
-                  <td className="px-3 py-2">{Math.round(slot.durationMs / 60000)} min</td>
-                  <td className="px-3 py-2">
-                    {slot.hasPlaceholderTeams ? (
-                      <span className="text-amber-700 text-xs">
-                        Playoff teams TBD — uses playoff_match clip
+              {slots.map((slot, i) => {
+                const nextStart = getNextRoundStartMs(i, slots);
+                return (
+                  <tr key={`${slot.round}-${slot.startMs}`} className="hover:bg-gray-50">
+                    <td className="px-3 py-2">{slot.round}</td>
+                    <td className="px-3 py-2 font-mono">{formatMsFromStart(slot.startMs)}</td>
+                    <td className="px-3 py-2 font-mono">
+                      {formatMsFromStart(getNoBlockingStartMs(slot, config))}
+                      <span className="text-gray-400 text-xs ml-1">
+                        (+{config.noBlockingStartMin}m)
                       </span>
-                    ) : (
-                      <span className="text-gray-400 text-xs">—</span>
-                    )}
-                  </td>
-                </tr>
-              ))}
+                    </td>
+                    <td className="px-3 py-2 font-mono">
+                      {formatMsFromStart(getNoBlockingEndMs(slot, config))}
+                      <span className="text-gray-400 text-xs ml-1">
+                        (+{config.noBlockingDurationMin}m)
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 font-mono">
+                      {nextStart != null ? (
+                        <>
+                          {formatMsFromStart(nextStart)}
+                          <span className="text-gray-400 text-xs ml-1 block">
+                            Court call{' '}
+                            {formatMsFromStart(getCourtCallMs(slots[i + 1], config))}
+                          </span>
+                        </>
+                      ) : (
+                        <span className="text-gray-400">—</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2">
+                      {slot.hasPlaceholderTeams ? (
+                        <span className="text-amber-700 text-xs">
+                          Playoff teams TBD — uses playoff_match clip
+                        </span>
+                      ) : (
+                        <span className="text-gray-400 text-xs">—</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>
+      </div>
+
+      <div className="border border-gray-200 rounded-lg p-4 space-y-6 bg-gray-50">
+        <h3 className="font-semibold text-gray-900">Audio configuration</h3>
+
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <label className="block text-sm">
+            <span className="font-medium text-gray-900">No-blocking starts (min after round)</span>
+            <input
+              type="number"
+              min={1}
+              max={120}
+              value={config.noBlockingStartMin}
+              onChange={(e) =>
+                patch({ noBlockingStartMin: Math.max(1, parseInt(e.target.value, 10) || 15) })
+              }
+              className="mt-1 w-full rounded border border-gray-300 px-2 py-1.5 text-sm"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="font-medium text-gray-900">No-blocking duration (min)</span>
+            <input
+              type="number"
+              min={1}
+              max={30}
+              value={config.noBlockingDurationMin}
+              onChange={(e) =>
+                patch({
+                  noBlockingDurationMin: Math.max(1, parseInt(e.target.value, 10) || 3),
+                })
+              }
+              className="mt-1 w-full rounded border border-gray-300 px-2 py-1.5 text-sm"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="font-medium text-gray-900">Court call lead time (seconds)</span>
+            <input
+              type="number"
+              min={30}
+              max={300}
+              value={Math.round(config.courtAssignOffsetMs / 1000)}
+              onChange={(e) =>
+                patch({
+                  courtAssignOffsetMs: Math.max(30, parseInt(e.target.value, 10) || 90) * 1000,
+                })
+              }
+              className="mt-1 w-full rounded border border-gray-300 px-2 py-1.5 text-sm"
+            />
+          </label>
+        </div>
+
+        <fieldset className="space-y-2">
+          <legend className="text-sm font-medium text-gray-900">Team names in court announcements</legend>
+          <div className="flex flex-col sm:flex-row gap-4">
+            <label className="flex items-start gap-2 text-sm text-gray-700">
+              <input
+                type="radio"
+                name="teamNameMode"
+                checked={config.teamNameMode === 'separate'}
+                onChange={() => patch({ teamNameMode: 'separate' })}
+                className="mt-1"
+              />
+              <span>
+                <span className="font-medium">Separate clips</span> — Team A + vs + Team B
+              </span>
+            </label>
+            <label className="flex items-start gap-2 text-sm text-gray-700">
+              <input
+                type="radio"
+                name="teamNameMode"
+                checked={config.teamNameMode === 'compound'}
+                onChange={() => patch({ teamNameMode: 'compound' })}
+                className="mt-1"
+              />
+              <span>
+                <span className="font-medium">Compound clip</span> — one clip per matchup (e.g.
+                black-panther-vs-proud-family)
+              </span>
+            </label>
+          </div>
+        </fieldset>
+
+        <label className="flex items-center gap-2 text-sm text-gray-700">
+          <input
+            type="checkbox"
+            checked={config.includeRefs}
+            onChange={(e) => patch({ includeRefs: e.target.checked })}
+            className="rounded border-gray-300"
+          />
+          <span>Include referee names in court announcements</span>
+        </label>
+
+        <CountdownCheckboxes
+          id="nb-start"
+          label="Countdowns before no-blocking starts"
+          selected={config.countdownsBeforeNoBlockingStart}
+          onChange={(countdownsBeforeNoBlockingStart) => patch({ countdownsBeforeNoBlockingStart })}
+        />
+
+        <CountdownCheckboxes
+          id="nb-end"
+          label="Countdowns before no-blocking ends (buzzer)"
+          selected={config.countdownsBeforeNoBlockingEnd}
+          onChange={(countdownsBeforeNoBlockingEnd) => patch({ countdownsBeforeNoBlockingEnd })}
+        />
+
+        <CountdownCheckboxes
+          id="court"
+          label="Countdowns before court call (get to your next court)"
+          selected={config.countdownsBeforeCourtCall}
+          onChange={(countdownsBeforeCourtCall) => patch({ countdownsBeforeCourtCall })}
+        />
       </div>
 
       <details className="border border-gray-200 rounded-lg">
@@ -70,8 +281,8 @@ export default function SchedulePreview({ slots, events, filename }: SchedulePre
               </tr>
             </thead>
             <tbody>
-              {events.map((e, i) => (
-                <tr key={i} className="border-t border-gray-100">
+              {events.map((e) => (
+                <tr key={`${e.absoluteMs}-${e.label}`} className="border-t border-gray-100">
                   <td className="px-2 py-1 font-mono whitespace-nowrap">
                     {formatMsFromStart(e.absoluteMs)}
                   </td>

--- a/app/tournament/page.tsx
+++ b/app/tournament/page.tsx
@@ -8,9 +8,11 @@ import type { WizardStep, TournamentClip } from './types';
 import {
   buildAudioEvents,
   buildTimeSlots,
+  DEFAULT_SCHEDULE_CONFIG,
   getRequiredClipKeys,
   getUniqueClipKeysFromEvents,
   parseTournamentCsv,
+  type ScheduleConfig,
 } from '@/app/lib/tournamentSchedule';
 
 const STEPS: { n: WizardStep; title: string }[] = [
@@ -26,6 +28,7 @@ export default function TournamentPage() {
   const [scheduleError, setScheduleError] = useState<string | null>(null);
   const [clips, setClips] = useState<TournamentClip[]>([]);
   const [clipsLoading, setClipsLoading] = useState(true);
+  const [scheduleConfig, setScheduleConfig] = useState<ScheduleConfig>(DEFAULT_SCHEDULE_CONFIG);
 
   const loadSchedule = useCallback(async () => {
     setScheduleError(null);
@@ -65,10 +68,10 @@ export default function TournamentPage() {
     }
     const rows = parseTournamentCsv(csv);
     const slots = buildTimeSlots(rows);
-    const events = buildAudioEvents(slots);
+    const events = buildAudioEvents(slots, scheduleConfig);
     const requiredKeys = getUniqueClipKeysFromEvents(events);
     return { slots, events, requiredKeys };
-  }, [csv]);
+  }, [csv, scheduleConfig]);
 
   const clipByKey = new Map(clips.map((c) => [c.key, c]));
   const uploadedRequired = requiredKeys.filter((k) => clipByKey.has(k)).length;
@@ -118,7 +121,13 @@ export default function TournamentPage() {
                 <p className="text-gray-500">Loading schedule…</p>
               )}
               {csv && (
-                <SchedulePreview slots={slots} events={events} filename={filename} />
+                <SchedulePreview
+                  slots={slots}
+                  events={events}
+                  filename={filename}
+                  config={scheduleConfig}
+                  onConfigChange={setScheduleConfig}
+                />
               )}
               <div className="mt-6 flex justify-end">
                 <button
@@ -141,6 +150,8 @@ export default function TournamentPage() {
                 <AudioFileGrid
                   clips={clips}
                   requiredKeys={requiredKeys}
+                  slots={slots}
+                  config={scheduleConfig}
                   onRefresh={loadClips}
                 />
               )}

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "vitest": "^4.0.16"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {


### PR DESCRIPTION
## Summary
- Add `ScheduleConfig` so step 1 controls no-blocking timing, court-call lead time, team name mode (separate vs compound), ref clips, and countdowns before each phase.
- Show a per-round timeline (round start, no-blocking start/end, next court call) and rebuild the event list live as settings change.
- Support `matchups` and `refs` clip uploads in the audio grid when those modes are enabled.

## Test plan
- [ ] Open `/tournament` step 1 and confirm the round timeline matches configured offsets.
- [ ] Toggle separate vs compound team names; verify required clips and event timeline update.
- [ ] Enable referee clips and upload `refs/*` clips for names in the CSV.
- [ ] Adjust countdown checkboxes and confirm events appear/disappear in the timeline.
- [ ] Upload `generic/no_blocking_start` and generate MP3; spot-check no-blocking and buzzer timestamps.

Made with [Cursor](https://cursor.com)