### PR TITLE
Add Throw Down team schedule generator UI

### DIFF
--- a/app/api/throwdown-team-schedules/route.ts
+++ b/app/api/throwdown-team-schedules/route.ts
@@ -1,0 +1,64 @@
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  buildTeamSchedulesBuffer,
+  defaultTeamSchedulesFilename,
+  groupPhaseTeams,
+  parseThrowdownScheduleCsv,
+} from '@/app/lib/buildTeamSchedules';
+
+const SAMPLE_CSV = join(process.cwd(), 'schedule_data', 'schedule_may_27.csv');
+
+function safeDownloadName(name: string | undefined): string {
+  const base = (name ?? defaultTeamSchedulesFilename()).trim() || defaultTeamSchedulesFilename();
+  const cleaned = base.replace(/[^\w\s.-]/g, '').replace(/\s+/g, '_');
+  return cleaned.toLowerCase().endsWith('.xlsx') ? cleaned : `${cleaned}.xlsx`;
+}
+
+export async function GET() {
+  try {
+    const csv = await readFile(SAMPLE_CSV, 'utf-8');
+    return NextResponse.json({
+      csv,
+      filename: 'schedule_may_27.csv',
+    });
+  } catch {
+    return NextResponse.json({ error: 'Sample schedule CSV not found.' }, { status: 404 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as { csv?: string; outputName?: string };
+    const csv = body.csv?.trim();
+    if (!csv) {
+      return NextResponse.json({ error: 'CSV content is required.' }, { status: 400 });
+    }
+
+    const games = parseThrowdownScheduleCsv(csv);
+    const teams = groupPhaseTeams(games);
+    if (teams.length === 0) {
+      return NextResponse.json(
+        { error: 'No group-phase teams found. Check that the CSV is a Throw Down schedule export.' },
+        { status: 400 }
+      );
+    }
+
+    const buffer = buildTeamSchedulesBuffer(csv);
+    const filename = safeDownloadName(body.outputName);
+
+    return new NextResponse(buffer, {
+      headers: {
+        'Content-Type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+      },
+    });
+  } catch (e) {
+    console.error('throwdown-team-schedules failed:', e);
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : 'Failed to build team schedules.' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/throwdown-team-schedules/route.ts
+++ b/app/api/throwdown-team-schedules/route.ts
@@ -10,9 +10,14 @@ import {
 
 const SAMPLE_CSV = join(process.cwd(), 'schedule_data', 'schedule_may_27.csv');
 
+function sanitizeDownloadName(name: string): string {
+  return name.trim().replace(/[^\w\s.-]/g, '').replace(/\s+/g, '_');
+}
+
 function safeDownloadName(name: string | undefined): string {
-  const base = (name ?? defaultTeamSchedulesFilename()).trim() || defaultTeamSchedulesFilename();
-  const cleaned = base.replace(/[^\w\s.-]/g, '').replace(/\s+/g, '_');
+  const fallback = defaultTeamSchedulesFilename();
+  const base = (name ?? fallback).trim() || fallback;
+  const cleaned = sanitizeDownloadName(base) || sanitizeDownloadName(fallback);
   return cleaned.toLowerCase().endsWith('.xlsx') ? cleaned : `${cleaned}.xlsx`;
 }
 

--- a/app/components/TopNav.tsx
+++ b/app/components/TopNav.tsx
@@ -16,6 +16,9 @@ export default function TopNav() {
         <Link href="/tournament" className="hover:underline">
           Tournament Audio
         </Link>
+        <Link href="/tournament/team-schedules" className="hover:underline">
+          Team Schedules
+        </Link>
       </div>
     </nav>
   );

--- a/app/lib/__tests__/buildTeamSchedules.test.ts
+++ b/app/lib/__tests__/buildTeamSchedules.test.ts
@@ -1,0 +1,82 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+import * as XLSX from 'xlsx';
+import {
+  buildPlayoffSummary,
+  buildTeamSchedulesWorkbook,
+  gamesByRound,
+  groupPhaseRoundStats,
+  groupPhaseStreamPlayRounds,
+  groupPhaseTeams,
+  parseThrowdownScheduleCsv,
+} from '../buildTeamSchedules';
+
+const SAMPLE_CSV = readFileSync(
+  join(process.cwd(), 'schedule_data', 'schedule_may_27.csv'),
+  'utf-8'
+);
+
+describe('buildTeamSchedules', () => {
+  it('parses throwdown CSV rows', () => {
+    const games = parseThrowdownScheduleCsv(SAMPLE_CSV);
+    expect(games.length).toBeGreaterThan(40);
+    expect(games[0].home).toBe('Black Panther');
+    expect(games[0].referees).toBe('Sister Sister');
+  });
+
+  it('finds 16 group-phase teams', () => {
+    const games = parseThrowdownScheduleCsv(SAMPLE_CSV);
+    const teams = groupPhaseTeams(games);
+    expect(teams).toHaveLength(16);
+    expect(teams).toContain('Black Panther');
+    expect(teams).toContain('Kenan & Kel');
+  });
+
+  it('computes group phase round stats', () => {
+    const games = parseThrowdownScheduleCsv(SAMPLE_CSV);
+    const gpByRound = gamesByRound(games, 'Group Phase');
+    const [home, away, ref, off] = groupPhaseRoundStats('Black Panther', gpByRound);
+    expect(home + away + ref + off).toBe(10);
+    expect(home + away).toBeGreaterThan(0);
+  });
+
+  it('finds stream court playing rounds', () => {
+    const games = parseThrowdownScheduleCsv(SAMPLE_CSV);
+    const gpByRound = gamesByRound(games, 'Group Phase');
+    const rounds = groupPhaseStreamPlayRounds('Black Panther', gpByRound);
+    expect(rounds.length).toBeGreaterThan(0);
+    expect(rounds.every((r) => r >= 1 && r <= 10)).toBe(true);
+  });
+
+  it('builds playoff summary rows', () => {
+    const games = parseThrowdownScheduleCsv(SAMPLE_CSV);
+    const playoffByRound = gamesByRound(games, 'Playoff');
+    const summary = buildPlayoffSummary(playoffByRound);
+    expect(summary.length).toBeGreaterThan(0);
+    expect(summary[0].courts).toMatch(/Court/);
+  });
+
+  it('creates summary plus one sheet per team', () => {
+    const workbook = buildTeamSchedulesWorkbook(SAMPLE_CSV);
+    expect(workbook.SheetNames[0]).toBe('Summary');
+    expect(workbook.SheetNames).toHaveLength(17);
+
+    const summary = XLSX.utils.sheet_to_json<string[]>(workbook.Sheets.Summary, {
+      header: 1,
+      defval: '',
+    }) as string[][];
+    expect(summary[3]?.[0]).toBe('Team');
+    expect(summary[4]?.[0]).toBe('Abbott Elementary');
+
+    const blackPantherSheet =
+      workbook.Sheets[workbook.SheetNames.find((n) => n.includes('Black Panther'))!];
+    const teamRows = XLSX.utils.sheet_to_json<string[]>(blackPantherSheet, {
+      header: 1,
+      defval: '',
+    }) as string[][];
+    expect(teamRows[0]?.[0]).toBe('Black Panther');
+    expect(teamRows.some((row) => row[3] === 'PLAYING (Home)' || row[3] === 'PLAYING (Away)'))
+      .toBe(true);
+  });
+});

--- a/app/lib/buildTeamSchedules.ts
+++ b/app/lib/buildTeamSchedules.ts
@@ -1,0 +1,326 @@
+import * as XLSX from 'xlsx';
+import { splitCsvLine } from './scheduleParser';
+
+export const STREAM_COURT = 'Court 1';
+
+export interface GameRow {
+  date: string;
+  court: string;
+  phase: string;
+  group: string;
+  roundNum: number;
+  home: string;
+  away: string;
+  referees: string;
+}
+
+export interface PlayoffSummaryRow {
+  round: number;
+  time: string;
+  description: string;
+  courts: string;
+}
+
+function cleanTeam(value: string | undefined): string {
+  const t = (value ?? '').trim();
+  if (t.toLowerCase() === 'undefined') return '';
+  return t;
+}
+
+function headerIndex(header: string[], name: string): number {
+  const lower = name.toLowerCase();
+  return header.findIndex((h) => h.includes(lower));
+}
+
+export function parseThrowdownScheduleCsv(csvText: string): GameRow[] {
+  const normalized = csvText.replace(/^\uFEFF/, '');
+  const lines = normalized.split('\n').filter((l) => l.trim());
+  if (lines.length < 2) return [];
+
+  const header = splitCsvLine(lines[0]).map((h) => h.trim().toLowerCase());
+  const dateIdx = headerIndex(header, 'date');
+  const courtIdx = headerIndex(header, 'court');
+  const phaseIdx = headerIndex(header, 'phase');
+  const groupIdx = headerIndex(header, 'group');
+  const roundIdx = headerIndex(header, 'round');
+  const homeIdx = headerIndex(header, 'home team');
+  const awayIdx = headerIndex(header, 'away team');
+  const refIdx = headerIndex(header, 'referee');
+
+  const rows: GameRow[] = [];
+  for (let i = 1; i < lines.length; i++) {
+    const cells = splitCsvLine(lines[i]);
+    const get = (n: number) => (n >= 0 ? cells[n]?.trim() ?? '' : '');
+    rows.push({
+      date: get(dateIdx),
+      court: get(courtIdx),
+      phase: get(phaseIdx),
+      group: get(groupIdx),
+      roundNum: parseInt(get(roundIdx) || '0', 10) || 0,
+      home: cleanTeam(get(homeIdx)),
+      away: cleanTeam(get(awayIdx)),
+      referees: cleanTeam(get(refIdx)),
+    });
+  }
+  return rows;
+}
+
+export function groupPhaseTeams(games: GameRow[]): string[] {
+  const names = new Set<string>();
+  for (const g of games) {
+    if (g.phase !== 'Group Phase') continue;
+    if (g.home) names.add(g.home);
+    if (g.away) names.add(g.away);
+  }
+  return [...names].sort();
+}
+
+export function gamesByRound(games: GameRow[], phase: string): Map<number, GameRow[]> {
+  const out = new Map<number, GameRow[]>();
+  for (const g of games) {
+    if (g.phase !== phase) continue;
+    const list = out.get(g.roundNum) ?? [];
+    list.push(g);
+    out.set(g.roundNum, list);
+  }
+  for (const [round, list] of out) {
+    list.sort((a, b) => a.court.localeCompare(b.court) || a.date.localeCompare(b.date));
+    out.set(round, list);
+  }
+  return out;
+}
+
+export function excelSheetTitle(name: string, used: Set<string>): string {
+  const bad = '[]:*?/\\';
+  let base = [...name].map((c) => (bad.includes(c) ? '_' : c)).join('');
+  if (base.length > 31) base = base.slice(0, 31);
+
+  let candidate = base;
+  let n = 2;
+  while (used.has(candidate)) {
+    const suffix = ` (${n})`;
+    candidate =
+      base.length + suffix.length > 31 ? base.slice(0, 31 - suffix.length) + suffix : base + suffix;
+    n += 1;
+  }
+  used.add(candidate);
+  return candidate;
+}
+
+export function groupPhaseRoundStats(
+  team: string,
+  gpByRound: Map<number, GameRow[]>
+): [number, number, number, number] {
+  const gpRounds = [...gpByRound.keys()].filter((k) => k >= 1 && k <= 10).sort((a, b) => a - b);
+  let homeC = 0;
+  let awayC = 0;
+  let refC = 0;
+  let offC = 0;
+
+  for (const rnd of gpRounds) {
+    const games = gpByRound.get(rnd) ?? [];
+    if (games.length === 0) {
+      offC += 1;
+      continue;
+    }
+    if (games.some((g) => g.home === team)) homeC += 1;
+    else if (games.some((g) => g.away === team)) awayC += 1;
+    else if (games.some((g) => g.referees === team)) refC += 1;
+    else offC += 1;
+  }
+  return [homeC, awayC, refC, offC];
+}
+
+export function groupPhaseStreamPlayRounds(
+  team: string,
+  gpByRound: Map<number, GameRow[]>
+): number[] {
+  const rounds: number[] = [];
+  for (const rnd of [...gpByRound.keys()].filter((k) => k >= 1 && k <= 10).sort((a, b) => a - b)) {
+    for (const g of gpByRound.get(rnd) ?? []) {
+      if (g.court !== STREAM_COURT) continue;
+      if (g.home === team || g.away === team) {
+        rounds.push(rnd);
+        break;
+      }
+    }
+  }
+  return rounds;
+}
+
+export function buildPlayoffSummary(
+  playoffByRound: Map<number, GameRow[]>
+): PlayoffSummaryRow[] {
+  const summary: PlayoffSummaryRow[] = [];
+  for (const rnd of [...playoffByRound.keys()].sort((a, b) => a - b)) {
+    const games = playoffByRound.get(rnd) ?? [];
+    if (games.length === 0) continue;
+
+    const time = games[0].date;
+    const uniqueGroups = [...new Set(games.map((g) => g.group))];
+    const description = uniqueGroups.length > 0 ? uniqueGroups.join(' | ') : 'Playoff block';
+
+    const courtNums = games
+      .map((g) => g.court.replace('Court ', '').trim())
+      .filter((c) => /^\d+$/.test(c))
+      .map((c) => parseInt(c, 10));
+
+    let courts: string;
+    if (courtNums.length > 0) {
+      const lo = Math.min(...courtNums);
+      const hi = Math.max(...courtNums);
+      courts = lo !== hi ? `Courts ${lo}–${hi}` : `Court ${lo}`;
+    } else {
+      courts = games.map((g) => g.court).join(', ');
+    }
+
+    summary.push({ round: rnd, time, description, courts });
+  }
+  return summary;
+}
+
+function buildSummarySheetRows(teams: string[], gpByRound: Map<number, GameRow[]>): string[][] {
+  const rows: string[][] = [
+    ['Group phase — team summary'],
+    ['Throw Down — group rounds 1–10'],
+    [],
+    [
+      'Team',
+      'Home',
+      'Away',
+      'Ref',
+      'Off',
+      'Total rounds',
+      'Playing total',
+      'Court 1 (stream) — playing rounds',
+    ],
+  ];
+
+  for (const team of teams) {
+    const [h, a, r, o] = groupPhaseRoundStats(team, gpByRound);
+    const total = h + a + r + o;
+    const play = h + a;
+    const c1Rounds = groupPhaseStreamPlayRounds(team, gpByRound);
+    const c1Str = c1Rounds.length > 0 ? c1Rounds.join(', ') : '—';
+    rows.push([team, String(h), String(a), String(r), String(o), String(total), String(play), c1Str]);
+  }
+  return rows;
+}
+
+function buildTeamSheetRows(
+  team: string,
+  gpByRound: Map<number, GameRow[]>,
+  playoffSummary: PlayoffSummaryRow[]
+): string[][] {
+  const rows: string[][] = [
+    [team],
+    ['Throw Down — schedule export'],
+    [],
+    ['Round', 'Time', 'Court', 'Status', 'Home Team', 'Away Team', 'Ref Team'],
+  ];
+
+  const gpRounds = [...gpByRound.keys()].filter((k) => k >= 1 && k <= 10).sort((a, b) => a - b);
+  let nPlay = 0;
+  let nRef = 0;
+
+  for (const rnd of gpRounds) {
+    const games = gpByRound.get(rnd) ?? [];
+    if (games.length === 0) continue;
+
+    const roundTime = games[0].date;
+    const playingHome = games.find((g) => g.home === team);
+    const playingAway = games.find((g) => g.away === team);
+    const reffing = games.find((g) => g.referees === team);
+
+    if (playingHome) {
+      nPlay += 1;
+      rows.push([
+        String(rnd),
+        roundTime,
+        playingHome.court,
+        'PLAYING (Home)',
+        playingHome.home,
+        playingHome.away,
+        playingHome.referees,
+      ]);
+    } else if (playingAway) {
+      nPlay += 1;
+      rows.push([
+        String(rnd),
+        roundTime,
+        playingAway.court,
+        'PLAYING (Away)',
+        playingAway.home,
+        playingAway.away,
+        playingAway.referees,
+      ]);
+    } else if (reffing) {
+      nRef += 1;
+      rows.push([
+        String(rnd),
+        roundTime,
+        reffing.court,
+        'REFFING',
+        reffing.home,
+        reffing.away,
+        reffing.referees,
+      ]);
+    } else {
+      rows.push([String(rnd), roundTime, '—', 'OFF', '—', '—', '—']);
+    }
+  }
+
+  const nOff = gpRounds.length - nPlay - nRef;
+  rows.push([]);
+  rows.push([
+    `Group phase summary — Playing: ${nPlay} rounds • Reffing: ${nRef} rounds • Off: ${nOff} rounds`,
+  ]);
+  rows.push([]);
+  rows.push(['Playoffs — Bracket TBD Based on Seeding']);
+  rows.push(['Round', 'Time', 'Phase / matches', 'Courts']);
+
+  for (const row of playoffSummary) {
+    rows.push([String(row.round), row.time, row.description, row.courts]);
+  }
+
+  return rows;
+}
+
+function applyColumnWidths(ws: XLSX.WorkSheet, widths: number[]): void {
+  ws['!cols'] = widths.map((wch) => ({ wch }));
+}
+
+export function buildTeamSchedulesWorkbook(csvText: string): XLSX.WorkBook {
+  const games = parseThrowdownScheduleCsv(csvText);
+  const teams = groupPhaseTeams(games);
+  const gpByRound = gamesByRound(games, 'Group Phase');
+  const playoffByRound = gamesByRound(games, 'Playoff');
+  const playoffSummary = buildPlayoffSummary(playoffByRound);
+
+  const workbook = XLSX.utils.book_new();
+
+  const summarySheet = XLSX.utils.aoa_to_sheet(buildSummarySheetRows(teams, gpByRound));
+  applyColumnWidths(summarySheet, [28, 10, 10, 10, 10, 14, 14, 32]);
+  XLSX.utils.book_append_sheet(workbook, summarySheet, 'Summary');
+
+  const usedTitles = new Set<string>(['Summary']);
+  for (const team of teams) {
+    const title = excelSheetTitle(team, usedTitles);
+    const teamSheet = XLSX.utils.aoa_to_sheet(
+      buildTeamSheetRows(team, gpByRound, playoffSummary)
+    );
+    applyColumnWidths(teamSheet, [10, 22, 12, 18, 22, 22, 22]);
+    XLSX.utils.book_append_sheet(workbook, teamSheet, title);
+  }
+
+  return workbook;
+}
+
+export function buildTeamSchedulesBuffer(csvText: string): Buffer {
+  const workbook = buildTeamSchedulesWorkbook(csvText);
+  return XLSX.write(workbook, { type: 'buffer', bookType: 'xlsx' }) as Buffer;
+}
+
+export function defaultTeamSchedulesFilename(): string {
+  return 'Throw_Down_Team_Schedules.xlsx';
+}

--- a/app/lib/buildTeamSchedules.ts
+++ b/app/lib/buildTeamSchedules.ts
@@ -118,11 +118,7 @@ export function groupPhaseRoundStats(
   let offC = 0;
 
   for (const rnd of gpRounds) {
-    const games = gpByRound.get(rnd) ?? [];
-    if (games.length === 0) {
-      offC += 1;
-      continue;
-    }
+    const games = gpByRound.get(rnd)!;
     if (games.some((g) => g.home === team)) homeC += 1;
     else if (games.some((g) => g.away === team)) awayC += 1;
     else if (games.some((g) => g.referees === team)) refC += 1;
@@ -224,9 +220,7 @@ function buildTeamSheetRows(
   let nRef = 0;
 
   for (const rnd of gpRounds) {
-    const games = gpByRound.get(rnd) ?? [];
-    if (games.length === 0) continue;
-
+    const games = gpByRound.get(rnd)!;
     const roundTime = games[0].date;
     const playingHome = games.find((g) => g.home === team);
     const playingAway = games.find((g) => g.away === team);

--- a/app/tournament/team-schedules/page.tsx
+++ b/app/tournament/team-schedules/page.tsx
@@ -73,7 +73,9 @@ export default function ThrowdownTeamSchedulesPage() {
       document.body.appendChild(a);
       a.click();
       a.remove();
-      URL.revokeObjectURL(url);
+      setTimeout(() => {
+        URL.revokeObjectURL(url);
+      }, 1000);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to generate workbook');
     } finally {

--- a/app/tournament/team-schedules/page.tsx
+++ b/app/tournament/team-schedules/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState, type ChangeEvent } from 'react';
 
 export default function ThrowdownTeamSchedulesPage() {
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const [csv, setCsv] = useState('');
   const [csvFilename, setCsvFilename] = useState('');
   const [outputName, setOutputName] = useState('Throw_Down_Team_Schedules');
@@ -10,8 +11,10 @@ export default function ThrowdownTeamSchedulesPage() {
   const [isGenerating, setIsGenerating] = useState(false);
   const [isLoadingSample, setIsLoadingSample] = useState(false);
 
-  const onFileChange = useCallback(async (file: File | null) => {
+  const onFileChange = useCallback(async (e: ChangeEvent<HTMLInputElement>) => {
     setError(null);
+    const file = e.target.files?.[0] ?? null;
+    e.target.value = '';
     if (!file) return;
     try {
       const text = await file.text();
@@ -99,10 +102,11 @@ export default function ThrowdownTeamSchedulesPage() {
           <label className="inline-flex cursor-pointer items-center rounded-md bg-gray-800 px-4 py-2 text-sm font-medium text-white hover:bg-gray-700">
             Choose CSV file
             <input
+              ref={fileInputRef}
               type="file"
               accept=".csv,text/csv"
               className="hidden"
-              onChange={(e) => void onFileChange(e.target.files?.[0] ?? null)}
+              onChange={(e) => void onFileChange(e)}
             />
           </label>
           <button

--- a/app/tournament/team-schedules/page.tsx
+++ b/app/tournament/team-schedules/page.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+export default function ThrowdownTeamSchedulesPage() {
+  const [csv, setCsv] = useState('');
+  const [csvFilename, setCsvFilename] = useState('');
+  const [outputName, setOutputName] = useState('Throw_Down_Team_Schedules');
+  const [error, setError] = useState<string | null>(null);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [isLoadingSample, setIsLoadingSample] = useState(false);
+
+  const onFileChange = useCallback(async (file: File | null) => {
+    setError(null);
+    if (!file) return;
+    try {
+      const text = await file.text();
+      setCsv(text);
+      setCsvFilename(file.name);
+    } catch {
+      setError('Could not read the uploaded file.');
+    }
+  }, []);
+
+  const loadSample = useCallback(async () => {
+    setError(null);
+    setIsLoadingSample(true);
+    try {
+      const res = await fetch('/api/throwdown-team-schedules');
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Failed to load sample CSV');
+      setCsv(data.csv);
+      setCsvFilename(data.filename);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load sample CSV');
+    } finally {
+      setIsLoadingSample(false);
+    }
+  }, []);
+
+  const generate = useCallback(async () => {
+    setError(null);
+    if (!csv.trim()) {
+      setError('Upload a Throw Down schedule CSV or load the sample export.');
+      return;
+    }
+
+    setIsGenerating(true);
+    try {
+      const res = await fetch('/api/throwdown-team-schedules', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ csv, outputName }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || `Request failed (${res.status})`);
+      }
+
+      const blob = await res.blob();
+      const disposition = res.headers.get('Content-Disposition') ?? '';
+      const match = disposition.match(/filename="([^"]+)"/);
+      const downloadName = match?.[1] ?? `${outputName.replace(/\s+/g, '_')}.xlsx`;
+
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = downloadName;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to generate workbook');
+    } finally {
+      setIsGenerating(false);
+    }
+  }, [csv, outputName]);
+
+  return (
+    <div className="max-w-3xl mx-auto p-6 space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Throw Down Team Schedules</h1>
+        <p className="mt-2 text-gray-600">
+          Upload a Throw Down schedule CSV export to generate an Excel workbook with a summary tab
+          plus one sheet per team (group phase rounds, reffing/off status, and playoff blocks).
+        </p>
+      </div>
+
+      <section className="rounded-lg border border-gray-200 bg-white p-5 space-y-4 shadow-sm">
+        <h2 className="text-lg font-semibold text-gray-900">1. Schedule CSV</h2>
+        <p className="text-sm text-gray-600">
+          Use the CSV export from Throw Down (columns like Date, Court, Phase, Home Team, Away
+          Team, Referees).
+        </p>
+
+        <div className="flex flex-wrap gap-3">
+          <label className="inline-flex cursor-pointer items-center rounded-md bg-gray-800 px-4 py-2 text-sm font-medium text-white hover:bg-gray-700">
+            Choose CSV file
+            <input
+              type="file"
+              accept=".csv,text/csv"
+              className="hidden"
+              onChange={(e) => void onFileChange(e.target.files?.[0] ?? null)}
+            />
+          </label>
+          <button
+            type="button"
+            onClick={() => void loadSample()}
+            disabled={isLoadingSample}
+            className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-800 hover:bg-gray-50 disabled:opacity-50"
+          >
+            {isLoadingSample ? 'Loading sample…' : 'Load sample CSV'}
+          </button>
+        </div>
+
+        {csvFilename ? (
+          <p className="text-sm text-green-700">
+            Loaded: <span className="font-medium">{csvFilename}</span>
+            {csv.trim() ? ` (${csv.split('\n').filter((l) => l.trim()).length - 1} games)` : ''}
+          </p>
+        ) : null}
+      </section>
+
+      <section className="rounded-lg border border-gray-200 bg-white p-5 space-y-4 shadow-sm">
+        <h2 className="text-lg font-semibold text-gray-900">2. Output</h2>
+        <label className="block text-sm font-medium text-gray-700" htmlFor="output-name">
+          Download filename
+        </label>
+        <input
+          id="output-name"
+          type="text"
+          value={outputName}
+          onChange={(e) => setOutputName(e.target.value)}
+          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+          placeholder="Throw_Down_Team_Schedules"
+        />
+        <p className="text-xs text-gray-500">.xlsx will be appended automatically if missing.</p>
+      </section>
+
+      {error ? (
+        <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
+          {error}
+        </div>
+      ) : null}
+
+      <button
+        type="button"
+        onClick={() => void generate()}
+        disabled={isGenerating || !csv.trim()}
+        className="rounded-md bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {isGenerating ? 'Generating…' : 'Generate & download XLSX'}
+      </button>
+
+      <p className="text-sm text-gray-500">
+        Same logic as{' '}
+        <code className="rounded bg-gray-100 px-1">schedule_data/build_team_schedules.py</code> —
+        run locally with{' '}
+        <code className="rounded bg-gray-100 px-1">
+          python3 schedule_data/build_team_schedules.py --csv your.csv --out out.xlsx
+        </code>{' '}
+        for styled Excel output with color-coded rows.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `/tournament/team-schedules` page to upload a Throw Down CSV export and download a per-team XLSX workbook
- Ports `schedule_data/build_team_schedules.py` logic to TypeScript (`app/lib/buildTeamSchedules.ts`) for server-side generation on Vercel
- Adds `/api/throwdown-team-schedules` (POST to generate, GET for sample CSV) and nav link under **Team Schedules**

## Test plan
- [ ] Open `/tournament/team-schedules`, click **Load sample CSV**, then **Generate & download XLSX**
- [ ] Verify workbook has **Summary** plus 16 team tabs matching `build_team_schedules.py` output
- [ ] Upload a fresh Throw Down CSV export and confirm download works
- [ ] `npm run test:run -- app/lib/__tests__/buildTeamSchedules.test.ts`


Made with [Cursor](https://cursor.com)