### PR TITLE
Fix players CSV import for TeamLinkt association exports

### DIFF
--- a/app/__tests__/teamlinkt-import.test.ts
+++ b/app/__tests__/teamlinkt-import.test.ts
@@ -34,4 +34,29 @@ describe('teamlinkt csv parse', () => {
     const parsed = parseTeamlinktCsv('Email\na@b.com\n')
     expect(parsed.error).toMatch(/First Name/)
   })
+
+  it('parses association members export and keeps active players only', () => {
+    const csv = [
+      'First Name,Last Name,Player,Coach,Official,Volunteer,Gender,Birthdate,City,Email,Phone,Health Insurance ID,Emergency Contact Name,Emergency Contact Phone,Member Since,Status',
+      'Abby,Lee,Yes,No,No,No,Female,June 5 1993,Boston,lee@example.com,(949) 742-1789,,Bradford Lee,(949) 232-2403,August 24 2025,active',
+      'Skip,Me,No,Yes,No,No,Female,June 5 1993,Boston,coach@example.com,,,,,,active',
+      'Gone,Away,Yes,No,No,No,Female,June 5 1993,Boston,old@example.com,,,,,,inactive',
+    ].join('\n')
+
+    const parsed = parseTeamlinktCsv(csv)
+    expect(parsed.error).toBeUndefined()
+    expect(parsed.rows).toHaveLength(1)
+    expect(parsed.rows[0]).toMatchObject({
+      firstName: 'Abby',
+      lastName: 'Lee',
+      email: 'lee@example.com',
+    })
+  })
+
+  it('strips a UTF-8 BOM from TeamLinkt exports', () => {
+    const csv = '\uFEFFFirst Name,Last Name,Email\nJess,Sartin,jess@example.com\n'
+    const parsed = parseTeamlinktCsv(csv)
+    expect(parsed.error).toBeUndefined()
+    expect(parsed.rows[0].firstName).toBe('Jess')
+  })
 })

--- a/app/api/players/import/route.ts
+++ b/app/api/players/import/route.ts
@@ -8,16 +8,34 @@ import {
   previewTeamlinktImport,
 } from '@/app/lib/players/teamlinkt-import'
 
-export async function POST(request: NextRequest) {
-  const session = getAdminSessionFromRequest(request)
-  if (!session) return adminUnauthorizedResponse()
+export const maxDuration = 60
 
+async function readJsonBody(request: NextRequest): Promise<
+  | { ok: true; body: { csv?: string; filename?: string; dryRun?: boolean } }
+  | { ok: false; error: string }
+> {
   try {
     const body = (await request.json()) as {
       csv?: string
       filename?: string
       dryRun?: boolean
     }
+    return { ok: true, body }
+  } catch {
+    return { ok: false, error: 'Request body must be valid JSON' }
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const parsedBody = await readJsonBody(request)
+    if (!parsedBody.ok) {
+      return NextResponse.json({ error: parsedBody.error }, { status: 400 })
+    }
+    const body = parsedBody.body
 
     if (!body.csv?.trim()) {
       return NextResponse.json({ error: 'csv is required' }, { status: 400 })
@@ -49,7 +67,8 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({ dryRun: false, ...result })
   } catch (err) {
+    console.error('players import failed', err)
     const message = err instanceof Error ? err.message : 'Import failed'
-    return NextResponse.json({ error: message }, { status: 400 })
+    return NextResponse.json({ error: message }, { status: 500 })
   }
 }

--- a/app/lib/players/teamlinkt-import.ts
+++ b/app/lib/players/teamlinkt-import.ts
@@ -1,19 +1,15 @@
 import { eq } from 'drizzle-orm'
 import { getDb } from '@/app/lib/db'
-import { importBatches } from '@/app/db/schema'
+import { importBatches, playerEmails, players } from '@/app/db/schema'
 import {
   createPlayer,
   ensurePlayerAlias,
   ensurePlayerEmail,
   updatePlayer,
 } from '@/app/lib/players/mutations'
-import {
-  findPlayerIdByEmail,
-  findPlayerIdsByName,
-  getPlayerSnapshot,
-} from '@/app/lib/players/queries'
+import { getPlayerSnapshot } from '@/app/lib/players/queries'
 import { defaultRosterName } from '@/app/lib/players/skill'
-import { normalizeEmail, normalizeNamePart } from '@/app/lib/players/normalize'
+import { normalizeEmail, normalizeNamePart, nameKey } from '@/app/lib/players/normalize'
 
 export type TeamlinktRow = {
   rowNumber: number
@@ -74,6 +70,11 @@ function mapHeaders(headers: string[]): {
   return mapped
 }
 
+function truthyFlag(value: string | undefined): boolean {
+  const v = (value ?? '').trim().toLowerCase()
+  return v === 'yes' || v === 'y' || v === 'true' || v === '1'
+}
+
 /** Minimal CSV parser supporting quoted fields. */
 export function parseCsv(text: string): string[][] {
   const rows: string[][] = []
@@ -128,7 +129,9 @@ export function parseTeamlinktCsv(csvText: string): {
   mapping: ReturnType<typeof mapHeaders>
   error?: string
 } {
-  const table = parseCsv(csvText)
+  // Strip BOM if present (common from Excel / TeamLinkt exports)
+  const text = csvText.replace(/^\uFEFF/, '')
+  const table = parseCsv(text)
   if (table.length < 2) {
     return { rows: [], headers: [], mapping: {}, error: 'CSV must include a header row and data' }
   }
@@ -145,6 +148,9 @@ export function parseTeamlinktCsv(csvText: string): {
     }
   }
 
+  const hasPlayerCol = headers.some((h) => normalizeHeader(h) === 'player')
+  const hasStatusCol = headers.some((h) => normalizeHeader(h) === 'status')
+
   const rows: TeamlinktRow[] = []
   for (let i = 1; i < table.length; i++) {
     const cells = table[i]
@@ -152,6 +158,15 @@ export function parseTeamlinktCsv(csvText: string): {
     headers.forEach((h, idx) => {
       raw[h] = (cells[idx] ?? '').trim()
     })
+
+    // Association members export: only import player rows that are active.
+    if (hasPlayerCol && !truthyFlag(raw['Player'] ?? raw['player'])) {
+      continue
+    }
+    if (hasStatusCol) {
+      const status = (raw['Status'] ?? raw['status'] ?? '').trim().toLowerCase()
+      if (status && status !== 'active') continue
+    }
 
     const firstName = normalizeNamePart(cells[mapping.firstName] ?? '')
     const lastName = normalizeNamePart(cells[mapping.lastName] ?? '')
@@ -183,6 +198,73 @@ export function parseTeamlinktCsv(csvText: string): {
   return { rows, headers, mapping }
 }
 
+type MatchIndex = {
+  emailToPlayerId: Map<string, string>
+  nameToPlayerIds: Map<string, string[]>
+  playersById: Map<
+    string,
+    {
+      id: string
+      firstName: string
+      lastName: string
+      rosterName: string
+      jerseyNumber: number | null
+      isMerged: boolean
+      emails: string[]
+    }
+  >
+}
+
+async function loadMatchIndex(): Promise<MatchIndex> {
+  const db = getDb()
+  const [playerRows, emailRows] = await Promise.all([
+    db.select().from(players),
+    db.select().from(playerEmails),
+  ])
+
+  const emailsByPlayer = new Map<string, string[]>()
+  const emailToPlayerId = new Map<string, string>()
+  for (const e of emailRows) {
+    emailToPlayerId.set(e.email, e.playerId)
+    const list = emailsByPlayer.get(e.playerId) ?? []
+    list.push(e.email)
+    emailsByPlayer.set(e.playerId, list)
+  }
+
+  const playersById = new Map<
+    string,
+    {
+      id: string
+      firstName: string
+      lastName: string
+      rosterName: string
+      jerseyNumber: number | null
+      isMerged: boolean
+      emails: string[]
+    }
+  >()
+  const nameToPlayerIds = new Map<string, string[]>()
+
+  for (const p of playerRows) {
+    playersById.set(p.id, {
+      id: p.id,
+      firstName: p.firstName,
+      lastName: p.lastName,
+      rosterName: p.rosterName,
+      jerseyNumber: p.jerseyNumber,
+      isMerged: p.isMerged,
+      emails: emailsByPlayer.get(p.id) ?? [],
+    })
+    if (p.isMerged) continue
+    const key = nameKey(p.firstName, p.lastName)
+    const list = nameToPlayerIds.get(key) ?? []
+    list.push(p.id)
+    nameToPlayerIds.set(key, list)
+  }
+
+  return { emailToPlayerId, nameToPlayerIds, playersById }
+}
+
 export async function previewTeamlinktImport(
   csvText: string
 ): Promise<{
@@ -195,6 +277,7 @@ export async function previewTeamlinktImport(
     return { actions: [], headers: parsed.headers, error: parsed.error }
   }
 
+  const index = await loadMatchIndex()
   const actions: ImportPreviewAction[] = []
 
   for (const row of parsed.rows) {
@@ -209,11 +292,11 @@ export async function previewTeamlinktImport(
 
     let playerId: string | null = null
     if (row.email) {
-      playerId = await findPlayerIdByEmail(row.email)
+      playerId = index.emailToPlayerId.get(row.email) ?? null
     }
 
     if (!playerId) {
-      const byName = await findPlayerIdsByName(row.firstName, row.lastName)
+      const byName = index.nameToPlayerIds.get(nameKey(row.firstName, row.lastName)) ?? []
       if (byName.length > 1) {
         actions.push({
           action: 'ambiguous',
@@ -225,9 +308,8 @@ export async function previewTeamlinktImport(
       }
       if (byName.length === 1) {
         playerId = byName[0]
-        // If matched by name but CSV email would collide with someone else — flag
         if (row.email) {
-          const emailOwner = await findPlayerIdByEmail(row.email)
+          const emailOwner = index.emailToPlayerId.get(row.email)
           if (emailOwner && emailOwner !== playerId) {
             actions.push({
               action: 'ambiguous',
@@ -246,7 +328,7 @@ export async function previewTeamlinktImport(
       continue
     }
 
-    const existing = await getPlayerSnapshot(playerId)
+    const existing = index.playersById.get(playerId)
     const notes: string[] = []
     if (!existing) {
       actions.push({ action: 'create', row })
@@ -264,10 +346,9 @@ export async function previewTeamlinktImport(
     if (row.jerseyNumber != null && existing.jerseyNumber == null) {
       notes.push(`Set jersey #${row.jerseyNumber}`)
     }
-    if (row.email && !existing.emails.some((e) => e.email === row.email)) {
+    if (row.email && !existing.emails.includes(row.email)) {
       notes.push(`Add email ${row.email}`)
     }
-    // Suggest first-name alias when CSV first name differs? skip on name match
     const full = defaultRosterName(row.firstName, row.lastName)
     if (
       full.toLowerCase() !== existing.rosterName.toLowerCase() &&
@@ -338,7 +419,6 @@ export async function commitTeamlinktImport(input: {
         continue
       }
 
-      // update
       const snap = await getPlayerSnapshot(item.playerId)
       if (!snap || snap.isMerged) {
         skipped++
@@ -364,9 +444,7 @@ export async function commitTeamlinktImport(input: {
         })
       }
 
-      if (
-        item.row.firstName.toLowerCase() !== snap.firstName.toLowerCase()
-      ) {
+      if (item.row.firstName.toLowerCase() !== snap.firstName.toLowerCase()) {
         await ensurePlayerAlias(item.playerId, item.row.firstName, {
           actor: input.actor,
           importBatchId: batch.id,

--- a/app/players/page.tsx
+++ b/app/players/page.tsx
@@ -216,6 +216,20 @@ export default function PlayersPage() {
     }
   }
 
+  async function readApiJson(res: Response): Promise<Record<string, unknown>> {
+    const text = await res.text()
+    try {
+      return JSON.parse(text) as Record<string, unknown>
+    } catch {
+      const snippet = text.replace(/\s+/g, ' ').trim().slice(0, 180)
+      throw new Error(
+        snippet
+          ? `Server returned a non-JSON response (${res.status}): ${snippet}`
+          : `Server returned an empty non-JSON response (${res.status})`
+      )
+    }
+  }
+
   async function previewImport() {
     setImportBusy(true)
     setFormError(null)
@@ -225,9 +239,12 @@ export default function PlayersPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ csv: importCsv, filename: importFilename, dryRun: true }),
       })
-      const data = await res.json()
-      if (!res.ok) throw new Error(data.error || 'Preview failed')
-      setImportPreview({ actions: data.actions, summary: data.summary })
+      const data = await readApiJson(res)
+      if (!res.ok) throw new Error(String(data.error || 'Preview failed'))
+      setImportPreview({
+        actions: data.actions as ImportAction[],
+        summary: data.summary as Record<string, number>,
+      })
     } catch (err) {
       setFormError(err instanceof Error ? err.message : 'Preview failed')
     } finally {
@@ -248,14 +265,20 @@ export default function PlayersPage() {
           dryRun: false,
         }),
       })
-      const data = await res.json()
-      if (!res.ok) throw new Error(data.error || 'Import failed')
+      const data = await readApiJson(res)
+      if (!res.ok) throw new Error(String(data.error || 'Import failed'))
+      const summary = data.summary as {
+        created: number
+        updated: number
+        skipped: number
+        ambiguous: number
+      }
       setImportOpen(false)
       setImportCsv('')
       setImportPreview(null)
       await loadPlayers()
       alert(
-        `Import done: ${data.summary.created} created, ${data.summary.updated} updated, ${data.summary.skipped} skipped, ${data.summary.ambiguous} ambiguous`
+        `Import done: ${summary.created} created, ${summary.updated} updated, ${summary.skipped} skipped, ${summary.ambiguous} ambiguous`
       )
     } catch (err) {
       setFormError(err instanceof Error ? err.message : 'Import failed')


### PR DESCRIPTION
## Summary
- Association members exports (~200 rows) were timing out during dry-run because each row hit the DB separately; matching is now batched.
- Association files with `Player` / `Status` columns only import active players.
- Import UI now handles non-JSON error bodies (the confusing `Unexpected token 'A'` message) instead of crashing on `res.json()`.

## Test plan
- [ ] On Players → Import, dry-run `association_members_export_*.csv` from Downloads
- [ ] Confirm preview counts appear without a JSON parse error
- [ ] Commit import and verify players land in the list

Made with [Cursor](https://cursor.com)