### PR TITLE
Add dev mode toggle to hide WIP features

### DIFF
--- a/app/components/TopNav.tsx
+++ b/app/components/TopNav.tsx
@@ -1,22 +1,40 @@
-import Link from "next/link";
+'use client'
+
+import Link from 'next/link'
+import { useDevMode } from '@/app/hooks/useDevMode'
+import { withDevMode } from '@/app/lib/devMode'
 
 export default function TopNav() {
+  const { devMode, setDevMode } = useDevMode()
+
+  const link = (href: string, label: string) => (
+    <Link href={withDevMode(href, devMode)} className="hover:underline">
+      {label}
+    </Link>
+  )
+
   return (
     <nav className="bg-gray-800 text-blue-300 p-4 flex justify-between items-center">
       <div className="flex space-x-4 items-center">
-        <Link href="/schedules" className="hover:underline">
-          League Schedules
-        </Link>
-        <Link href="/create-league" className="hover:underline">
-          Create League
-        </Link>
-        <Link href="/open-gym" className="hover:underline">
-          Open Gym
-        </Link>
-        <Link href="/tournament" className="hover:underline">
-          Tournament Audio
-        </Link>
+        {link('/schedules', 'League Schedules')}
+        {link('/create-league', 'Create League')}
+        {link('/open-gym', 'Open Gym')}
+        {devMode && (
+          <>
+            {link('/tournament', 'Tournament Audio')}
+            {link('/tournament/team-schedules', 'Team Schedules')}
+          </>
+        )}
       </div>
+      <label className="flex items-center gap-2 text-sm cursor-pointer select-none">
+        <span>Dev mode</span>
+        <input
+          type="checkbox"
+          checked={devMode}
+          onChange={(e) => setDevMode(e.target.checked)}
+          className="rounded border-gray-500"
+        />
+      </label>
     </nav>
-  );
+  )
 }

--- a/app/components/TopNav.tsx
+++ b/app/components/TopNav.tsx
@@ -7,22 +7,26 @@ import { withDevMode } from '@/app/lib/devMode'
 export default function TopNav() {
   const { devMode, setDevMode } = useDevMode()
 
-  const link = (href: string, label: string) => (
-    <Link href={withDevMode(href, devMode)} className="hover:underline">
-      {label}
-    </Link>
-  )
-
   return (
     <nav className="bg-gray-800 text-blue-300 p-4 flex justify-between items-center">
       <div className="flex space-x-4 items-center">
-        {link('/schedules', 'League Schedules')}
-        {link('/create-league', 'Create League')}
-        {link('/open-gym', 'Open Gym')}
+        <Link href={withDevMode('/schedules', devMode)} className="hover:underline">
+          League Schedules
+        </Link>
+        <Link href={withDevMode('/create-league', devMode)} className="hover:underline">
+          Create League
+        </Link>
+        <Link href={withDevMode('/open-gym', devMode)} className="hover:underline">
+          Open Gym
+        </Link>
         {devMode && (
           <>
-            {link('/tournament', 'Tournament Audio')}
-            {link('/tournament/team-schedules', 'Team Schedules')}
+            <Link href={withDevMode('/tournament', devMode)} className="hover:underline">
+              Tournament Audio
+            </Link>
+            <Link href={withDevMode('/tournament/team-schedules', devMode)} className="hover:underline">
+              Team Schedules
+            </Link>
           </>
         )}
       </div>

--- a/app/components/schedule/TeamStatsCards.tsx
+++ b/app/components/schedule/TeamStatsCards.tsx
@@ -9,7 +9,6 @@ interface TeamStatsCardsProps {
   selectedWeek: string
   /** When viewing a single week (1-6), pass games so each card can show "View this week's schedule" */
   games?: Game[]
-  /** Per-team week schedule expanders (dev-only when false). Defaults to true. */
   showTeamSchedules?: boolean
 }
 
@@ -67,8 +66,7 @@ export default function TeamStatsCards({
   showTeamSchedules = true,
 }: TeamStatsCardsProps) {
   const [expandedTeams, setExpandedTeams] = useState<Set<string>>(new Set())
-  const showWeekSchedule =
-    showTeamSchedules && isSingleWeek(selectedWeek) && games.length > 0
+  const showWeekSchedule = showTeamSchedules && isSingleWeek(selectedWeek) && games.length > 0
   const allTeamNames = teamStats.map((s) => s.team)
   const allExpanded = allTeamNames.length > 0 && allTeamNames.every((t) => expandedTeams.has(t))
 

--- a/app/components/schedule/TeamStatsCards.tsx
+++ b/app/components/schedule/TeamStatsCards.tsx
@@ -9,6 +9,8 @@ interface TeamStatsCardsProps {
   selectedWeek: string
   /** When viewing a single week (1-6), pass games so each card can show "View this week's schedule" */
   games?: Game[]
+  /** Per-team week schedule expanders (dev-only when false). Defaults to true. */
+  showTeamSchedules?: boolean
 }
 
 /** Matches scheduleParser: both courts have a real matchup (not BYE/TBD/empty). */
@@ -58,9 +60,15 @@ function getTeamScheduleForWeek(team: string, games: Game[]): TeamWeekRow[] {
 
 const isSingleWeek = (w: string) => w !== 'all' && w !== 'weeks5-6'
 
-export default function TeamStatsCards({ teamStats, selectedWeek, games = [] }: TeamStatsCardsProps) {
+export default function TeamStatsCards({
+  teamStats,
+  selectedWeek,
+  games = [],
+  showTeamSchedules = true,
+}: TeamStatsCardsProps) {
   const [expandedTeams, setExpandedTeams] = useState<Set<string>>(new Set())
-  const showWeekSchedule = isSingleWeek(selectedWeek) && games.length > 0
+  const showWeekSchedule =
+    showTeamSchedules && isSingleWeek(selectedWeek) && games.length > 0
   const allTeamNames = teamStats.map((s) => s.team)
   const allExpanded = allTeamNames.length > 0 && allTeamNames.every((t) => expandedTeams.has(t))
 

--- a/app/hooks/useDevMode.ts
+++ b/app/hooks/useDevMode.ts
@@ -1,0 +1,25 @@
+'use client'
+
+import { useCallback } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { DEV_MODE_PARAM, isDevMode } from '@/app/lib/devMode'
+
+export function useDevMode() {
+  const searchParams = useSearchParams()
+  const pathname = usePathname()
+  const router = useRouter()
+  const devMode = isDevMode(searchParams)
+
+  const setDevMode = useCallback(
+    (on: boolean) => {
+      const params = new URLSearchParams(searchParams.toString())
+      if (on) params.set(DEV_MODE_PARAM, '1')
+      else params.delete(DEV_MODE_PARAM)
+      const q = params.toString()
+      router.replace(q ? `${pathname}?${q}` : pathname)
+    },
+    [pathname, router, searchParams]
+  )
+
+  return { devMode, setDevMode }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import { Suspense } from "react";
+import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import TopNav from "./components/TopNav";
 
@@ -29,11 +29,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <Suspense
-          fallback={
-            <nav className="bg-gray-800 text-blue-300 p-4 flex justify-between items-center h-[52px]" />
-          }
-        >
+        <Suspense fallback={<nav className="bg-gray-800 p-4 h-[52px]" />}>
           <TopNav />
         </Suspense>
         <main>{children}</main>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { Suspense } from "react";
 import "./globals.css";
 import TopNav from "./components/TopNav";
 
@@ -28,7 +29,13 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <TopNav />
+        <Suspense
+          fallback={
+            <nav className="bg-gray-800 text-blue-300 p-4 flex justify-between items-center h-[52px]" />
+          }
+        >
+          <TopNav />
+        </Suspense>
         <main>{children}</main>
       </body>
     </html>

--- a/app/lib/devMode.ts
+++ b/app/lib/devMode.ts
@@ -9,7 +9,9 @@ export function isDevMode(searchParams: SearchParamsLike): boolean {
 
 export function withDevMode(href: string, devMode: boolean): string {
   if (!devMode) return href
+  // Only rewrite app-relative paths; avoid corrupting absolute URLs or non-http schemes.
+  if (!href.startsWith('/')) return href
   const url = new URL(href, 'http://local')
   url.searchParams.set(DEV_MODE_PARAM, '1')
-  return `${url.pathname}${url.search}`
+  return `${url.pathname}${url.search}${url.hash}`
 }

--- a/app/lib/devMode.ts
+++ b/app/lib/devMode.ts
@@ -1,0 +1,14 @@
+export const DEV_MODE_PARAM = 'dev'
+
+export function isDevMode(searchParams: { get(name: string): string | null }): boolean {
+  const value = searchParams.get(DEV_MODE_PARAM)
+  return value === '1' || value === 'true'
+}
+
+/** Preserve dev=1 on internal links when dev mode is active. */
+export function withDevMode(href: string, devMode: boolean): string {
+  if (!devMode) return href
+  const url = new URL(href, 'http://local')
+  url.searchParams.set(DEV_MODE_PARAM, '1')
+  return `${url.pathname}${url.search}`
+}

--- a/app/lib/devMode.ts
+++ b/app/lib/devMode.ts
@@ -1,11 +1,12 @@
 export const DEV_MODE_PARAM = 'dev'
 
-export function isDevMode(searchParams: { get(name: string): string | null }): boolean {
+type SearchParamsLike = Pick<URLSearchParams, 'get'>
+
+export function isDevMode(searchParams: SearchParamsLike): boolean {
   const value = searchParams.get(DEV_MODE_PARAM)
   return value === '1' || value === 'true'
 }
 
-/** Preserve dev=1 on internal links when dev mode is active. */
 export function withDevMode(href: string, devMode: boolean): string {
   if (!devMode) return href
   const url = new URL(href, 'http://local')

--- a/app/schedules/page.tsx
+++ b/app/schedules/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useState, useEffect, useMemo } from 'react'
+import { Suspense, useState, useEffect, useMemo } from 'react'
 import {
   GameCard,
   LoadingState,
@@ -11,13 +11,15 @@ import {
   TeamStatsCards,
 } from '../components/schedule'
 import { useScheduleData } from '../components/schedule/useScheduleData'
+import { useDevMode } from '@/app/hooks/useDevMode'
 
 interface DriveFile {
   id: string
   name: string
 }
 
-export default function SchedulesPage() {
+function SchedulesPageContent() {
+  const { devMode } = useDevMode()
   const [selectedWeek, setSelectedWeek] = useState('all')
   const [sheets, setSheets] = useState<DriveFile[]>([])
   const [selectedSheetId, setSelectedSheetId] = useState<string>('')
@@ -138,6 +140,7 @@ export default function SchedulesPage() {
             }))}
             selectedWeek={selectedWeek}
             games={games}
+            showTeamSchedules={devMode}
           />
 
           <ConflictsAlert conflicts={conflicts} />
@@ -157,5 +160,17 @@ export default function SchedulesPage() {
         </>
       )}
     </div>
+  )
+}
+
+export default function SchedulesPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="container mx-auto px-4 py-6 text-gray-600">Loading…</div>
+      }
+    >
+      <SchedulesPageContent />
+    </Suspense>
   )
 }

--- a/app/schedules/page.tsx
+++ b/app/schedules/page.tsx
@@ -18,6 +18,14 @@ interface DriveFile {
   name: string
 }
 
+export default function SchedulesPage() {
+  return (
+    <Suspense fallback={<div className="container mx-auto px-4 py-6 text-gray-600">Loading…</div>}>
+      <SchedulesPageContent />
+    </Suspense>
+  )
+}
+
 function SchedulesPageContent() {
   const { devMode } = useDevMode()
   const [selectedWeek, setSelectedWeek] = useState('all')
@@ -160,17 +168,5 @@ function SchedulesPageContent() {
         </>
       )}
     </div>
-  )
-}
-
-export default function SchedulesPage() {
-  return (
-    <Suspense
-      fallback={
-        <div className="container mx-auto px-4 py-6 text-gray-600">Loading…</div>
-      }
-    >
-      <SchedulesPageContent />
-    </Suspense>
   )
 }


### PR DESCRIPTION
## Summary
- Adds a **Dev mode** checkbox in the top nav (right side) backed by `?dev=1` in the URL.
- When dev mode is off (default), hides Tournament Audio, Team Schedules nav links, and per-team week schedule expanders on League Schedules.
- Nav links preserve `dev=1` across in-app navigation so WIP features stay visible while browsing.

## Test plan
- [ ] Load app without `?dev=1` — Tournament Audio and Team Schedules links hidden; no per-team schedule expanders on `/schedules`
- [ ] Enable Dev mode — URL gets `?dev=1`, WIP nav links appear
- [ ] Navigate between pages — `dev=1` persists in URL
- [ ] Select a single week on League Schedules with dev mode on — per-team "View this week's schedule" expanders work
- [ ] Disable Dev mode — param removed and WIP UI hidden again
- [ ] Direct `/tournament` URL still loads without dev param


Made with [Cursor](https://cursor.com)