### PR TITLE
Add Apps menu and parent-domain admin SSO

### DIFF
--- a/.cursor/players-and-auth-runbook.md
+++ b/.cursor/players-and-auth-runbook.md
@@ -8,7 +8,7 @@ Add these to `.env.local` (local) and Vercel project env (Production / Preview):
 # Google admin auth (same allowlist pattern as bdl-merch / open-gym / concessions)
 ADMIN_GOOGLE_CLIENT_ID=
 ADMIN_GOOGLE_CLIENT_SECRET=
-ADMIN_SESSION_SECRET=          # long random string; unique per app is fine
+ADMIN_SESSION_SECRET=          # must match merch + open-gym for cross-app SSO
 ADMIN_ALLOWED_EMAILS=a@x.com,b@y.com   # required when VERCEL_ENV=production
 NEXT_PUBLIC_APP_URL=http://localhost:3000   # no trailing slash; must match the host users hit
 
@@ -17,6 +17,8 @@ DATABASE_URL=postgresql://...
 ```
 
 Copy `ADMIN_ALLOWED_EMAILS` from bdl-merch so the same board members can sign in.
+
+On `*.bostondodgeballleague.com`, `admin_session` is set with `Domain=.bostondodgeballleague.com` so League Admin, Merch, and Open Gym share one login. Localhost stays host-only.
 
 | Environment | Host | Git branch | `NEXT_PUBLIC_APP_URL` |
 |-------------|------|------------|------------------------|

--- a/app/__tests__/admin-auth.test.ts
+++ b/app/__tests__/admin-auth.test.ts
@@ -12,6 +12,7 @@ vi.mock('next/server', () => ({
 
 import {
   createAdminSessionToken,
+  getAdminSessionCookieDomain,
   isAdminAllowlistConfigured,
   isAllowedAdminEmail,
   readAdminSession,
@@ -82,5 +83,15 @@ describe('admin auth session', () => {
     expect(token).toBeTruthy()
     const session = await readAdminSessionEdge(token)
     expect(session?.email).toBe('admin@example.com')
+  })
+
+  it('uses a shared parent cookie domain on league hosts', () => {
+    expect(getAdminSessionCookieDomain('admin.bostondodgeballleague.com')).toBe(
+      '.bostondodgeballleague.com'
+    )
+    expect(getAdminSessionCookieDomain('merch.bostondodgeballleague.com')).toBe(
+      '.bostondodgeballleague.com'
+    )
+    expect(getAdminSessionCookieDomain('localhost')).toBeUndefined()
   })
 })

--- a/app/__tests__/board-apps.test.ts
+++ b/app/__tests__/board-apps.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { getBoardAppLinks, isPreviewBoardHost } from '@/app/lib/board-apps'
+
+describe('board apps menu links', () => {
+  it('detects preview hosts', () => {
+    expect(isPreviewBoardHost('admin-preview.bostondodgeballleague.com')).toBe(true)
+    expect(isPreviewBoardHost('store-preview.bostondodgeballleague.com')).toBe(true)
+    expect(isPreviewBoardHost('open-gym-preview.bostondodgeballleague.com')).toBe(true)
+    expect(isPreviewBoardHost('admin.bostondodgeballleague.com')).toBe(false)
+  })
+
+  it('returns prod sibling apps and excludes the current app', () => {
+    const links = getBoardAppLinks('admin', 'admin.bostondodgeballleague.com')
+    expect(links.map((link) => link.id)).toEqual(['merch', 'open-gym'])
+    expect(links.find((link) => link.id === 'merch')?.href).toBe(
+      'https://merch.bostondodgeballleague.com/admin/dashboard'
+    )
+  })
+
+  it('returns preview sibling apps on preview hosts', () => {
+    const links = getBoardAppLinks('merch', 'store-preview.bostondodgeballleague.com')
+    expect(links.map((link) => link.id)).toEqual(['admin', 'open-gym'])
+    expect(links.find((link) => link.id === 'admin')?.href).toBe(
+      'https://admin-preview.bostondodgeballleague.com'
+    )
+    expect(links.find((link) => link.id === 'open-gym')?.href).toBe(
+      'https://open-gym-preview.bostondodgeballleague.com/admin/dashboard'
+    )
+  })
+})

--- a/app/components/BoardAppsMenu.tsx
+++ b/app/components/BoardAppsMenu.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { getBoardAppLinks, type BoardAppId } from '@/app/lib/board-apps'
+
+type BoardAppsMenuProps = {
+  currentApp: BoardAppId
+  className?: string
+  linkClassName?: string
+  menuClassName?: string
+  buttonClassName?: string
+}
+
+export default function BoardAppsMenu({
+  currentApp,
+  className = '',
+  linkClassName = 'block px-3 py-2 text-sm text-gray-200 hover:bg-gray-700',
+  menuClassName = 'absolute right-0 mt-1 w-48 rounded-md bg-gray-800 py-1 shadow-lg ring-1 ring-gray-600 z-50',
+  buttonClassName = 'hover:underline text-blue-300',
+}: BoardAppsMenuProps) {
+  const [open, setOpen] = useState(false)
+  const [links, setLinks] = useState(() => getBoardAppLinks(currentApp, ''))
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    setLinks(getBoardAppLinks(currentApp, window.location.hostname))
+  }, [currentApp])
+
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (event: MouseEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
+
+  if (links.length === 0) return null
+
+  return (
+    <div ref={rootRef} className={`relative ${className}`}>
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        className={buttonClassName}
+        aria-expanded={open}
+        aria-haspopup="menu"
+      >
+        Apps
+      </button>
+      {open ? (
+        <div className={menuClassName} role="menu">
+          {links.map((app) => (
+            <a
+              key={app.id}
+              href={app.href}
+              className={linkClassName}
+              role="menuitem"
+              onClick={() => setOpen(false)}
+            >
+              {app.label}
+            </a>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/app/components/TopNav.tsx
+++ b/app/components/TopNav.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react'
 import { useDevMode } from '@/app/hooks/useDevMode'
 import { withDevMode } from '@/app/lib/devMode'
 import { fetchAdminSession, logoutAdminSession } from '@/app/lib/admin-client-auth'
+import BoardAppsMenu from '@/app/components/BoardAppsMenu'
 
 export default function TopNav() {
   const pathname = usePathname()
@@ -63,6 +64,7 @@ export default function TopNav() {
         )}
       </div>
       <div className="flex items-center gap-4 text-sm">
+        <BoardAppsMenu currentApp="admin" />
         <label className="flex items-center gap-2 cursor-pointer select-none">
           <span>Dev mode</span>
           <input

--- a/app/lib/admin-auth.ts
+++ b/app/lib/admin-auth.ts
@@ -73,31 +73,73 @@ export function verifyAdminSession(request: NextRequest): boolean {
   return getAdminSessionFromRequest(request) !== null
 }
 
+const SHARED_ADMIN_COOKIE_DOMAIN = '.bostondodgeballleague.com'
+
+function getAppHostname(): string {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL?.trim()
+  if (!appUrl) return ''
+  try {
+    return new URL(appUrl).hostname.toLowerCase()
+  } catch {
+    return ''
+  }
+}
+
+export function getAdminSessionCookieDomain(hostname = getAppHostname()): string | undefined {
+  if (hostname === 'bostondodgeballleague.com' || hostname.endsWith('.bostondodgeballleague.com')) {
+    return SHARED_ADMIN_COOKIE_DOMAIN
+  }
+  return undefined
+}
+
+function adminSessionCookieOptions(maxAge: number) {
+  const domain = getAdminSessionCookieDomain()
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax' as const,
+    path: '/',
+    maxAge,
+    ...(domain ? { domain } : {}),
+  }
+}
+
+/** Next ResponseCookies is keyed by name, so a second same-name set must be appended. */
+function appendClearHostOnlyAdminSessionCookie(response: NextResponse) {
+  const parts = [
+    `${ADMIN_SESSION_COOKIE}=`,
+    'Path=/',
+    'Max-Age=0',
+    'HttpOnly',
+    'SameSite=Lax',
+  ]
+  if (process.env.NODE_ENV === 'production') parts.push('Secure')
+  response.headers.append('Set-Cookie', parts.join('; '))
+}
+
 export function setAdminSessionCookie(response: NextResponse, email: string): boolean {
   const token = createAdminSessionToken(email)
   if (!token) return false
+  const domain = getAdminSessionCookieDomain()
   response.cookies.set({
     name: ADMIN_SESSION_COOKIE,
     value: token,
-    httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
-    sameSite: 'lax',
-    path: '/',
-    maxAge: ADMIN_SESSION_TTL_SECONDS,
+    ...adminSessionCookieOptions(ADMIN_SESSION_TTL_SECONDS),
   })
+  // Drop any leftover host-only cookie when moving to the shared parent domain.
+  if (domain) appendClearHostOnlyAdminSessionCookie(response)
   return true
 }
 
 export function clearAdminSessionCookie(response: NextResponse) {
+  const domain = getAdminSessionCookieDomain()
   response.cookies.set({
     name: ADMIN_SESSION_COOKIE,
     value: '',
-    httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
-    sameSite: 'lax',
-    path: '/',
-    maxAge: 0,
+    ...adminSessionCookieOptions(0),
   })
+  // Also clear a host-only cookie in case a pre-SSO session remains.
+  if (domain) appendClearHostOnlyAdminSessionCookie(response)
 }
 
 export function createOAuthState(): string {

--- a/app/lib/board-apps.ts
+++ b/app/lib/board-apps.ts
@@ -1,0 +1,49 @@
+export type BoardAppId = 'admin' | 'merch' | 'open-gym'
+
+export type BoardAppLink = {
+  id: BoardAppId
+  label: string
+  href: string
+}
+
+const PROD_APPS: Record<BoardAppId, string> = {
+  admin: 'https://admin.bostondodgeballleague.com',
+  merch: 'https://merch.bostondodgeballleague.com/admin/dashboard',
+  'open-gym': 'https://open-gym.bostondodgeballleague.com/admin/dashboard',
+}
+
+const PREVIEW_APPS: Record<BoardAppId, string> = {
+  admin: 'https://admin-preview.bostondodgeballleague.com',
+  merch: 'https://store-preview.bostondodgeballleague.com/admin/dashboard',
+  'open-gym': 'https://open-gym-preview.bostondodgeballleague.com/admin/dashboard',
+}
+
+const APP_LABELS: Record<BoardAppId, string> = {
+  admin: 'League Admin',
+  merch: 'Merch Admin',
+  'open-gym': 'Open Gym Admin',
+}
+
+const ALL_APP_IDS: BoardAppId[] = ['admin', 'merch', 'open-gym']
+
+export function isPreviewBoardHost(hostname: string): boolean {
+  const host = hostname.toLowerCase()
+  return (
+    host.includes('-preview.') ||
+    host.startsWith('store-preview.') ||
+    host === 'store-preview.bostondodgeballleague.com'
+  )
+}
+
+export function getBoardAppLinks(currentApp: BoardAppId, hostname?: string): BoardAppLink[] {
+  const host =
+    hostname ??
+    (typeof window !== 'undefined' ? window.location.hostname : '') ??
+    ''
+  const map = isPreviewBoardHost(host) ? PREVIEW_APPS : PROD_APPS
+  return ALL_APP_IDS.filter((id) => id !== currentApp).map((id) => ({
+    id,
+    label: APP_LABELS[id],
+    href: map[id],
+  }))
+}


### PR DESCRIPTION
## Summary
- Add an Apps menu in TopNav linking to Merch and Open Gym admin (prod/preview URL maps).
- Share `admin_session` on `.bostondodgeballleague.com` so one Google sign-in covers League Admin, Merch, and Open Gym.
- Document that `ADMIN_SESSION_SECRET` must match the sibling apps for SSO.

Two commits: Apps menu (phase 1), then parent-domain cookie SSO (phase 2).

## Test plan
- [ ] Sign in on admin → Apps → Merch / Open Gym lands authenticated after sibling deploys
- [ ] Log out on admin clears the shared session for sibling apps
- [ ] Localhost login still works with a host-only cookie
- [ ] `npm test -- --run app/__tests__/admin-auth.test.ts app/__tests__/board-apps.test.ts`