### PR TITLE
Add player gender grouping and skill typography cues

### DIFF
--- a/.cursor/players-and-auth-runbook.md
+++ b/.cursor/players-and-auth-runbook.md
@@ -68,5 +68,6 @@ Sign in at `/login`. TopNav shows the signed-in email and Log out.
 - UI: `/players`
 - Import TeamLinkt CSV (dry run → commit). Matching: email, then first+last name.
 - Skill levels: 1 Beginner, 2 Intermediate, 3 Advanced, 4 Worlds level (`null` = Unset).
+- Gender: man / woman / nonbinary / other (imported from TeamLinkt Gender column). List sorts women/nonbinary/other together for drafting. Birthdate from TeamLinkt is not stored or shown.
 - Import fills skill when the CSV has a Skill / Skill Level column (`2`/`Intermediate`, `3`/`Advanced`, etc.). Creates get the value; updates only set skill when the existing player is unset.
 - All writes audit to `player_changes` with `actor` = Google email and `source` = `admin` or `import`.

--- a/app/__tests__/teamlinkt-import.test.ts
+++ b/app/__tests__/teamlinkt-import.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { parseCsv, parseTeamlinktCsv } from '@/app/lib/players/teamlinkt-import'
 import { parseSkillLevel } from '@/app/lib/players/skill'
+import { genderGroup, parseGender } from '@/app/lib/players/gender'
 
 describe('parseSkillLevel', () => {
   it('maps intermediate/advanced and numeric levels', () => {
@@ -12,6 +13,25 @@ describe('parseSkillLevel', () => {
     expect(parseSkillLevel('Worlds level')).toBe(4)
     expect(parseSkillLevel('')).toBeNull()
     expect(parseSkillLevel('unknown')).toBeNull()
+  })
+})
+
+describe('parseGender', () => {
+  it('maps TeamLinkt gender labels', () => {
+    expect(parseGender('Female')).toBe('woman')
+    expect(parseGender('Male')).toBe('man')
+    expect(parseGender('Other')).toBe('other')
+    expect(parseGender('Cisgender Woman')).toBe('woman')
+    expect(parseGender('Non-binary')).toBe('nonbinary')
+    expect(parseGender('')).toBeNull()
+  })
+
+  it('groups woman/nonbinary/other together', () => {
+    expect(genderGroup('woman')).toBe('w_nb_o')
+    expect(genderGroup('nonbinary')).toBe('w_nb_o')
+    expect(genderGroup('other')).toBe('w_nb_o')
+    expect(genderGroup('man')).toBe('men')
+    expect(genderGroup(null)).toBe('unset')
   })
 })
 
@@ -40,6 +60,7 @@ describe('teamlinkt csv parse', () => {
       email: 'jess@example.com',
       jerseyNumber: 7,
       skillLevel: null,
+      gender: null,
     })
     expect(parsed.rows[1].email).toBeNull()
     expect(parsed.rows[1].jerseyNumber).toBeNull()
@@ -81,7 +102,10 @@ describe('teamlinkt csv parse', () => {
       firstName: 'Abby',
       lastName: 'Lee',
       email: 'lee@example.com',
+      gender: 'woman',
     })
+    // Birthdate is in raw CSV but not mapped onto the player row
+    expect(parsed.rows[0]).not.toHaveProperty('birthdate')
   })
 
   it('strips a UTF-8 BOM from TeamLinkt exports', () => {

--- a/app/api/players/[id]/route.ts
+++ b/app/api/players/[id]/route.ts
@@ -44,6 +44,7 @@ export async function PATCH(request: NextRequest, context: Ctx) {
       rosterName?: string
       jerseyNumber?: number | null
       skillLevel?: number | null
+      gender?: string | null
       addEmail?: string
       removeEmailId?: string
       setPrimaryEmailId?: string
@@ -61,7 +62,8 @@ export async function PATCH(request: NextRequest, context: Ctx) {
       body.lastName !== undefined ||
       body.rosterName !== undefined ||
       body.jerseyNumber !== undefined ||
-      body.skillLevel !== undefined
+      body.skillLevel !== undefined ||
+      body.gender !== undefined
 
     if (hasCorePatch) {
       player = await updatePlayer(
@@ -72,6 +74,7 @@ export async function PATCH(request: NextRequest, context: Ctx) {
           rosterName: body.rosterName,
           jerseyNumber: body.jerseyNumber,
           skillLevel: body.skillLevel,
+          gender: body.gender,
         },
         { actor: session.email, source: 'admin' }
       )

--- a/app/api/players/route.ts
+++ b/app/api/players/route.ts
@@ -6,6 +6,7 @@ import {
 import { listPlayers } from '@/app/lib/players/queries'
 import { createPlayer } from '@/app/lib/players/mutations'
 import { isValidSkillLevel } from '@/app/lib/players/skill'
+import { isValidGender } from '@/app/lib/players/gender'
 
 export async function GET(request: NextRequest) {
   const session = getAdminSessionFromRequest(request)
@@ -43,6 +44,7 @@ export async function POST(request: NextRequest) {
       rosterName?: string
       jerseyNumber?: number | null
       skillLevel?: number | null
+      gender?: string | null
       email?: string | null
     }
 
@@ -53,12 +55,17 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    if (body.gender != null && body.gender !== '' && !isValidGender(body.gender)) {
+      return NextResponse.json({ error: 'Invalid gender' }, { status: 400 })
+    }
+
     const player = await createPlayer({
       firstName: body.firstName,
       lastName: body.lastName,
       rosterName: body.rosterName,
       jerseyNumber: body.jerseyNumber ?? null,
       skillLevel: body.skillLevel ?? null,
+      gender: body.gender || null,
       email: body.email,
       actor: session.email,
       source: 'admin',

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -19,6 +19,8 @@ export const players = pgTable(
     rosterName: text('roster_name').notNull(),
     jerseyNumber: integer('jersey_number'),
     skillLevel: integer('skill_level'),
+    /** Canonical: man | woman | nonbinary | other */
+    gender: text('gender'),
     isMerged: boolean('is_merged').notNull().default(false),
     mergedIntoPlayerId: uuid('merged_into_player_id'),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),

--- a/app/lib/players/gender.ts
+++ b/app/lib/players/gender.ts
@@ -1,0 +1,81 @@
+export const GENDERS = {
+  man: 'Man',
+  woman: 'Woman',
+  nonbinary: 'Nonbinary',
+  other: 'Other',
+} as const
+
+export type Gender = keyof typeof GENDERS
+
+/** Drafting / roster balance: woman + nonbinary + other count together. */
+export type GenderGroup = 'w_nb_o' | 'men' | 'unset'
+
+const GENDER_ALIASES: Record<string, Gender> = {
+  man: 'man',
+  male: 'man',
+  m: 'man',
+  'cisgender man': 'man',
+  cisgender_man: 'man',
+  'cis man': 'man',
+  cis_man: 'man',
+  woman: 'woman',
+  female: 'woman',
+  f: 'woman',
+  w: 'woman',
+  'cisgender woman': 'woman',
+  cisgender_woman: 'woman',
+  'cis woman': 'woman',
+  cis_woman: 'woman',
+  nonbinary: 'nonbinary',
+  'non binary': 'nonbinary',
+  nb: 'nonbinary',
+  enby: 'nonbinary',
+  genderqueer: 'nonbinary',
+  other: 'other',
+  'prefer not to say': 'other',
+  prefer_not_to_say: 'other',
+  unspecified: 'other',
+}
+
+export function isValidGender(value: unknown): value is Gender {
+  return value === 'man' || value === 'woman' || value === 'nonbinary' || value === 'other'
+}
+
+export function genderLabel(gender: string | null | undefined): string {
+  if (gender == null) return '—'
+  if (isValidGender(gender)) return GENDERS[gender]
+  return '—'
+}
+
+export function genderGroup(gender: string | null | undefined): GenderGroup {
+  if (gender === 'woman' || gender === 'nonbinary' || gender === 'other') return 'w_nb_o'
+  if (gender === 'man') return 'men'
+  return 'unset'
+}
+
+export function genderGroupLabel(gender: string | null | undefined): string {
+  const group = genderGroup(gender)
+  if (group === 'w_nb_o') return 'W/NB/O'
+  if (group === 'men') return 'M'
+  return '—'
+}
+
+/** Sort key: W/NB/O first, then men, then unset. */
+export function genderGroupSortKey(gender: string | null | undefined): number {
+  const group = genderGroup(gender)
+  if (group === 'w_nb_o') return 0
+  if (group === 'men') return 1
+  return 2
+}
+
+export function parseGender(value: string | null | undefined): Gender | null {
+  if (value == null) return null
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+  if (!normalized) return null
+  const underscored = normalized.replace(/\s+/g, '_')
+  return GENDER_ALIASES[normalized] ?? GENDER_ALIASES[underscored] ?? null
+}

--- a/app/lib/players/merge.ts
+++ b/app/lib/players/merge.ts
@@ -7,6 +7,7 @@ import {
   snapshotToJson,
 } from '@/app/lib/players/queries'
 import { isValidSkillLevel } from '@/app/lib/players/skill'
+import { isValidGender } from '@/app/lib/players/gender'
 import { normalizeNamePart } from '@/app/lib/players/normalize'
 
 export type MergeFieldResolution = {
@@ -15,6 +16,7 @@ export type MergeFieldResolution = {
   rosterName?: string
   jerseyNumber?: number | null
   skillLevel?: number | null
+  gender?: string | null
 }
 
 export async function mergePlayers(input: {
@@ -49,10 +51,12 @@ export async function mergePlayers(input: {
   let rosterName = survivorBefore.rosterName
   let jerseyNumber = survivorBefore.jerseyNumber
   let skillLevel = survivorBefore.skillLevel
+  let gender = survivorBefore.gender
 
   for (const loser of loserSnapshots) {
     if (jerseyNumber == null && loser.jerseyNumber != null) jerseyNumber = loser.jerseyNumber
     if (skillLevel == null && loser.skillLevel != null) skillLevel = loser.skillLevel
+    if (gender == null && loser.gender != null) gender = loser.gender
   }
 
   if (input.fields?.firstName !== undefined) {
@@ -73,6 +77,12 @@ export async function mergePlayers(input: {
     }
     skillLevel = input.fields.skillLevel
   }
+  if (input.fields?.gender !== undefined) {
+    if (input.fields.gender !== null && !isValidGender(input.fields.gender)) {
+      throw new Error('Invalid gender')
+    }
+    gender = input.fields.gender
+  }
 
   await db
     .update(players)
@@ -82,6 +92,7 @@ export async function mergePlayers(input: {
       rosterName,
       jerseyNumber,
       skillLevel,
+      gender,
       updatedAt: new Date(),
     })
     .where(eq(players.id, survivorId))

--- a/app/lib/players/mutations.ts
+++ b/app/lib/players/mutations.ts
@@ -3,6 +3,7 @@ import { getDb } from '@/app/lib/db'
 import { playerAliases, playerEmails, players } from '@/app/db/schema'
 import { writePlayerChange } from '@/app/lib/players/audit'
 import { defaultRosterName, isValidSkillLevel } from '@/app/lib/players/skill'
+import { isValidGender } from '@/app/lib/players/gender'
 import {
   getPlayerSnapshot,
   snapshotToJson,
@@ -16,6 +17,7 @@ export async function createPlayer(input: {
   rosterName?: string
   jerseyNumber?: number | null
   skillLevel?: number | null
+  gender?: string | null
   email?: string | null
   actor: string
   source?: ChangeSource
@@ -38,6 +40,12 @@ export async function createPlayer(input: {
     skillLevel = input.skillLevel
   }
 
+  let gender: string | null = null
+  if (input.gender != null) {
+    if (!isValidGender(input.gender)) throw new Error('Invalid gender')
+    gender = input.gender
+  }
+
   const [created] = await db
     .insert(players)
     .values({
@@ -46,6 +54,7 @@ export async function createPlayer(input: {
       rosterName,
       jerseyNumber: input.jerseyNumber ?? null,
       skillLevel,
+      gender,
     })
     .returning()
 
@@ -80,6 +89,7 @@ export async function updatePlayer(
     rosterName?: string
     jerseyNumber?: number | null
     skillLevel?: number | null
+    gender?: string | null
   },
   opts: { actor: string; source?: ChangeSource; importBatchId?: string | null }
 ) {
@@ -115,6 +125,12 @@ export async function updatePlayer(
       throw new Error('Invalid skill level')
     }
     updates.skillLevel = patch.skillLevel
+  }
+  if (patch.gender !== undefined) {
+    if (patch.gender !== null && !isValidGender(patch.gender)) {
+      throw new Error('Invalid gender')
+    }
+    updates.gender = patch.gender
   }
 
   await db.update(players).set(updates).where(eq(players.id, playerId))

--- a/app/lib/players/queries.ts
+++ b/app/lib/players/queries.ts
@@ -7,6 +7,7 @@ import {
   players,
 } from '@/app/db/schema'
 import { skillLevelLabel } from '@/app/lib/players/skill'
+import { genderGroupLabel, genderGroupSortKey, genderLabel } from '@/app/lib/players/gender'
 import type { PlayerListItem, PlayerSnapshot } from '@/app/lib/players/types'
 
 export async function listPlayers(opts: {
@@ -75,7 +76,7 @@ export async function listPlayers(opts: {
     }
   }
 
-  return rows.map((r) => ({
+  const items: PlayerListItem[] = rows.map((r) => ({
     id: r.id,
     firstName: r.firstName,
     lastName: r.lastName,
@@ -83,9 +84,23 @@ export async function listPlayers(opts: {
     jerseyNumber: r.jerseyNumber,
     skillLevel: r.skillLevel,
     skillLabel: skillLevelLabel(r.skillLevel),
+    gender: r.gender,
+    genderLabel: genderLabel(r.gender),
+    genderGroupLabel: genderGroupLabel(r.gender),
     primaryEmail: primaryByPlayer.get(r.id) ?? null,
     isMerged: r.isMerged,
   }))
+
+  // W/NB/O together, then men, then unset — name order within each group
+  items.sort((a, b) => {
+    const g = genderGroupSortKey(a.gender) - genderGroupSortKey(b.gender)
+    if (g !== 0) return g
+    const last = a.lastName.localeCompare(b.lastName, undefined, { sensitivity: 'base' })
+    if (last !== 0) return last
+    return a.firstName.localeCompare(b.firstName, undefined, { sensitivity: 'base' })
+  })
+
+  return items
 }
 
 export async function getPlayerSnapshot(playerId: string): Promise<PlayerSnapshot | null> {
@@ -112,6 +127,7 @@ export async function getPlayerSnapshot(playerId: string): Promise<PlayerSnapsho
     rosterName: player.rosterName,
     jerseyNumber: player.jerseyNumber,
     skillLevel: player.skillLevel,
+    gender: player.gender,
     isMerged: player.isMerged,
     mergedIntoPlayerId: player.mergedIntoPlayerId,
     emails: emails.map((e) => ({ id: e.id, email: e.email, isPrimary: e.isPrimary })),
@@ -127,6 +143,7 @@ export function snapshotToJson(snapshot: PlayerSnapshot): Record<string, unknown
     rosterName: snapshot.rosterName,
     jerseyNumber: snapshot.jerseyNumber,
     skillLevel: snapshot.skillLevel,
+    gender: snapshot.gender,
     isMerged: snapshot.isMerged,
     mergedIntoPlayerId: snapshot.mergedIntoPlayerId,
     emails: snapshot.emails,

--- a/app/lib/players/teamlinkt-import.ts
+++ b/app/lib/players/teamlinkt-import.ts
@@ -14,6 +14,7 @@ import {
   skillLevelLabel,
   type SkillLevel,
 } from '@/app/lib/players/skill'
+import { genderLabel, parseGender, type Gender } from '@/app/lib/players/gender'
 import { normalizeEmail, normalizeNamePart, nameKey } from '@/app/lib/players/normalize'
 
 export type TeamlinktRow = {
@@ -23,6 +24,7 @@ export type TeamlinktRow = {
   email: string | null
   jerseyNumber: number | null
   skillLevel: SkillLevel | null
+  gender: Gender | null
   raw: Record<string, string>
 }
 
@@ -55,6 +57,7 @@ const HEADER_ALIASES: Record<string, string[]> = {
     'ability',
     'ability level',
   ],
+  gender: ['gender', 'sex', 'player gender'],
 }
 
 function normalizeHeader(h: string): string {
@@ -67,6 +70,7 @@ function mapHeaders(headers: string[]): {
   email?: number
   jerseyNumber?: number
   skillLevel?: number
+  gender?: number
 } {
   const mapped: {
     firstName?: number
@@ -74,6 +78,7 @@ function mapHeaders(headers: string[]): {
     email?: number
     jerseyNumber?: number
     skillLevel?: number
+    gender?: number
   } = {}
 
   headers.forEach((header, index) => {
@@ -206,6 +211,11 @@ export function parseTeamlinktCsv(csvText: string): {
       skillLevel = parseSkillLevel(cells[mapping.skillLevel] ?? '')
     }
 
+    let gender: Gender | null = null
+    if (mapping.gender !== undefined) {
+      gender = parseGender(cells[mapping.gender] ?? '')
+    }
+
     if (!firstName && !lastName && !email) continue
 
     rows.push({
@@ -215,6 +225,7 @@ export function parseTeamlinktCsv(csvText: string): {
       email,
       jerseyNumber,
       skillLevel,
+      gender,
       raw,
     })
   }
@@ -234,6 +245,7 @@ type MatchIndex = {
       rosterName: string
       jerseyNumber: number | null
       skillLevel: number | null
+      gender: string | null
       isMerged: boolean
       emails: string[]
     }
@@ -265,6 +277,7 @@ async function loadMatchIndex(): Promise<MatchIndex> {
       rosterName: string
       jerseyNumber: number | null
       skillLevel: number | null
+      gender: string | null
       isMerged: boolean
       emails: string[]
     }
@@ -279,6 +292,7 @@ async function loadMatchIndex(): Promise<MatchIndex> {
       rosterName: p.rosterName,
       jerseyNumber: p.jerseyNumber,
       skillLevel: p.skillLevel,
+      gender: p.gender,
       isMerged: p.isMerged,
       emails: emailsByPlayer.get(p.id) ?? [],
     })
@@ -376,6 +390,9 @@ export async function previewTeamlinktImport(
     if (row.skillLevel != null && existing.skillLevel == null) {
       notes.push(`Set skill ${skillLevelLabel(row.skillLevel)} (${row.skillLevel})`)
     }
+    if (row.gender != null && existing.gender == null) {
+      notes.push(`Set gender ${genderLabel(row.gender)}`)
+    }
     if (row.email && !existing.emails.includes(row.email)) {
       notes.push(`Add email ${row.email}`)
     }
@@ -441,6 +458,7 @@ export async function commitTeamlinktImport(input: {
           lastName: item.row.lastName,
           jerseyNumber: item.row.jerseyNumber,
           skillLevel: item.row.skillLevel,
+          gender: item.row.gender,
           email: item.row.email,
           actor: input.actor,
           source: 'import',
@@ -456,12 +474,19 @@ export async function commitTeamlinktImport(input: {
         continue
       }
 
-      const patch: { jerseyNumber?: number | null; skillLevel?: number | null } = {}
+      const patch: {
+        jerseyNumber?: number | null
+        skillLevel?: number | null
+        gender?: string | null
+      } = {}
       if (item.row.jerseyNumber != null && snap.jerseyNumber == null) {
         patch.jerseyNumber = item.row.jerseyNumber
       }
       if (item.row.skillLevel != null && snap.skillLevel == null) {
         patch.skillLevel = item.row.skillLevel
+      }
+      if (item.row.gender != null && snap.gender == null) {
+        patch.gender = item.row.gender
       }
       if (Object.keys(patch).length > 0) {
         await updatePlayer(item.playerId, patch, {

--- a/app/lib/players/types.ts
+++ b/app/lib/players/types.ts
@@ -8,6 +8,7 @@ export type PlayerSnapshot = {
   rosterName: string
   jerseyNumber: number | null
   skillLevel: number | null
+  gender: string | null
   isMerged: boolean
   mergedIntoPlayerId: string | null
   emails: { id: string; email: string; isPrimary: boolean }[]
@@ -22,6 +23,9 @@ export type PlayerListItem = {
   jerseyNumber: number | null
   skillLevel: number | null
   skillLabel: string
+  gender: string | null
+  genderLabel: string
+  genderGroupLabel: string
   primaryEmail: string | null
   isMerged: boolean
 }

--- a/app/players/page.tsx
+++ b/app/players/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
 import { SKILL_LEVELS, skillLevelLabel } from '@/app/lib/players/skill'
+import { GENDERS, genderGroup } from '@/app/lib/players/gender'
 import type { PlayerListItem, PlayerSnapshot } from '@/app/lib/players/types'
 
 type HistoryRow = {
@@ -33,6 +34,32 @@ function parseJerseyNumber(value: string): number | null {
   if (!value.trim()) return null
   const n = Number.parseInt(value, 10)
   return Number.isNaN(n) ? null : n
+}
+
+/** Skill cues: beginner italic+parens, intermediate normal, advanced bold, worlds bold+underline. */
+function SkillStyledText(props: {
+  skillLevel: number | null
+  children: ReactNode
+}) {
+  const { skillLevel, children } = props
+  if (skillLevel === 1) {
+    return <span className="italic">({children})</span>
+  }
+  if (skillLevel === 3) {
+    return <span className="font-bold">{children}</span>
+  }
+  if (skillLevel === 4) {
+    return <span className="font-bold underline">{children}</span>
+  }
+  return <span>{children}</span>
+}
+
+function genderRowClass(gender: string | null, isMerged: boolean): string {
+  if (isMerged) return 'bg-gray-50 text-gray-500'
+  const group = genderGroup(gender)
+  if (group === 'w_nb_o') return 'bg-rose-50/70 text-gray-900'
+  if (group === 'men') return 'text-gray-900'
+  return 'text-gray-900'
 }
 
 export default function PlayersPage() {
@@ -170,6 +197,7 @@ export default function PlayersPage() {
     rosterName?: string
     jerseyNumber?: number | null
     skillLevel?: number | null
+    gender?: string | null
     email?: string
   }) {
     setSaving(true)
@@ -294,7 +322,7 @@ export default function PlayersPage() {
         <div>
           <h1 className="text-2xl font-bold text-gray-900">Players</h1>
           <p className="text-sm text-gray-600 mt-1">
-            Roster names, jersey numbers, skill levels, aliases, and emails.
+            Roster names, jersey numbers, skill levels, gender, aliases, and emails.
           </p>
         </div>
         <div className="flex flex-wrap gap-2">
@@ -390,6 +418,7 @@ export default function PlayersPage() {
                 <th className="px-3 py-2">Last</th>
                 <th className="px-3 py-2">Roster name</th>
                 <th className="px-3 py-2">Jersey</th>
+                <th className="px-3 py-2">Gender</th>
                 <th className="px-3 py-2">Skill</th>
                 <th className="px-3 py-2">Email</th>
                 <th className="px-3 py-2">Actions</th>
@@ -399,7 +428,7 @@ export default function PlayersPage() {
               {players.map((p) => (
                 <tr
                   key={p.id}
-                  className={`border-t border-gray-100 ${p.isMerged ? 'bg-gray-50 text-gray-500' : 'text-gray-900'}`}
+                  className={`border-t border-gray-100 ${genderRowClass(p.gender, p.isMerged)}`}
                 >
                   <td className="px-3 py-2">
                     <input
@@ -409,11 +438,41 @@ export default function PlayersPage() {
                       onChange={() => toggleSelect(p.id)}
                     />
                   </td>
-                  <td className="px-3 py-2">{p.firstName}</td>
-                  <td className="px-3 py-2">{p.lastName}</td>
-                  <td className="px-3 py-2">{p.rosterName}</td>
+                  <td className="px-3 py-2">
+                    <SkillStyledText skillLevel={p.skillLevel}>{p.firstName}</SkillStyledText>
+                  </td>
+                  <td className="px-3 py-2">
+                    <SkillStyledText skillLevel={p.skillLevel}>{p.lastName}</SkillStyledText>
+                  </td>
+                  <td className="px-3 py-2">
+                    <SkillStyledText skillLevel={p.skillLevel}>{p.rosterName}</SkillStyledText>
+                  </td>
                   <td className="px-3 py-2">{p.jerseyNumber ?? '—'}</td>
-                  <td className="px-3 py-2">{p.skillLabel}</td>
+                  <td className="px-3 py-2">
+                    <span
+                      className={
+                        genderGroup(p.gender) === 'w_nb_o'
+                          ? 'font-medium text-rose-800'
+                          : genderGroup(p.gender) === 'men'
+                            ? 'text-sky-900'
+                            : 'text-gray-500'
+                      }
+                    >
+                      {genderGroup(p.gender) === 'w_nb_o' ? (
+                        <>
+                          W/NB/O
+                          <span className="ml-1 font-normal text-gray-600">
+                            ({p.genderLabel})
+                          </span>
+                        </>
+                      ) : (
+                        p.genderLabel
+                      )}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2">
+                    <SkillStyledText skillLevel={p.skillLevel}>{p.skillLabel}</SkillStyledText>
+                  </td>
                   <td className="px-3 py-2">{p.primaryEmail ?? '—'}</td>
                   <td className="px-3 py-2 space-x-2 whitespace-nowrap">
                     <button
@@ -435,7 +494,7 @@ export default function PlayersPage() {
               ))}
               {players.length === 0 ? (
                 <tr>
-                  <td colSpan={8} className="px-3 py-8 text-center text-gray-500">
+                  <td colSpan={9} className="px-3 py-8 text-center text-gray-500">
                     No players yet. Import a TeamLinkt CSV or add one manually.
                   </td>
                 </tr>
@@ -651,6 +710,7 @@ function EditPanel(props: {
   const [skillLevel, setSkillLevel] = useState(
     p.skillLevel != null ? String(p.skillLevel) : ''
   )
+  const [gender, setGender] = useState(p.gender ?? '')
   const [newEmail, setNewEmail] = useState('')
   const [newAlias, setNewAlias] = useState('')
 
@@ -660,6 +720,7 @@ function EditPanel(props: {
     setRosterName(p.rosterName)
     setJerseyNumber(p.jerseyNumber != null ? String(p.jerseyNumber) : '')
     setSkillLevel(p.skillLevel != null ? String(p.skillLevel) : '')
+    setGender(p.gender ?? '')
   }, [p])
 
   return (
@@ -731,6 +792,22 @@ function EditPanel(props: {
               ))}
             </select>
           </label>
+          <label className="text-sm">
+            Gender
+            <select
+              className="mt-1 w-full rounded border px-3 py-2"
+              value={gender}
+              disabled={p.isMerged}
+              onChange={(e) => setGender(e.target.value)}
+            >
+              <option value="">Unset</option>
+              {Object.entries(GENDERS).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
         </div>
 
         {!p.isMerged ? (
@@ -745,6 +822,7 @@ function EditPanel(props: {
                 rosterName,
                 jerseyNumber: parseJerseyNumber(jerseyNumber),
                 skillLevel: skillLevel ? Number(skillLevel) : null,
+                gender: gender || null,
               })
             }
           >
@@ -872,6 +950,7 @@ function CreatePanel(props: {
     rosterName?: string
     jerseyNumber?: number | null
     skillLevel?: number | null
+    gender?: string | null
     email?: string
   }) => void
 }) {
@@ -880,6 +959,7 @@ function CreatePanel(props: {
   const [rosterName, setRosterName] = useState('')
   const [jerseyNumber, setJerseyNumber] = useState('')
   const [skillLevel, setSkillLevel] = useState('')
+  const [gender, setGender] = useState('')
   const [email, setEmail] = useState('')
 
   return (
@@ -934,6 +1014,21 @@ function CreatePanel(props: {
               ))}
             </select>
           </label>
+          <label className="text-sm">
+            Gender
+            <select
+              className="mt-1 w-full rounded border px-3 py-2"
+              value={gender}
+              onChange={(e) => setGender(e.target.value)}
+            >
+              <option value="">Unset</option>
+              {Object.entries(GENDERS).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
           <label className="text-sm col-span-2">
             Email
             <input
@@ -959,6 +1054,7 @@ function CreatePanel(props: {
                 rosterName: rosterName.trim() || undefined,
                 jerseyNumber: parseJerseyNumber(jerseyNumber),
                 skillLevel: skillLevel ? Number(skillLevel) : null,
+                gender: gender || null,
                 email: email.trim() || undefined,
               })
             }

--- a/drizzle/0001_player_gender.sql
+++ b/drizzle/0001_player_gender.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "players" ADD COLUMN IF NOT EXISTS "gender" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1752528000000,
       "tag": "0000_players",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1752614400000,
+      "tag": "0001_player_gender",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Store and import player gender from TeamLinkt; list sorts women/nonbinary/other together for drafting
- Style roster names by skill (beginner italic/parens, advanced bold, worlds bold+underline)
- Do not store or display birthdate from association exports

## Test plan
- [ ] Run `npm run db:push` (or migrate) so `players.gender` exists
- [ ] Import association members CSV → gender populates; birthdate never shown
- [ ] Confirm W/NB/O rows group first with rose tint; men after
- [ ] Confirm skill typography on names/skill label for levels 1–4
- [ ] Edit/create player gender from the UI and verify list updates


Made with [Cursor](https://cursor.com)