### PR TITLE
Fix players UI contrast and import skill from CSV

### DIFF
--- a/.cursor/players-and-auth-runbook.md
+++ b/.cursor/players-and-auth-runbook.md
@@ -68,4 +68,5 @@ Sign in at `/login`. TopNav shows the signed-in email and Log out.
 - UI: `/players`
 - Import TeamLinkt CSV (dry run → commit). Matching: email, then first+last name.
 - Skill levels: 1 Beginner, 2 Intermediate, 3 Advanced, 4 Worlds level (`null` = Unset).
+- Import fills skill when the CSV has a Skill / Skill Level column (`2`/`Intermediate`, `3`/`Advanced`, etc.). Creates get the value; updates only set skill when the existing player is unset.
 - All writes audit to `player_changes` with `actor` = Google email and `source` = `admin` or `import`.

--- a/app/__tests__/teamlinkt-import.test.ts
+++ b/app/__tests__/teamlinkt-import.test.ts
@@ -1,5 +1,19 @@
 import { describe, expect, it } from 'vitest'
 import { parseCsv, parseTeamlinktCsv } from '@/app/lib/players/teamlinkt-import'
+import { parseSkillLevel } from '@/app/lib/players/skill'
+
+describe('parseSkillLevel', () => {
+  it('maps intermediate/advanced and numeric levels', () => {
+    expect(parseSkillLevel('2')).toBe(2)
+    expect(parseSkillLevel('Intermediate')).toBe(2)
+    expect(parseSkillLevel('3')).toBe(3)
+    expect(parseSkillLevel('advanced')).toBe(3)
+    expect(parseSkillLevel('Beginner')).toBe(1)
+    expect(parseSkillLevel('Worlds level')).toBe(4)
+    expect(parseSkillLevel('')).toBeNull()
+    expect(parseSkillLevel('unknown')).toBeNull()
+  })
+})
 
 describe('teamlinkt csv parse', () => {
   it('parses quoted CSV fields', () => {
@@ -25,9 +39,26 @@ describe('teamlinkt csv parse', () => {
       lastName: 'Sartin',
       email: 'jess@example.com',
       jerseyNumber: 7,
+      skillLevel: null,
     })
     expect(parsed.rows[1].email).toBeNull()
     expect(parsed.rows[1].jerseyNumber).toBeNull()
+  })
+
+  it('maps skill level from CSV labels or numbers', () => {
+    const csv = [
+      'First Name,Last Name,Email,Skill Level',
+      'Jess,Sartin,jess@example.com,2',
+      'Alex,Player,alex@example.com,Advanced',
+      'Sam,Beginner,sam@example.com,Intermediate',
+    ].join('\n')
+
+    const parsed = parseTeamlinktCsv(csv)
+    expect(parsed.error).toBeUndefined()
+    expect(parsed.rows).toHaveLength(3)
+    expect(parsed.rows[0].skillLevel).toBe(2)
+    expect(parsed.rows[1].skillLevel).toBe(3)
+    expect(parsed.rows[2].skillLevel).toBe(2)
   })
 
   it('errors when name columns are missing', () => {

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,6 +3,7 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  color-scheme: light;
 }
 
 @theme inline {
@@ -10,13 +11,6 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
 }
 
 body {

--- a/app/lib/players/skill.ts
+++ b/app/lib/players/skill.ts
@@ -7,6 +7,24 @@ export const SKILL_LEVELS = {
 
 export type SkillLevel = keyof typeof SKILL_LEVELS
 
+const SKILL_LABEL_TO_LEVEL: Record<string, SkillLevel> = {
+  '1': 1,
+  beginner: 1,
+  beg: 1,
+  '2': 2,
+  intermediate: 2,
+  intermed: 2,
+  inter: 2,
+  mid: 2,
+  '3': 3,
+  advanced: 3,
+  adv: 3,
+  '4': 4,
+  worlds: 4,
+  'worlds level': 4,
+  world: 4,
+}
+
 export function isValidSkillLevel(value: unknown): value is SkillLevel {
   return value === 1 || value === 2 || value === 3 || value === 4
 }
@@ -15,6 +33,14 @@ export function skillLevelLabel(level: number | null | undefined): string {
   if (level == null) return 'Unset'
   if (isValidSkillLevel(level)) return SKILL_LEVELS[level]
   return 'Unset'
+}
+
+/** Parse TeamLinkt / CSV skill cells (labels or 1–4). */
+export function parseSkillLevel(value: string | null | undefined): SkillLevel | null {
+  if (value == null) return null
+  const normalized = value.trim().toLowerCase().replace(/[_]+/g, ' ').replace(/\s+/g, ' ')
+  if (!normalized) return null
+  return SKILL_LABEL_TO_LEVEL[normalized] ?? null
 }
 
 export function defaultRosterName(firstName: string, lastName: string): string {

--- a/app/lib/players/teamlinkt-import.ts
+++ b/app/lib/players/teamlinkt-import.ts
@@ -8,7 +8,12 @@ import {
   updatePlayer,
 } from '@/app/lib/players/mutations'
 import { getPlayerSnapshot } from '@/app/lib/players/queries'
-import { defaultRosterName } from '@/app/lib/players/skill'
+import {
+  defaultRosterName,
+  parseSkillLevel,
+  skillLevelLabel,
+  type SkillLevel,
+} from '@/app/lib/players/skill'
 import { normalizeEmail, normalizeNamePart, nameKey } from '@/app/lib/players/normalize'
 
 export type TeamlinktRow = {
@@ -17,6 +22,7 @@ export type TeamlinktRow = {
   lastName: string
   email: string | null
   jerseyNumber: number | null
+  skillLevel: SkillLevel | null
   raw: Record<string, string>
 }
 
@@ -39,6 +45,16 @@ const HEADER_ALIASES: Record<string, string[]> = {
     '#',
     'player number',
   ],
+  skillLevel: [
+    'skill',
+    'skill level',
+    'skilllevel',
+    'player skill',
+    'level',
+    'caliber',
+    'ability',
+    'ability level',
+  ],
 }
 
 function normalizeHeader(h: string): string {
@@ -50,12 +66,14 @@ function mapHeaders(headers: string[]): {
   lastName?: number
   email?: number
   jerseyNumber?: number
+  skillLevel?: number
 } {
   const mapped: {
     firstName?: number
     lastName?: number
     email?: number
     jerseyNumber?: number
+    skillLevel?: number
   } = {}
 
   headers.forEach((header, index) => {
@@ -183,6 +201,11 @@ export function parseTeamlinktCsv(csvText: string): {
       }
     }
 
+    let skillLevel: SkillLevel | null = null
+    if (mapping.skillLevel !== undefined) {
+      skillLevel = parseSkillLevel(cells[mapping.skillLevel] ?? '')
+    }
+
     if (!firstName && !lastName && !email) continue
 
     rows.push({
@@ -191,6 +214,7 @@ export function parseTeamlinktCsv(csvText: string): {
       lastName,
       email,
       jerseyNumber,
+      skillLevel,
       raw,
     })
   }
@@ -209,6 +233,7 @@ type MatchIndex = {
       lastName: string
       rosterName: string
       jerseyNumber: number | null
+      skillLevel: number | null
       isMerged: boolean
       emails: string[]
     }
@@ -239,6 +264,7 @@ async function loadMatchIndex(): Promise<MatchIndex> {
       lastName: string
       rosterName: string
       jerseyNumber: number | null
+      skillLevel: number | null
       isMerged: boolean
       emails: string[]
     }
@@ -252,6 +278,7 @@ async function loadMatchIndex(): Promise<MatchIndex> {
       lastName: p.lastName,
       rosterName: p.rosterName,
       jerseyNumber: p.jerseyNumber,
+      skillLevel: p.skillLevel,
       isMerged: p.isMerged,
       emails: emailsByPlayer.get(p.id) ?? [],
     })
@@ -346,6 +373,9 @@ export async function previewTeamlinktImport(
     if (row.jerseyNumber != null && existing.jerseyNumber == null) {
       notes.push(`Set jersey #${row.jerseyNumber}`)
     }
+    if (row.skillLevel != null && existing.skillLevel == null) {
+      notes.push(`Set skill ${skillLevelLabel(row.skillLevel)} (${row.skillLevel})`)
+    }
     if (row.email && !existing.emails.includes(row.email)) {
       notes.push(`Add email ${row.email}`)
     }
@@ -410,6 +440,7 @@ export async function commitTeamlinktImport(input: {
           firstName: item.row.firstName,
           lastName: item.row.lastName,
           jerseyNumber: item.row.jerseyNumber,
+          skillLevel: item.row.skillLevel,
           email: item.row.email,
           actor: input.actor,
           source: 'import',
@@ -425,16 +456,19 @@ export async function commitTeamlinktImport(input: {
         continue
       }
 
+      const patch: { jerseyNumber?: number | null; skillLevel?: number | null } = {}
       if (item.row.jerseyNumber != null && snap.jerseyNumber == null) {
-        await updatePlayer(
-          item.playerId,
-          { jerseyNumber: item.row.jerseyNumber },
-          {
-            actor: input.actor,
-            source: 'import',
-            importBatchId: batch.id,
-          }
-        )
+        patch.jerseyNumber = item.row.jerseyNumber
+      }
+      if (item.row.skillLevel != null && snap.skillLevel == null) {
+        patch.skillLevel = item.row.skillLevel
+      }
+      if (Object.keys(patch).length > 0) {
+        await updatePlayer(item.playerId, patch, {
+          actor: input.actor,
+          source: 'import',
+          importBatchId: batch.id,
+        })
       }
 
       if (item.row.email) {

--- a/app/players/page.tsx
+++ b/app/players/page.tsx
@@ -22,6 +22,7 @@ type ImportAction = {
     lastName: string
     email: string | null
     jerseyNumber: number | null
+    skillLevel: number | null
   }
   notes?: string[]
   reason?: string
@@ -288,7 +289,7 @@ export default function PlayersPage() {
   }
 
   return (
-    <div className="container mx-auto px-4 py-6 space-y-6">
+    <div className="container mx-auto px-4 py-6 space-y-6 text-gray-900">
       <div className="flex flex-wrap items-end justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">Players</h1>
@@ -314,7 +315,7 @@ export default function PlayersPage() {
               setImportPreview(null)
               setFormError(null)
             }}
-            className="rounded border border-gray-300 bg-white px-3 py-2 text-sm hover:bg-gray-50"
+            className="rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800 hover:bg-gray-50"
           >
             Import TeamLinkt CSV
           </button>
@@ -326,7 +327,7 @@ export default function PlayersPage() {
               setSurvivorId([...selectedIds][0] ?? '')
               setFormError(null)
             }}
-            className="rounded border border-gray-300 bg-white px-3 py-2 text-sm hover:bg-gray-50 disabled:opacity-40"
+            className="rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800 hover:bg-gray-50 disabled:opacity-40"
           >
             Merge selected ({selectedIds.size})
           </button>
@@ -334,21 +335,21 @@ export default function PlayersPage() {
       </div>
 
       <div className="flex flex-wrap gap-3 items-end">
-        <label className="text-sm">
+        <label className="text-sm text-gray-900">
           <span className="block text-gray-600 mb-1">Search</span>
           <input
             value={q}
             onChange={(e) => setQ(e.target.value)}
             placeholder="Name, alias, or email"
-            className="rounded border border-gray-300 px-3 py-2 text-sm w-64"
+            className="rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 w-64"
           />
         </label>
-        <label className="text-sm">
+        <label className="text-sm text-gray-900">
           <span className="block text-gray-600 mb-1">Skill</span>
           <select
             value={skillFilter}
             onChange={(e) => setSkillFilter(e.target.value)}
-            className="rounded border border-gray-300 px-3 py-2 text-sm"
+            className="rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900"
           >
             <option value="">All</option>
             <option value="unset">Unset</option>
@@ -359,7 +360,7 @@ export default function PlayersPage() {
             ))}
           </select>
         </label>
-        <label className="flex items-center gap-2 text-sm pb-2">
+        <label className="flex items-center gap-2 text-sm text-gray-900 pb-2">
           <input
             type="checkbox"
             checked={includeMerged}
@@ -370,7 +371,7 @@ export default function PlayersPage() {
         <button
           type="button"
           onClick={() => void loadPlayers()}
-          className="rounded border border-gray-300 bg-white px-3 py-2 text-sm hover:bg-gray-50"
+          className="rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800 hover:bg-gray-50"
         >
           Refresh
         </button>
@@ -380,9 +381,9 @@ export default function PlayersPage() {
       {loading ? <p className="text-sm text-gray-600">Loading players…</p> : null}
 
       {!loading && (
-        <div className="overflow-x-auto border border-gray-200 rounded-lg bg-white">
-          <table className="min-w-full text-sm">
-            <thead className="bg-gray-50 text-left text-gray-600">
+        <div className="overflow-x-auto border border-gray-200 rounded-lg bg-white text-gray-900">
+          <table className="min-w-full text-sm text-gray-900">
+            <thead className="bg-gray-50 text-left text-gray-700">
               <tr>
                 <th className="px-3 py-2 w-10" />
                 <th className="px-3 py-2">First</th>
@@ -394,11 +395,11 @@ export default function PlayersPage() {
                 <th className="px-3 py-2">Actions</th>
               </tr>
             </thead>
-            <tbody>
+            <tbody className="text-gray-900">
               {players.map((p) => (
                 <tr
                   key={p.id}
-                  className={`border-t border-gray-100 ${p.isMerged ? 'bg-gray-50 text-gray-500' : ''}`}
+                  className={`border-t border-gray-100 ${p.isMerged ? 'bg-gray-50 text-gray-500' : 'text-gray-900'}`}
                 >
                   <td className="px-3 py-2">
                     <input
@@ -480,8 +481,8 @@ export default function PlayersPage() {
 
       {mergeOpen ? (
         <div className="fixed inset-0 z-40 bg-black/40 flex items-center justify-center p-4">
-          <div className="bg-white rounded-lg shadow-xl max-w-lg w-full p-6 space-y-4">
-            <h2 className="text-lg font-semibold">Merge players</h2>
+          <div className="bg-white rounded-lg shadow-xl max-w-lg w-full p-6 space-y-4 text-gray-900">
+            <h2 className="text-lg font-semibold text-gray-900">Merge players</h2>
             <p className="text-sm text-gray-600">
               Choose the survivor. Emails and aliases from the others will move onto them;
               the other records will be marked merged.
@@ -524,8 +525,8 @@ export default function PlayersPage() {
 
       {importOpen ? (
         <div className="fixed inset-0 z-40 bg-black/40 flex items-center justify-center p-4">
-          <div className="bg-white rounded-lg shadow-xl max-w-3xl w-full max-h-[90vh] overflow-y-auto p-6 space-y-4">
-            <h2 className="text-lg font-semibold">Import TeamLinkt CSV</h2>
+          <div className="bg-white rounded-lg shadow-xl max-w-3xl w-full max-h-[90vh] overflow-y-auto p-6 space-y-4 text-gray-900">
+            <h2 className="text-lg font-semibold text-gray-900">Import TeamLinkt CSV</h2>
             <label className="block text-sm">
               <span className="text-gray-600">Filename</span>
               <input
@@ -663,9 +664,9 @@ function EditPanel(props: {
 
   return (
     <div className="fixed inset-0 z-40 bg-black/40 flex items-center justify-center p-4">
-      <div className="bg-white rounded-lg shadow-xl max-w-xl w-full max-h-[90vh] overflow-y-auto p-6 space-y-4">
+      <div className="bg-white rounded-lg shadow-xl max-w-xl w-full max-h-[90vh] overflow-y-auto p-6 space-y-4 text-gray-900">
         <div className="flex justify-between items-start gap-4">
-          <h2 className="text-lg font-semibold">Edit player</h2>
+          <h2 className="text-lg font-semibold text-gray-900">Edit player</h2>
           <button type="button" className="text-sm text-gray-500" onClick={props.onClose}>
             Close
           </button>
@@ -883,8 +884,8 @@ function CreatePanel(props: {
 
   return (
     <div className="fixed inset-0 z-40 bg-black/40 flex items-center justify-center p-4">
-      <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-6 space-y-4">
-        <h2 className="text-lg font-semibold">Add player</h2>
+      <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-6 space-y-4 text-gray-900">
+        <h2 className="text-lg font-semibold text-gray-900">Add player</h2>
         <div className="grid grid-cols-2 gap-3">
           <label className="text-sm">
             First name
@@ -973,9 +974,9 @@ function CreatePanel(props: {
 function HistoryPanel(props: { history: HistoryRow[]; onClose: () => void }) {
   return (
     <div className="fixed inset-0 z-40 bg-black/40 flex items-center justify-center p-4">
-      <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto p-6 space-y-4">
+      <div className="bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto p-6 space-y-4 text-gray-900">
         <div className="flex justify-between items-center">
-          <h2 className="text-lg font-semibold">Change history</h2>
+          <h2 className="text-lg font-semibold text-gray-900">Change history</h2>
           <button type="button" className="text-sm text-gray-500" onClick={props.onClose}>
             Close
           </button>


### PR DESCRIPTION
## Summary
- Force light theme in `globals.css` and harden Players page text colors so dark-mode OS settings no longer leave light-gray text on white cards
- Parse TeamLinkt Skill / Skill Level columns on import (`2`/`Intermediate`, `3`/`Advanced`, etc.); set on create and fill only when existing skill is unset

Promoted from preview PR #71.

## Test plan
- [ ] Open `/players` with the OS set to dark mode — table and modals should use dark readable text on white
- [ ] Dry-run import a CSV with a Skill Level column containing `2` and `Advanced`; preview notes should mention setting skill for unset players
- [ ] Commit import and confirm new/updated players get Intermediate (2) / Advanced (3) when previously unset
- [ ] Re-import should not overwrite an already-set skill


Made with [Cursor](https://cursor.com)