### PR TITLE
Keep preview admin sessions host-only

### DIFF
--- a/.cursor/players-and-auth-runbook.md
+++ b/.cursor/players-and-auth-runbook.md
@@ -18,7 +18,7 @@ DATABASE_URL=postgresql://...
 
 Copy `ADMIN_ALLOWED_EMAILS` from bdl-merch so the same board members can sign in.
 
-On `*.bostondodgeballleague.com`, `admin_session` is set with `Domain=.bostondodgeballleague.com` so League Admin, Merch, and Open Gym share one login. Localhost stays host-only.
+On production `*.bostondodgeballleague.com` hosts, `admin_session` is set with `Domain=.bostondodgeballleague.com` so League Admin, Merch, and Open Gym share one login. Preview hosts and localhost stay host-only.
 
 | Environment | Host | Git branch | `NEXT_PUBLIC_APP_URL` |
 |-------------|------|------------|------------------------|

--- a/app/__tests__/admin-auth.test.ts
+++ b/app/__tests__/admin-auth.test.ts
@@ -85,13 +85,14 @@ describe('admin auth session', () => {
     expect(session?.email).toBe('admin@example.com')
   })
 
-  it('uses a shared parent cookie domain on league hosts', () => {
+  it('uses a shared parent cookie domain on production league hosts only', () => {
     expect(getAdminSessionCookieDomain('admin.bostondodgeballleague.com')).toBe(
       '.bostondodgeballleague.com'
     )
     expect(getAdminSessionCookieDomain('merch.bostondodgeballleague.com')).toBe(
       '.bostondodgeballleague.com'
     )
+    expect(getAdminSessionCookieDomain('admin-preview.bostondodgeballleague.com')).toBeUndefined()
     expect(getAdminSessionCookieDomain('localhost')).toBeUndefined()
   })
 })

--- a/app/components/BoardAppsMenu.tsx
+++ b/app/components/BoardAppsMenu.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
 import { getBoardAppLinks, type BoardAppId } from '@/app/lib/board-apps'
 
 type BoardAppsMenuProps = {
@@ -11,6 +11,18 @@ type BoardAppsMenuProps = {
   buttonClassName?: string
 }
 
+function subscribeHostname() {
+  return () => {}
+}
+
+function getHostnameSnapshot() {
+  return window.location.hostname
+}
+
+function getHostnameServerSnapshot() {
+  return ''
+}
+
 export default function BoardAppsMenu({
   currentApp,
   className = '',
@@ -19,12 +31,13 @@ export default function BoardAppsMenu({
   buttonClassName = 'hover:underline text-blue-300',
 }: BoardAppsMenuProps) {
   const [open, setOpen] = useState(false)
-  const [links, setLinks] = useState(() => getBoardAppLinks(currentApp, ''))
+  const hostname = useSyncExternalStore(
+    subscribeHostname,
+    getHostnameSnapshot,
+    getHostnameServerSnapshot
+  )
+  const links = getBoardAppLinks(currentApp, hostname)
   const rootRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    setLinks(getBoardAppLinks(currentApp, window.location.hostname))
-  }, [currentApp])
 
   useEffect(() => {
     if (!open) return
@@ -53,18 +66,17 @@ export default function BoardAppsMenu({
         onClick={() => setOpen((value) => !value)}
         className={buttonClassName}
         aria-expanded={open}
-        aria-haspopup="menu"
+        aria-haspopup="true"
       >
         Apps
       </button>
       {open ? (
-        <div className={menuClassName} role="menu">
+        <div className={menuClassName}>
           {links.map((app) => (
             <a
               key={app.id}
               href={app.href}
               className={linkClassName}
-              role="menuitem"
               onClick={() => setOpen(false)}
             >
               {app.label}

--- a/app/lib/admin-auth.ts
+++ b/app/lib/admin-auth.ts
@@ -85,11 +85,21 @@ function getAppHostname(): string {
   }
 }
 
+function isPreviewBoardHost(hostname: string): boolean {
+  return (
+    hostname.includes('-preview.') ||
+    hostname.startsWith('store-preview.') ||
+    hostname === 'store-preview.bostondodgeballleague.com'
+  )
+}
+
 export function getAdminSessionCookieDomain(hostname = getAppHostname()): string | undefined {
-  if (hostname === 'bostondodgeballleague.com' || hostname.endsWith('.bostondodgeballleague.com')) {
-    return SHARED_ADMIN_COOKIE_DOMAIN
+  if (hostname !== 'bostondodgeballleague.com' && !hostname.endsWith('.bostondodgeballleague.com')) {
+    return undefined
   }
-  return undefined
+  // Keep preview host-only so preview/prod never share one parent-domain cookie.
+  if (isPreviewBoardHost(hostname)) return undefined
+  return SHARED_ADMIN_COOKIE_DOMAIN
 }
 
 function adminSessionCookieOptions(maxAge: number) {


### PR DESCRIPTION
## Summary
- Parent-domain `admin_session` is limited to production league hosts so preview/prod cannot clobber each other.
- Apps menu drops incomplete ARIA menu roles and reads hostname via `useSyncExternalStore`.

Follow-up to #68 from the same review feedback applied on merch/open-gym.

## Test plan
- [ ] `npm test -- --run app/__tests__/admin-auth.test.ts app/__tests__/board-apps.test.ts`
- [ ] Prod login still sets `Domain=.bostondodgeballleague.com`
- [ ] Preview login remains host-only