### PR TITLE
Polish players UI: nickname, jersey, import, and unmerge

### DIFF
--- a/app/__tests__/teamlinkt-import.test.ts
+++ b/app/__tests__/teamlinkt-import.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it } from 'vitest'
-import { parseCsv, parseTeamlinktCsv } from '@/app/lib/players/teamlinkt-import'
-import { parseSkillLevel } from '@/app/lib/players/skill'
+import {
+  parseCsv,
+  parseTeamlinktCsv,
+  shouldApplyProfileField,
+} from '@/app/lib/players/teamlinkt-import'
+import {
+  defaultJerseyName,
+  defaultNickname,
+  normalizeStoredJerseyName,
+  normalizeStoredNickname,
+  parseSkillLevel,
+  resolveJerseyName,
+  resolveNickname,
+} from '@/app/lib/players/skill'
 import { genderGroup, parseGender } from '@/app/lib/players/gender'
 
 describe('parseSkillLevel', () => {
@@ -13,6 +25,31 @@ describe('parseSkillLevel', () => {
     expect(parseSkillLevel('Worlds level')).toBe(4)
     expect(parseSkillLevel('')).toBeNull()
     expect(parseSkillLevel('unknown')).toBeNull()
+  })
+})
+
+describe('nickname defaults', () => {
+  it('builds first name + last initial', () => {
+    expect(defaultNickname('Jess', 'Sartin')).toBe('Jess S')
+    expect(defaultNickname('alex', 'player')).toBe('alex P')
+  })
+
+  it('uses custom nickname until cleared back to default', () => {
+    expect(resolveNickname(null, 'Jess', 'Sartin')).toBe('Jess S')
+    expect(resolveNickname('JC', 'Jess', 'Sartin')).toBe('JC')
+    expect(normalizeStoredNickname('Jess S', 'Jess', 'Sartin')).toBeNull()
+    expect(normalizeStoredNickname('JC', 'Jess', 'Sartin')).toBe('JC')
+    expect(normalizeStoredNickname('', 'Jess', 'Sartin')).toBeNull()
+  })
+})
+
+describe('jersey name defaults', () => {
+  it('defaults to last name and stores custom overrides', () => {
+    expect(defaultJerseyName('Sartin')).toBe('Sartin')
+    expect(resolveJerseyName(null, 'Sartin')).toBe('Sartin')
+    expect(resolveJerseyName('Jet', 'Sartin')).toBe('Jet')
+    expect(normalizeStoredJerseyName('Sartin', 'Sartin')).toBeNull()
+    expect(normalizeStoredJerseyName('Jet', 'Sartin')).toBe('Jet')
   })
 })
 
@@ -32,6 +69,25 @@ describe('parseGender', () => {
     expect(genderGroup('other')).toBe('w_nb_o')
     expect(genderGroup('man')).toBe('men')
     expect(genderGroup(null)).toBe('unset')
+  })
+})
+
+describe('shouldApplyProfileField', () => {
+  it('skips profile fields by default mode', () => {
+    expect(shouldApplyProfileField(3, null, 'skip')).toBe(false)
+    expect(shouldApplyProfileField(3, 2, 'skip')).toBe(false)
+  })
+
+  it('fill_blank only applies when existing is unset', () => {
+    expect(shouldApplyProfileField(3, null, 'fill_blank')).toBe(true)
+    expect(shouldApplyProfileField(3, 2, 'fill_blank')).toBe(false)
+    expect(shouldApplyProfileField(null, null, 'fill_blank')).toBe(false)
+  })
+
+  it('overwrite replaces differing existing values', () => {
+    expect(shouldApplyProfileField(3, null, 'overwrite')).toBe(true)
+    expect(shouldApplyProfileField(3, 2, 'overwrite')).toBe(true)
+    expect(shouldApplyProfileField(3, 3, 'overwrite')).toBe(false)
   })
 })
 

--- a/app/api/admin/session/route.ts
+++ b/app/api/admin/session/route.ts
@@ -1,12 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import {
-  ADMIN_SESSION_COOKIE,
   adminUnauthorizedResponse,
-  readAdminSession,
+  getAdminSessionFromRequest,
 } from '@/app/lib/admin-auth'
 
 export async function GET(request: NextRequest) {
-  const session = readAdminSession(request.cookies.get(ADMIN_SESSION_COOKIE)?.value)
+  const session = getAdminSessionFromRequest(request)
   if (!session) {
     return adminUnauthorizedResponse()
   }

--- a/app/api/players/[id]/route.ts
+++ b/app/api/players/[id]/route.ts
@@ -42,7 +42,9 @@ export async function PATCH(request: NextRequest, context: Ctx) {
       firstName?: string
       lastName?: string
       rosterName?: string
+      nickname?: string | null
       jerseyNumber?: number | null
+      jerseyName?: string | null
       skillLevel?: number | null
       gender?: string | null
       addEmail?: string
@@ -61,7 +63,9 @@ export async function PATCH(request: NextRequest, context: Ctx) {
       body.firstName !== undefined ||
       body.lastName !== undefined ||
       body.rosterName !== undefined ||
+      body.nickname !== undefined ||
       body.jerseyNumber !== undefined ||
+      body.jerseyName !== undefined ||
       body.skillLevel !== undefined ||
       body.gender !== undefined
 
@@ -72,7 +76,9 @@ export async function PATCH(request: NextRequest, context: Ctx) {
           firstName: body.firstName,
           lastName: body.lastName,
           rosterName: body.rosterName,
+          nickname: body.nickname,
           jerseyNumber: body.jerseyNumber,
+          jerseyName: body.jerseyName,
           skillLevel: body.skillLevel,
           gender: body.gender,
         },

--- a/app/api/players/import/route.ts
+++ b/app/api/players/import/route.ts
@@ -6,12 +6,26 @@ import {
 import {
   commitTeamlinktImport,
   previewTeamlinktImport,
+  type ImportProfileFieldsMode,
 } from '@/app/lib/players/teamlinkt-import'
 
 export const maxDuration = 60
 
+function parseProfileFieldsMode(value: unknown): ImportProfileFieldsMode {
+  if (value === 'fill_blank' || value === 'overwrite' || value === 'skip') return value
+  return 'skip'
+}
+
 async function readJsonBody(request: NextRequest): Promise<
-  | { ok: true; body: { csv?: string; filename?: string; dryRun?: boolean } }
+  | {
+      ok: true
+      body: {
+        csv?: string
+        filename?: string
+        dryRun?: boolean
+        profileFields?: ImportProfileFieldsMode
+      }
+    }
   | { ok: false; error: string }
 > {
   try {
@@ -19,6 +33,7 @@ async function readJsonBody(request: NextRequest): Promise<
       csv?: string
       filename?: string
       dryRun?: boolean
+      profileFields?: ImportProfileFieldsMode
     }
     return { ok: true, body }
   } catch {
@@ -36,13 +51,14 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: parsedBody.error }, { status: 400 })
     }
     const body = parsedBody.body
+    const options = { profileFields: parseProfileFieldsMode(body.profileFields) }
 
     if (!body.csv?.trim()) {
       return NextResponse.json({ error: 'csv is required' }, { status: 400 })
     }
 
     if (body.dryRun !== false) {
-      const preview = await previewTeamlinktImport(body.csv)
+      const preview = await previewTeamlinktImport(body.csv, options)
       if (preview.error) {
         return NextResponse.json({ error: preview.error }, { status: 400 })
       }
@@ -50,6 +66,7 @@ export async function POST(request: NextRequest) {
         dryRun: true,
         headers: preview.headers,
         actions: preview.actions,
+        options,
         summary: {
           create: preview.actions.filter((a) => a.action === 'create').length,
           update: preview.actions.filter((a) => a.action === 'update').length,
@@ -63,6 +80,7 @@ export async function POST(request: NextRequest) {
       csvText: body.csv,
       filename: body.filename?.trim() || 'teamlinkt.csv',
       actor: session.email,
+      options,
     })
 
     return NextResponse.json({ dryRun: false, ...result })

--- a/app/api/players/route.ts
+++ b/app/api/players/route.ts
@@ -42,7 +42,9 @@ export async function POST(request: NextRequest) {
       firstName?: string
       lastName?: string
       rosterName?: string
+      nickname?: string | null
       jerseyNumber?: number | null
+      jerseyName?: string | null
       skillLevel?: number | null
       gender?: string | null
       email?: string | null
@@ -63,7 +65,9 @@ export async function POST(request: NextRequest) {
       firstName: body.firstName,
       lastName: body.lastName,
       rosterName: body.rosterName,
+      nickname: body.nickname,
       jerseyNumber: body.jerseyNumber ?? null,
+      jerseyName: body.jerseyName,
       skillLevel: body.skillLevel ?? null,
       gender: body.gender || null,
       email: body.email,

--- a/app/api/players/unmerge/route.ts
+++ b/app/api/players/unmerge/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import { unmergePlayer } from '@/app/lib/players/merge'
+
+export async function POST(request: NextRequest) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const body = (await request.json()) as { playerId?: string }
+
+    if (!body.playerId?.trim()) {
+      return NextResponse.json({ error: 'playerId is required' }, { status: 400 })
+    }
+
+    const result = await unmergePlayer({
+      playerId: body.playerId.trim(),
+      actor: session.email,
+    })
+
+    return NextResponse.json(result)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unmerge failed'
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+}

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -17,7 +17,11 @@ export const players = pgTable(
     firstName: text('first_name').notNull(),
     lastName: text('last_name').notNull(),
     rosterName: text('roster_name').notNull(),
+    /** Null = default to first name + last initial until manually set. */
+    nickname: text('nickname'),
     jerseyNumber: integer('jersey_number'),
+    /** Null = default to last name until manually set. */
+    jerseyName: text('jersey_name'),
     skillLevel: integer('skill_level'),
     /** Canonical: man | woman | nonbinary | other */
     gender: text('gender'),

--- a/app/lib/admin-auth.ts
+++ b/app/lib/admin-auth.ts
@@ -11,6 +11,15 @@ export type AdminSessionPayload = {
   exp: number
 }
 
+/** Local `next dev` only — never active when NODE_ENV is production. */
+export function getDevBypassAdminSession(): AdminSessionPayload | null {
+  if (process.env.NODE_ENV !== 'development') return null
+  return {
+    email: process.env.ADMIN_DEV_EMAIL?.trim().toLowerCase() || 'dev@localhost',
+    exp: Math.floor(Date.now() / 1000) + ADMIN_SESSION_TTL_SECONDS,
+  }
+}
+
 function getAdminSessionSecret(): string | null {
   const secret = process.env.ADMIN_SESSION_SECRET?.trim()
   return secret ? secret : null
@@ -66,7 +75,10 @@ export function readAdminSession(token: string | null | undefined): AdminSession
 }
 
 export function getAdminSessionFromRequest(request: NextRequest): AdminSessionPayload | null {
-  return readAdminSession(request.cookies.get(ADMIN_SESSION_COOKIE)?.value)
+  return (
+    getDevBypassAdminSession() ??
+    readAdminSession(request.cookies.get(ADMIN_SESSION_COOKIE)?.value)
+  )
 }
 
 export function verifyAdminSession(request: NextRequest): boolean {

--- a/app/lib/admin-session-edge.ts
+++ b/app/lib/admin-session-edge.ts
@@ -10,6 +10,15 @@ export type AdminSessionPayload = {
   exp: number
 }
 
+/** Local `next dev` only — never active when NODE_ENV is production. */
+function getDevBypassAdminSession(): AdminSessionPayload | null {
+  if (process.env.NODE_ENV !== 'development') return null
+  return {
+    email: process.env.ADMIN_DEV_EMAIL?.trim().toLowerCase() || 'dev@localhost',
+    exp: Math.floor(Date.now() / 1000) + 60 * 60 * 12,
+  }
+}
+
 function adminEmailAllowlist(): Set<string> | null {
   const allowed = process.env.ADMIN_ALLOWED_EMAILS?.trim()
   if (!allowed) {
@@ -45,6 +54,9 @@ function safeEqual(a: string, b: string): boolean {
 export async function readAdminSessionEdge(
   token: string | null | undefined
 ): Promise<AdminSessionPayload | null> {
+  const bypass = getDevBypassAdminSession()
+  if (bypass) return bypass
+
   if (!token) return null
   const [encodedPayload, signature] = token.split('.')
   if (!encodedPayload || !signature) return null

--- a/app/lib/players/merge.ts
+++ b/app/lib/players/merge.ts
@@ -1,20 +1,26 @@
-import { eq, inArray } from 'drizzle-orm'
+import { and, desc, eq, inArray } from 'drizzle-orm'
 import { getDb } from '@/app/lib/db'
-import { playerAliases, playerEmails, players } from '@/app/db/schema'
+import { playerAliases, playerChanges, playerEmails, players } from '@/app/db/schema'
 import { writePlayerChange } from '@/app/lib/players/audit'
 import {
   getPlayerSnapshot,
   snapshotToJson,
 } from '@/app/lib/players/queries'
-import { isValidSkillLevel } from '@/app/lib/players/skill'
+import {
+  isValidSkillLevel,
+  normalizeStoredJerseyName,
+  normalizeStoredNickname,
+} from '@/app/lib/players/skill'
 import { isValidGender } from '@/app/lib/players/gender'
-import { normalizeNamePart } from '@/app/lib/players/normalize'
+import { normalizeEmail, normalizeNamePart } from '@/app/lib/players/normalize'
 
 export type MergeFieldResolution = {
   firstName?: string
   lastName?: string
   rosterName?: string
+  nickname?: string | null
   jerseyNumber?: number | null
+  jerseyName?: string | null
   skillLevel?: number | null
   gender?: string | null
 }
@@ -49,7 +55,9 @@ export async function mergePlayers(input: {
   let firstName = survivorBefore.firstName
   let lastName = survivorBefore.lastName
   let rosterName = survivorBefore.rosterName
+  let nicknameCustom = survivorBefore.nicknameCustom
   let jerseyNumber = survivorBefore.jerseyNumber
+  let jerseyNameCustom = survivorBefore.jerseyNameCustom
   let skillLevel = survivorBefore.skillLevel
   let gender = survivorBefore.gender
 
@@ -57,6 +65,12 @@ export async function mergePlayers(input: {
     if (jerseyNumber == null && loser.jerseyNumber != null) jerseyNumber = loser.jerseyNumber
     if (skillLevel == null && loser.skillLevel != null) skillLevel = loser.skillLevel
     if (gender == null && loser.gender != null) gender = loser.gender
+    if (nicknameCustom == null && loser.nicknameCustom != null) {
+      nicknameCustom = loser.nicknameCustom
+    }
+    if (jerseyNameCustom == null && loser.jerseyNameCustom != null) {
+      jerseyNameCustom = loser.jerseyNameCustom
+    }
   }
 
   if (input.fields?.firstName !== undefined) {
@@ -83,6 +97,17 @@ export async function mergePlayers(input: {
     }
     gender = input.fields.gender
   }
+  if (input.fields?.nickname !== undefined) {
+    nicknameCustom = normalizeStoredNickname(input.fields.nickname, firstName, lastName)
+  } else if (nicknameCustom != null) {
+    // Re-normalize against resolved names (may clear back to default).
+    nicknameCustom = normalizeStoredNickname(nicknameCustom, firstName, lastName)
+  }
+  if (input.fields?.jerseyName !== undefined) {
+    jerseyNameCustom = normalizeStoredJerseyName(input.fields.jerseyName, lastName)
+  } else if (jerseyNameCustom != null) {
+    jerseyNameCustom = normalizeStoredJerseyName(jerseyNameCustom, lastName)
+  }
 
   await db
     .update(players)
@@ -90,7 +115,9 @@ export async function mergePlayers(input: {
       firstName,
       lastName,
       rosterName,
+      nickname: nicknameCustom,
       jerseyNumber,
+      jerseyName: jerseyNameCustom,
       skillLevel,
       gender,
       updatedAt: new Date(),
@@ -203,5 +230,223 @@ export async function mergePlayers(input: {
   return {
     survivor: survivorAfter,
     mergedIds: loserIds,
+  }
+}
+
+type SnapshotEmail = { id?: string; email: string; isPrimary?: boolean }
+type SnapshotAlias = { id?: string; alias: string }
+
+function readMergeBefore(before: Record<string, unknown> | null | undefined): {
+  emails: SnapshotEmail[]
+  aliases: SnapshotAlias[]
+  firstName: string | null
+} {
+  const emailsRaw = before?.emails
+  const aliasesRaw = before?.aliases
+  const emails: SnapshotEmail[] = []
+  if (Array.isArray(emailsRaw)) {
+    for (const item of emailsRaw) {
+      if (!item || typeof item !== 'object') continue
+      const email = (item as { email?: unknown }).email
+      if (typeof email !== 'string' || !email.trim()) continue
+      emails.push({
+        email: normalizeEmail(email),
+        isPrimary: Boolean((item as { isPrimary?: unknown }).isPrimary),
+      })
+    }
+  }
+  const aliases: SnapshotAlias[] = []
+  if (Array.isArray(aliasesRaw)) {
+    for (const item of aliasesRaw) {
+      if (!item || typeof item !== 'object') continue
+      const alias = (item as { alias?: unknown }).alias
+      if (typeof alias !== 'string' || !alias.trim()) continue
+      aliases.push({ alias: alias.trim() })
+    }
+  }
+  const firstName =
+    typeof before?.firstName === 'string' ? before.firstName.trim() : null
+  return { emails, aliases, firstName }
+}
+
+/**
+ * Reverse a soft-merge: reactivate the merged player and move emails/aliases
+ * that still live on the survivor back using the merge audit snapshot.
+ * Does not undo core-field fills (jersey/skill/gender) on the survivor.
+ */
+export async function unmergePlayer(input: { playerId: string; actor: string }) {
+  const playerId = input.playerId
+  const before = await getPlayerSnapshot(playerId)
+  if (!before) throw new Error('Player not found')
+  if (!before.isMerged) throw new Error('Player is not merged')
+  const survivorId = before.mergedIntoPlayerId
+  if (!survivorId) throw new Error('Merged player is missing survivor reference')
+
+  const survivorBefore = await getPlayerSnapshot(survivorId)
+  if (!survivorBefore) throw new Error('Survivor player not found')
+
+  const db = getDb()
+  const [mergeEvent] = await db
+    .select()
+    .from(playerChanges)
+    .where(and(eq(playerChanges.playerId, playerId), eq(playerChanges.changeType, 'merge')))
+    .orderBy(desc(playerChanges.createdAt))
+    .limit(1)
+
+  const mergeBefore = readMergeBefore(mergeEvent?.before ?? null)
+
+  // Find the survivor's merge audit for this pair so we know which emails/aliases
+  // they already owned (duplicates deleted on merge — leave those on survivor).
+  const survivorMergeEvents = await db
+    .select()
+    .from(playerChanges)
+    .where(
+      and(eq(playerChanges.playerId, survivorId), eq(playerChanges.changeType, 'merge'))
+    )
+    .orderBy(desc(playerChanges.createdAt))
+
+  const survivorMergeEvent =
+    survivorMergeEvents.find((event) => {
+      const mergedFrom = (event.after as { mergedFrom?: unknown } | null)?.mergedFrom
+      return Array.isArray(mergedFrom) && mergedFrom.includes(playerId)
+    }) ?? null
+  const survivorOwnedBefore = readMergeBefore(survivorMergeEvent?.before ?? null)
+  const survivorHadEmail = new Set(survivorOwnedBefore.emails.map((e) => e.email))
+  const survivorHadAlias = new Set(
+    survivorOwnedBefore.aliases.map((a) => a.alias.toLowerCase())
+  )
+  const canDetectSurvivorOwned = survivorMergeEvent != null
+
+  await db
+    .update(players)
+    .set({
+      isMerged: false,
+      mergedIntoPlayerId: null,
+      updatedAt: new Date(),
+    })
+    .where(eq(players.id, playerId))
+
+  // Restore emails that were moved from this player onto the survivor.
+  // If the survivor already had the address at merge time, leave it there.
+  for (const email of mergeBefore.emails) {
+    if (canDetectSurvivorOwned && survivorHadEmail.has(email.email)) continue
+
+    const [existing] = await db
+      .select()
+      .from(playerEmails)
+      .where(eq(playerEmails.email, email.email))
+      .limit(1)
+
+    if (!existing) {
+      await db.insert(playerEmails).values({
+        playerId,
+        email: email.email,
+        isPrimary: Boolean(email.isPrimary),
+      })
+      continue
+    }
+
+    if (existing.playerId === playerId) continue
+
+    // Without the survivor merge audit we can't tell move vs duplicate — leave it.
+    if (existing.playerId === survivorId && canDetectSurvivorOwned) {
+      await db
+        .update(playerEmails)
+        .set({ playerId, isPrimary: Boolean(email.isPrimary) })
+        .where(eq(playerEmails.id, existing.id))
+    }
+  }
+
+  // Ensure both sides have a primary when they have emails
+  for (const id of [playerId, survivorId]) {
+    const emails = await db.select().from(playerEmails).where(eq(playerEmails.playerId, id))
+    if (emails.length === 0) continue
+    if (emails.some((e) => e.isPrimary)) continue
+    await db
+      .update(playerEmails)
+      .set({ isPrimary: true })
+      .where(eq(playerEmails.id, emails[0].id))
+  }
+
+  // Restore aliases that were moved (skip ones the survivor already had).
+  for (const alias of mergeBefore.aliases) {
+    if (canDetectSurvivorOwned && survivorHadAlias.has(alias.alias.toLowerCase())) {
+      continue
+    }
+
+    const [onSurvivor] = await db
+      .select()
+      .from(playerAliases)
+      .where(
+        and(
+          eq(playerAliases.playerId, survivorId),
+          eq(playerAliases.alias, alias.alias)
+        )
+      )
+      .limit(1)
+    if (onSurvivor && canDetectSurvivorOwned) {
+      await db
+        .update(playerAliases)
+        .set({ playerId })
+        .where(eq(playerAliases.id, onSurvivor.id))
+      continue
+    }
+
+    const [already] = await db
+      .select()
+      .from(playerAliases)
+      .where(and(eq(playerAliases.playerId, playerId), eq(playerAliases.alias, alias.alias)))
+      .limit(1)
+    if (!already) {
+      await db.insert(playerAliases).values({ playerId, alias: alias.alias })
+    }
+  }
+
+  // Drop first-name alias that merge may have added onto the survivor
+  if (
+    mergeBefore.firstName &&
+    survivorBefore.firstName.toLowerCase() !== mergeBefore.firstName.toLowerCase() &&
+    !survivorHadAlias.has(mergeBefore.firstName.toLowerCase())
+  ) {
+    await db
+      .delete(playerAliases)
+      .where(
+        and(
+          eq(playerAliases.playerId, survivorId),
+          eq(playerAliases.alias, mergeBefore.firstName)
+        )
+      )
+  }
+
+  const playerAfter = await getPlayerSnapshot(playerId)
+  const survivorAfter = await getPlayerSnapshot(survivorId)
+
+  await writePlayerChange({
+    playerId,
+    source: 'admin',
+    actor: input.actor,
+    changeType: 'unmerge',
+    before: snapshotToJson(before),
+    after: {
+      ...(playerAfter ? snapshotToJson(playerAfter) : {}),
+      unmergedFrom: survivorId,
+    },
+  })
+
+  await writePlayerChange({
+    playerId: survivorId,
+    source: 'admin',
+    actor: input.actor,
+    changeType: 'unmerge',
+    before: snapshotToJson(survivorBefore),
+    after: {
+      ...(survivorAfter ? snapshotToJson(survivorAfter) : {}),
+      unmergedPlayerId: playerId,
+    },
+  })
+
+  return {
+    player: playerAfter,
+    survivor: survivorAfter,
   }
 }

--- a/app/lib/players/mutations.ts
+++ b/app/lib/players/mutations.ts
@@ -2,7 +2,12 @@ import { and, eq } from 'drizzle-orm'
 import { getDb } from '@/app/lib/db'
 import { playerAliases, playerEmails, players } from '@/app/db/schema'
 import { writePlayerChange } from '@/app/lib/players/audit'
-import { defaultRosterName, isValidSkillLevel } from '@/app/lib/players/skill'
+import {
+  defaultRosterName,
+  isValidSkillLevel,
+  normalizeStoredJerseyName,
+  normalizeStoredNickname,
+} from '@/app/lib/players/skill'
 import { isValidGender } from '@/app/lib/players/gender'
 import {
   getPlayerSnapshot,
@@ -15,7 +20,9 @@ export async function createPlayer(input: {
   firstName: string
   lastName: string
   rosterName?: string
+  nickname?: string | null
   jerseyNumber?: number | null
+  jerseyName?: string | null
   skillLevel?: number | null
   gender?: string | null
   email?: string | null
@@ -33,6 +40,14 @@ export async function createPlayer(input: {
   const rosterName = input.rosterName?.trim()
     ? normalizeNamePart(input.rosterName)
     : defaultRosterName(firstName, lastName)
+  const nickname =
+    input.nickname !== undefined
+      ? normalizeStoredNickname(input.nickname, firstName, lastName)
+      : null
+  const jerseyName =
+    input.jerseyName !== undefined
+      ? normalizeStoredJerseyName(input.jerseyName, lastName)
+      : null
 
   let skillLevel: number | null = null
   if (input.skillLevel != null) {
@@ -52,7 +67,9 @@ export async function createPlayer(input: {
       firstName,
       lastName,
       rosterName,
+      nickname,
       jerseyNumber: input.jerseyNumber ?? null,
+      jerseyName,
       skillLevel,
       gender,
     })
@@ -87,7 +104,9 @@ export async function updatePlayer(
     firstName?: string
     lastName?: string
     rosterName?: string
+    nickname?: string | null
     jerseyNumber?: number | null
+    jerseyName?: string | null
     skillLevel?: number | null
     gender?: string | null
   },
@@ -131,6 +150,15 @@ export async function updatePlayer(
       throw new Error('Invalid gender')
     }
     updates.gender = patch.gender
+  }
+
+  const nextFirst = updates.firstName ?? before.firstName
+  const nextLast = updates.lastName ?? before.lastName
+  if (patch.nickname !== undefined) {
+    updates.nickname = normalizeStoredNickname(patch.nickname, nextFirst, nextLast)
+  }
+  if (patch.jerseyName !== undefined) {
+    updates.jerseyName = normalizeStoredJerseyName(patch.jerseyName, nextLast)
   }
 
   await db.update(players).set(updates).where(eq(players.id, playerId))

--- a/app/lib/players/queries.ts
+++ b/app/lib/players/queries.ts
@@ -6,8 +6,12 @@ import {
   playerEmails,
   players,
 } from '@/app/db/schema'
-import { skillLevelLabel } from '@/app/lib/players/skill'
-import { genderGroupLabel, genderGroupSortKey, genderLabel } from '@/app/lib/players/gender'
+import {
+  resolveJerseyName,
+  resolveNickname,
+  skillLevelLabel,
+} from '@/app/lib/players/skill'
+import { genderGroupLabel, genderLabel } from '@/app/lib/players/gender'
 import type { PlayerListItem, PlayerSnapshot } from '@/app/lib/players/types'
 
 export async function listPlayers(opts: {
@@ -44,6 +48,8 @@ export async function listPlayers(opts: {
         ilike(players.firstName, term),
         ilike(players.lastName, term),
         ilike(players.rosterName, term),
+        ilike(players.nickname, term),
+        ilike(players.jerseyName, term),
         inArray(players.id, matchingEmailIds),
         inArray(players.id, matchingAliasIds)
       )
@@ -76,12 +82,14 @@ export async function listPlayers(opts: {
     }
   }
 
-  const items: PlayerListItem[] = rows.map((r) => ({
+  return rows.map((r) => ({
     id: r.id,
     firstName: r.firstName,
     lastName: r.lastName,
     rosterName: r.rosterName,
+    nickname: resolveNickname(r.nickname, r.firstName, r.lastName),
     jerseyNumber: r.jerseyNumber,
+    jerseyName: resolveJerseyName(r.jerseyName, r.lastName),
     skillLevel: r.skillLevel,
     skillLabel: skillLevelLabel(r.skillLevel),
     gender: r.gender,
@@ -90,17 +98,6 @@ export async function listPlayers(opts: {
     primaryEmail: primaryByPlayer.get(r.id) ?? null,
     isMerged: r.isMerged,
   }))
-
-  // W/NB/O together, then men, then unset — name order within each group
-  items.sort((a, b) => {
-    const g = genderGroupSortKey(a.gender) - genderGroupSortKey(b.gender)
-    if (g !== 0) return g
-    const last = a.lastName.localeCompare(b.lastName, undefined, { sensitivity: 'base' })
-    if (last !== 0) return last
-    return a.firstName.localeCompare(b.firstName, undefined, { sensitivity: 'base' })
-  })
-
-  return items
 }
 
 export async function getPlayerSnapshot(playerId: string): Promise<PlayerSnapshot | null> {
@@ -120,12 +117,19 @@ export async function getPlayerSnapshot(playerId: string): Promise<PlayerSnapsho
     .where(eq(playerAliases.playerId, playerId))
     .orderBy(asc(playerAliases.alias))
 
+  const nicknameCustom = player.nickname?.trim() ? player.nickname.trim() : null
+  const jerseyNameCustom = player.jerseyName?.trim() ? player.jerseyName.trim() : null
+
   return {
     id: player.id,
     firstName: player.firstName,
     lastName: player.lastName,
     rosterName: player.rosterName,
+    nickname: resolveNickname(nicknameCustom, player.firstName, player.lastName),
+    nicknameCustom,
     jerseyNumber: player.jerseyNumber,
+    jerseyName: resolveJerseyName(jerseyNameCustom, player.lastName),
+    jerseyNameCustom,
     skillLevel: player.skillLevel,
     gender: player.gender,
     isMerged: player.isMerged,
@@ -141,7 +145,11 @@ export function snapshotToJson(snapshot: PlayerSnapshot): Record<string, unknown
     firstName: snapshot.firstName,
     lastName: snapshot.lastName,
     rosterName: snapshot.rosterName,
+    nickname: snapshot.nickname,
+    nicknameCustom: snapshot.nicknameCustom,
     jerseyNumber: snapshot.jerseyNumber,
+    jerseyName: snapshot.jerseyName,
+    jerseyNameCustom: snapshot.jerseyNameCustom,
     skillLevel: snapshot.skillLevel,
     gender: snapshot.gender,
     isMerged: snapshot.isMerged,

--- a/app/lib/players/skill.ts
+++ b/app/lib/players/skill.ts
@@ -46,3 +46,66 @@ export function parseSkillLevel(value: string | null | undefined): SkillLevel | 
 export function defaultRosterName(firstName: string, lastName: string): string {
   return `${firstName.trim()} ${lastName.trim()}`.trim()
 }
+
+/** Default nickname: first name + last initial (e.g. "Jess S"). */
+export function defaultNickname(firstName: string, lastName: string): string {
+  const first = firstName.trim()
+  const last = lastName.trim()
+  if (!first) return last ? last.charAt(0).toUpperCase() : ''
+  if (!last) return first
+  return `${first} ${last.charAt(0).toUpperCase()}`
+}
+
+/** Effective nickname: stored custom value, or first + last initial. */
+export function resolveNickname(
+  nickname: string | null | undefined,
+  firstName: string,
+  lastName: string
+): string {
+  const custom = nickname?.trim()
+  if (custom) return custom
+  return defaultNickname(firstName, lastName)
+}
+
+/**
+ * Persist null when empty or equal to the default so nickname tracks name changes
+ * until someone sets a custom value.
+ */
+export function normalizeStoredNickname(
+  nickname: string | null | undefined,
+  firstName: string,
+  lastName: string
+): string | null {
+  const trimmed = nickname?.trim() ?? ''
+  if (!trimmed) return null
+  if (trimmed.toLowerCase() === defaultNickname(firstName, lastName).toLowerCase()) {
+    return null
+  }
+  return trimmed
+}
+
+/** Default jersey name: last name. */
+export function defaultJerseyName(lastName: string): string {
+  return lastName.trim()
+}
+
+export function resolveJerseyName(
+  jerseyName: string | null | undefined,
+  lastName: string
+): string {
+  const custom = jerseyName?.trim()
+  if (custom) return custom
+  return defaultJerseyName(lastName)
+}
+
+export function normalizeStoredJerseyName(
+  jerseyName: string | null | undefined,
+  lastName: string
+): string | null {
+  const trimmed = jerseyName?.trim() ?? ''
+  if (!trimmed) return null
+  if (trimmed.toLowerCase() === defaultJerseyName(lastName).toLowerCase()) {
+    return null
+  }
+  return trimmed
+}

--- a/app/lib/players/teamlinkt-import.ts
+++ b/app/lib/players/teamlinkt-import.ts
@@ -34,6 +34,36 @@ export type ImportPreviewAction =
   | { action: 'skip'; row: TeamlinktRow; reason: string }
   | { action: 'ambiguous'; row: TeamlinktRow; reason: string; playerIds: string[] }
 
+/**
+ * How TeamLinkt updates skill / gender / jersey on existing players.
+ * - skip (default): never change those fields; new players still get CSV values
+ * - fill_blank: only set a field when the player currently has it unset
+ * - overwrite: replace existing values when the CSV differs
+ */
+export type ImportProfileFieldsMode = 'skip' | 'fill_blank' | 'overwrite'
+
+export type TeamlinktImportOptions = {
+  profileFields?: ImportProfileFieldsMode
+}
+
+function resolveProfileFieldsMode(
+  options?: TeamlinktImportOptions
+): ImportProfileFieldsMode {
+  return options?.profileFields ?? 'skip'
+}
+
+export function shouldApplyProfileField(
+  csvValue: string | number | null,
+  existingValue: string | number | null,
+  mode: ImportProfileFieldsMode
+): boolean {
+  if (csvValue == null) return false
+  if (mode === 'skip') return false
+  if (existingValue == null) return mode === 'fill_blank' || mode === 'overwrite'
+  if (mode !== 'overwrite') return false
+  return csvValue !== existingValue
+}
+
 const HEADER_ALIASES: Record<string, string[]> = {
   firstName: ['first name', 'firstname', 'first', 'player first name', 'given name'],
   lastName: ['last name', 'lastname', 'last', 'player last name', 'surname', 'family name'],
@@ -307,12 +337,14 @@ async function loadMatchIndex(): Promise<MatchIndex> {
 }
 
 export async function previewTeamlinktImport(
-  csvText: string
+  csvText: string,
+  options?: TeamlinktImportOptions
 ): Promise<{
   actions: ImportPreviewAction[]
   headers: string[]
   error?: string
 }> {
+  const profileFields = resolveProfileFieldsMode(options)
   const parsed = parseTeamlinktCsv(csvText)
   if (parsed.error) {
     return { actions: [], headers: parsed.headers, error: parsed.error }
@@ -371,6 +403,7 @@ export async function previewTeamlinktImport(
 
     const existing = index.playersById.get(playerId)
     const notes: string[] = []
+    const ignored: string[] = []
     if (!existing) {
       actions.push({ action: 'create', row })
       continue
@@ -384,15 +417,61 @@ export async function previewTeamlinktImport(
       continue
     }
 
-    if (row.jerseyNumber != null && existing.jerseyNumber == null) {
-      notes.push(`Set jersey #${row.jerseyNumber}`)
+    if (shouldApplyProfileField(row.jerseyNumber, existing.jerseyNumber, profileFields)) {
+      notes.push(
+        existing.jerseyNumber == null
+          ? `Set jersey #${row.jerseyNumber}`
+          : `Overwrite jersey #${existing.jerseyNumber} → #${row.jerseyNumber}`
+      )
+    } else if (
+      profileFields === 'skip' &&
+      row.jerseyNumber != null &&
+      existing.jerseyNumber != null &&
+      row.jerseyNumber !== existing.jerseyNumber
+    ) {
+      ignored.push(`jersey #${existing.jerseyNumber} kept (CSV #${row.jerseyNumber})`)
     }
-    if (row.skillLevel != null && existing.skillLevel == null) {
-      notes.push(`Set skill ${skillLevelLabel(row.skillLevel)} (${row.skillLevel})`)
+
+    if (shouldApplyProfileField(row.skillLevel, existing.skillLevel, profileFields)) {
+      notes.push(
+        existing.skillLevel == null
+          ? `Set skill ${skillLevelLabel(row.skillLevel)} (${row.skillLevel})`
+          : `Overwrite skill ${skillLevelLabel(existing.skillLevel)} → ${skillLevelLabel(row.skillLevel)}`
+      )
+    } else if (
+      profileFields === 'skip' &&
+      row.skillLevel != null &&
+      existing.skillLevel != null &&
+      row.skillLevel !== existing.skillLevel
+    ) {
+      ignored.push(
+        `skill ${skillLevelLabel(existing.skillLevel)} kept (CSV ${skillLevelLabel(row.skillLevel)})`
+      )
+    } else if (
+      profileFields === 'skip' &&
+      row.skillLevel != null &&
+      existing.skillLevel == null
+    ) {
+      ignored.push(`skill left unset (CSV ${skillLevelLabel(row.skillLevel)})`)
     }
-    if (row.gender != null && existing.gender == null) {
-      notes.push(`Set gender ${genderLabel(row.gender)}`)
+
+    if (shouldApplyProfileField(row.gender, existing.gender, profileFields)) {
+      notes.push(
+        existing.gender == null
+          ? `Set gender ${genderLabel(row.gender)}`
+          : `Overwrite gender ${genderLabel(existing.gender)} → ${genderLabel(row.gender)}`
+      )
+    } else if (
+      profileFields === 'skip' &&
+      row.gender != null &&
+      existing.gender != null &&
+      row.gender !== existing.gender
+    ) {
+      ignored.push(
+        `gender ${genderLabel(existing.gender)} kept (CSV ${genderLabel(row.gender)})`
+      )
     }
+
     if (row.email && !existing.emails.includes(row.email)) {
       notes.push(`Add email ${row.email}`)
     }
@@ -405,8 +484,16 @@ export async function previewTeamlinktImport(
     }
 
     if (notes.length === 0) {
-      actions.push({ action: 'skip', row, reason: 'Already up to date' })
+      actions.push({
+        action: 'skip',
+        row,
+        reason:
+          ignored.length > 0
+            ? `Already up to date; ${ignored.join('; ')}`
+            : 'Already up to date',
+      })
     } else {
+      if (ignored.length > 0) notes.push(...ignored.map((n) => `Skipped: ${n}`))
       actions.push({ action: 'update', row, playerId, notes })
     }
   }
@@ -418,8 +505,10 @@ export async function commitTeamlinktImport(input: {
   csvText: string
   filename: string
   actor: string
+  options?: TeamlinktImportOptions
 }) {
-  const preview = await previewTeamlinktImport(input.csvText)
+  const profileFields = resolveProfileFieldsMode(input.options)
+  const preview = await previewTeamlinktImport(input.csvText, input.options)
   if (preview.error) {
     throw new Error(preview.error)
   }
@@ -479,13 +568,13 @@ export async function commitTeamlinktImport(input: {
         skillLevel?: number | null
         gender?: string | null
       } = {}
-      if (item.row.jerseyNumber != null && snap.jerseyNumber == null) {
+      if (shouldApplyProfileField(item.row.jerseyNumber, snap.jerseyNumber, profileFields)) {
         patch.jerseyNumber = item.row.jerseyNumber
       }
-      if (item.row.skillLevel != null && snap.skillLevel == null) {
+      if (shouldApplyProfileField(item.row.skillLevel, snap.skillLevel, profileFields)) {
         patch.skillLevel = item.row.skillLevel
       }
-      if (item.row.gender != null && snap.gender == null) {
+      if (shouldApplyProfileField(item.row.gender, snap.gender, profileFields)) {
         patch.gender = item.row.gender
       }
       if (Object.keys(patch).length > 0) {
@@ -518,7 +607,7 @@ export async function commitTeamlinktImport(input: {
     }
   }
 
-  const summary = { created, updated, skipped, ambiguous, errors }
+  const summary = { created, updated, skipped, ambiguous, errors, profileFields }
   await db.update(importBatches).set({ summary }).where(eq(importBatches.id, batch.id))
 
   return { batchId: batch.id, summary, actions: preview.actions }

--- a/app/lib/players/types.ts
+++ b/app/lib/players/types.ts
@@ -1,12 +1,20 @@
 export type ChangeSource = 'import' | 'admin' | 'webapp'
-export type ChangeType = 'create' | 'update' | 'merge' | 'import'
+export type ChangeType = 'create' | 'update' | 'merge' | 'unmerge' | 'import'
 
 export type PlayerSnapshot = {
   id: string
   firstName: string
   lastName: string
   rosterName: string
+  /** Effective nickname (custom or first + last initial). */
+  nickname: string
+  /** Stored custom nickname; null means still using the default. */
+  nicknameCustom: string | null
   jerseyNumber: number | null
+  /** Effective jersey name (custom or last name). */
+  jerseyName: string
+  /** Stored custom jersey name; null means still using last name. */
+  jerseyNameCustom: string | null
   skillLevel: number | null
   gender: string | null
   isMerged: boolean
@@ -20,7 +28,9 @@ export type PlayerListItem = {
   firstName: string
   lastName: string
   rosterName: string
+  nickname: string
   jerseyNumber: number | null
+  jerseyName: string
   skillLevel: number | null
   skillLabel: string
   gender: string | null

--- a/app/players/page.tsx
+++ b/app/players/page.tsx
@@ -1,8 +1,18 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
-import { SKILL_LEVELS, skillLevelLabel } from '@/app/lib/players/skill'
-import { GENDERS, genderGroup } from '@/app/lib/players/gender'
+import {
+  SKILL_LEVELS,
+  defaultJerseyName,
+  defaultNickname,
+  skillLevelLabel,
+} from '@/app/lib/players/skill'
+import {
+  GENDERS,
+  genderGroup,
+  genderGroupSortKey,
+  type GenderGroup,
+} from '@/app/lib/players/gender'
 import type { PlayerListItem, PlayerSnapshot } from '@/app/lib/players/types'
 
 type HistoryRow = {
@@ -58,8 +68,143 @@ function genderRowClass(gender: string | null, isMerged: boolean): string {
   if (isMerged) return 'bg-gray-50 text-gray-500'
   const group = genderGroup(gender)
   if (group === 'w_nb_o') return 'bg-rose-50/70 text-gray-900'
-  if (group === 'men') return 'text-gray-900'
+  if (group === 'men') return 'bg-sky-50/70 text-gray-900'
   return 'text-gray-900'
+}
+
+function sortIndicator(active: boolean, dir: 'asc' | 'desc'): string {
+  if (!active) return '↕'
+  return dir === 'asc' ? '↑' : '↓'
+}
+
+function SortableHeaderButton(props: {
+  label: string
+  active: boolean
+  dir: 'asc' | 'desc'
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={props.onClick}
+      className={`inline-flex items-center gap-1 font-medium hover:text-gray-900 ${
+        props.active ? 'text-gray-900' : 'text-gray-700'
+      }`}
+    >
+      {props.label}
+      <span className="text-xs text-gray-500" aria-hidden>
+        {sortIndicator(props.active, props.dir)}
+      </span>
+    </button>
+  )
+}
+
+function SortableHeader(props: {
+  label: string
+  active: boolean
+  dir: 'asc' | 'desc'
+  onClick: () => void
+}) {
+  return (
+    <th className="px-3 py-2">
+      <SortableHeaderButton {...props} />
+    </th>
+  )
+}
+
+type SortKey = 'first' | 'last' | 'jersey' | 'jerseyName' | 'gender' | 'skill'
+
+type ColumnKey =
+  | 'roster'
+  | 'nickname'
+  | 'jerseyNumber'
+  | 'jerseyName'
+  | 'gender'
+  | 'skill'
+  | 'email'
+
+const COLUMN_OPTIONS: { key: ColumnKey; label: string }[] = [
+  { key: 'roster', label: 'Roster name' },
+  { key: 'nickname', label: 'Nickname' },
+  { key: 'jerseyNumber', label: 'Jersey #' },
+  { key: 'jerseyName', label: 'Jersey name' },
+  { key: 'gender', label: 'Gender' },
+  { key: 'skill', label: 'Skill' },
+  { key: 'email', label: 'Email' },
+]
+
+const DEFAULT_VISIBLE_COLUMNS: Record<ColumnKey, boolean> = {
+  roster: true,
+  nickname: true,
+  jerseyNumber: false,
+  jerseyName: false,
+  gender: true,
+  skill: true,
+  email: true,
+}
+
+const COLUMNS_STORAGE_KEY = 'bdl-admin.players.visibleColumns'
+
+function loadVisibleColumns(): Record<ColumnKey, boolean> {
+  if (typeof window === 'undefined') return { ...DEFAULT_VISIBLE_COLUMNS }
+  try {
+    const raw = window.localStorage.getItem(COLUMNS_STORAGE_KEY)
+    if (!raw) return { ...DEFAULT_VISIBLE_COLUMNS }
+    const parsed = JSON.parse(raw) as Partial<Record<ColumnKey, boolean>>
+    return {
+      ...DEFAULT_VISIBLE_COLUMNS,
+      ...parsed,
+    }
+  } catch {
+    return { ...DEFAULT_VISIBLE_COLUMNS }
+  }
+}
+
+function compareByLastName(a: PlayerListItem, b: PlayerListItem): number {
+  const last = a.lastName.localeCompare(b.lastName, undefined, { sensitivity: 'base' })
+  if (last !== 0) return last
+  return a.firstName.localeCompare(b.firstName, undefined, { sensitivity: 'base' })
+}
+
+function compareByFirstName(a: PlayerListItem, b: PlayerListItem): number {
+  const first = a.firstName.localeCompare(b.firstName, undefined, { sensitivity: 'base' })
+  if (first !== 0) return first
+  return a.lastName.localeCompare(b.lastName, undefined, { sensitivity: 'base' })
+}
+
+function compareJersey(a: PlayerListItem, b: PlayerListItem): number {
+  if (a.jerseyNumber == null && b.jerseyNumber == null) return 0
+  if (a.jerseyNumber == null) return 1
+  if (b.jerseyNumber == null) return -1
+  return a.jerseyNumber - b.jerseyNumber
+}
+
+function compareJerseyName(a: PlayerListItem, b: PlayerListItem): number {
+  const cmp = a.jerseyName.localeCompare(b.jerseyName, undefined, { sensitivity: 'base' })
+  if (cmp !== 0) return cmp
+  return compareByLastName(a, b)
+}
+
+function compareSkill(a: PlayerListItem, b: PlayerListItem): number {
+  if (a.skillLevel == null && b.skillLevel == null) return 0
+  if (a.skillLevel == null) return 1
+  if (b.skillLevel == null) return -1
+  return a.skillLevel - b.skillLevel
+}
+
+function comparePlayers(a: PlayerListItem, b: PlayerListItem, key: SortKey): number {
+  if (key === 'first') return compareByFirstName(a, b)
+  if (key === 'last') return compareByLastName(a, b)
+  if (key === 'jersey') return compareJersey(a, b)
+  if (key === 'jerseyName') return compareJerseyName(a, b)
+  if (key === 'gender') {
+    const g = genderGroupSortKey(a.gender) - genderGroupSortKey(b.gender)
+    if (g !== 0) return g
+    return compareByLastName(a, b)
+  }
+  const s = compareSkill(a, b)
+  if (s !== 0) return s
+  return compareByLastName(a, b)
 }
 
 export default function PlayersPage() {
@@ -68,7 +213,44 @@ export default function PlayersPage() {
   const [error, setError] = useState<string | null>(null)
   const [q, setQ] = useState('')
   const [skillFilter, setSkillFilter] = useState('')
+  const [genderFilter, setGenderFilter] = useState<'' | GenderGroup>('')
+  const [sortKey, setSortKey] = useState<SortKey>('last')
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc')
   const [includeMerged, setIncludeMerged] = useState(false)
+  const [visibleColumns, setVisibleColumns] = useState<Record<ColumnKey, boolean>>(
+    DEFAULT_VISIBLE_COLUMNS
+  )
+  const [columnsOpen, setColumnsOpen] = useState(false)
+
+  useEffect(() => {
+    setVisibleColumns(loadVisibleColumns())
+  }, [])
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(COLUMNS_STORAGE_KEY, JSON.stringify(visibleColumns))
+    } catch {
+      // ignore quota / private mode
+    }
+  }, [visibleColumns])
+
+  function toggleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+      return
+    }
+    setSortKey(key)
+    setSortDir('asc')
+  }
+
+  function toggleColumn(key: ColumnKey) {
+    setVisibleColumns((prev) => ({ ...prev, [key]: !prev[key] }))
+  }
+
+  const visibleColumnCount =
+    2 + // first + last always shown
+    COLUMN_OPTIONS.filter((c) => visibleColumns[c.key]).length +
+    2 // checkbox + actions
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [editing, setEditing] = useState<PlayerSnapshot | null>(null)
@@ -81,6 +263,9 @@ export default function PlayersPage() {
   const [importOpen, setImportOpen] = useState(false)
   const [importCsv, setImportCsv] = useState('')
   const [importFilename, setImportFilename] = useState('teamlinkt.csv')
+  const [importProfileFields, setImportProfileFields] = useState<
+    'skip' | 'fill_blank' | 'overwrite'
+  >('skip')
   const [importPreview, setImportPreview] = useState<{
     actions: ImportAction[]
     summary: Record<string, number>
@@ -114,9 +299,21 @@ export default function PlayersPage() {
     void loadPlayers()
   }, [loadPlayers])
 
+  const displayedPlayers = useMemo(() => {
+    const filtered = genderFilter
+      ? players.filter((p) => genderGroup(p.gender) === genderFilter)
+      : players
+    const sorted = [...filtered]
+    sorted.sort((a, b) => {
+      const cmp = comparePlayers(a, b, sortKey)
+      return sortDir === 'asc' ? cmp : -cmp
+    })
+    return sorted
+  }, [players, genderFilter, sortKey, sortDir])
+
   const selectedPlayers = useMemo(
-    () => players.filter((p) => selectedIds.has(p.id)),
-    [players, selectedIds]
+    () => displayedPlayers.filter((p) => selectedIds.has(p.id)),
+    [displayedPlayers, selectedIds]
   )
 
   function toggleSelect(id: string) {
@@ -195,7 +392,9 @@ export default function PlayersPage() {
     firstName: string
     lastName: string
     rosterName?: string
+    nickname?: string | null
     jerseyNumber?: number | null
+    jerseyName?: string | null
     skillLevel?: number | null
     gender?: string | null
     email?: string
@@ -245,6 +444,27 @@ export default function PlayersPage() {
     }
   }
 
+  async function runUnmerge(playerId: string) {
+    setSaving(true)
+    setFormError(null)
+    try {
+      const res = await fetch('/api/players/unmerge', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ playerId }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Unmerge failed')
+      await loadPlayers()
+      if (data.player) setEditing(data.player)
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Unmerge failed')
+      setError(err instanceof Error ? err.message : 'Unmerge failed')
+    } finally {
+      setSaving(false)
+    }
+  }
+
   async function readApiJson(res: Response): Promise<Record<string, unknown>> {
     const text = await res.text()
     try {
@@ -266,7 +486,12 @@ export default function PlayersPage() {
       const res = await fetch('/api/players/import', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ csv: importCsv, filename: importFilename, dryRun: true }),
+        body: JSON.stringify({
+          csv: importCsv,
+          filename: importFilename,
+          dryRun: true,
+          profileFields: importProfileFields,
+        }),
       })
       const data = await readApiJson(res)
       if (!res.ok) throw new Error(String(data.error || 'Preview failed'))
@@ -292,6 +517,7 @@ export default function PlayersPage() {
           csv: importCsv,
           filename: importFilename,
           dryRun: false,
+          profileFields: importProfileFields,
         }),
       })
       const data = await readApiJson(res)
@@ -305,6 +531,7 @@ export default function PlayersPage() {
       setImportOpen(false)
       setImportCsv('')
       setImportPreview(null)
+      setImportProfileFields('skip')
       await loadPlayers()
       alert(
         `Import done: ${summary.created} created, ${summary.updated} updated, ${summary.skipped} skipped, ${summary.ambiguous} ambiguous`
@@ -341,6 +568,7 @@ export default function PlayersPage() {
             onClick={() => {
               setImportOpen(true)
               setImportPreview(null)
+              setImportProfileFields('skip')
               setFormError(null)
             }}
             className="rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800 hover:bg-gray-50"
@@ -372,22 +600,6 @@ export default function PlayersPage() {
             className="rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 w-64"
           />
         </label>
-        <label className="text-sm text-gray-900">
-          <span className="block text-gray-600 mb-1">Skill</span>
-          <select
-            value={skillFilter}
-            onChange={(e) => setSkillFilter(e.target.value)}
-            className="rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900"
-          >
-            <option value="">All</option>
-            <option value="unset">Unset</option>
-            {Object.entries(SKILL_LEVELS).map(([value, label]) => (
-              <option key={value} value={value}>
-                {value}: {label}
-              </option>
-            ))}
-          </select>
-        </label>
         <label className="flex items-center gap-2 text-sm text-gray-900 pb-2">
           <input
             type="checkbox"
@@ -396,6 +608,40 @@ export default function PlayersPage() {
           />
           Show merged
         </label>
+        <div className="relative pb-0.5">
+          <button
+            type="button"
+            onClick={() => setColumnsOpen((open) => !open)}
+            className="rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800 hover:bg-gray-50"
+          >
+            Columns
+          </button>
+          {columnsOpen ? (
+            <div className="absolute left-0 top-full z-20 mt-1 w-52 rounded border border-gray-200 bg-white p-2 shadow-lg">
+              <p className="px-1 pb-1 text-xs text-gray-500">First/last always shown</p>
+              {COLUMN_OPTIONS.map((col) => (
+                <label
+                  key={col.key}
+                  className="flex items-center gap-2 rounded px-1 py-1 text-sm text-gray-900 hover:bg-gray-50"
+                >
+                  <input
+                    type="checkbox"
+                    checked={visibleColumns[col.key]}
+                    onChange={() => toggleColumn(col.key)}
+                  />
+                  {col.label}
+                </label>
+              ))}
+              <button
+                type="button"
+                className="mt-1 w-full rounded px-1 py-1 text-left text-xs text-blue-700 hover:bg-blue-50"
+                onClick={() => setVisibleColumns({ ...DEFAULT_VISIBLE_COLUMNS })}
+              >
+                Reset defaults
+              </button>
+            </div>
+          ) : null}
+        </div>
         <button
           type="button"
           onClick={() => void loadPlayers()}
@@ -405,27 +651,125 @@ export default function PlayersPage() {
         </button>
       </div>
 
+      <p className="text-xs text-gray-600 flex flex-wrap gap-x-4 gap-y-1">
+        <span>
+          <span className="inline-block w-3 h-3 rounded-sm bg-rose-50/70 border border-rose-200 align-middle mr-1" />
+          W/NB/O
+        </span>
+        <span>
+          <span className="inline-block w-3 h-3 rounded-sm bg-sky-50/70 border border-sky-200 align-middle mr-1" />
+          Men
+        </span>
+        <span>
+          Skill:{' '}
+          <span className="italic">(beginner)</span>
+          {' · '}
+          intermediate
+          {' · '}
+          <span className="font-bold">advanced</span>
+          {' · '}
+          <span className="font-bold underline">worlds</span>
+        </span>
+      </p>
+
       {error ? <p className="text-sm text-red-600">{error}</p> : null}
       {loading ? <p className="text-sm text-gray-600">Loading players…</p> : null}
 
       {!loading && (
-        <div className="overflow-x-auto border border-gray-200 rounded-lg bg-white text-gray-900">
+        <div className="space-y-2">
+          <p className="text-sm text-gray-600">
+            {displayedPlayers.length} player{displayedPlayers.length === 1 ? '' : 's'}
+          </p>
+          <div className="overflow-x-auto border border-gray-200 rounded-lg bg-white text-gray-900">
           <table className="min-w-full text-sm text-gray-900">
             <thead className="bg-gray-50 text-left text-gray-700">
               <tr>
                 <th className="px-3 py-2 w-10" />
-                <th className="px-3 py-2">First</th>
-                <th className="px-3 py-2">Last</th>
-                <th className="px-3 py-2">Roster name</th>
-                <th className="px-3 py-2">Jersey</th>
-                <th className="px-3 py-2">Gender</th>
-                <th className="px-3 py-2">Skill</th>
-                <th className="px-3 py-2">Email</th>
+                <SortableHeader
+                  label="First"
+                  active={sortKey === 'first'}
+                  dir={sortDir}
+                  onClick={() => toggleSort('first')}
+                />
+                <SortableHeader
+                  label="Last"
+                  active={sortKey === 'last'}
+                  dir={sortDir}
+                  onClick={() => toggleSort('last')}
+                />
+                {visibleColumns.roster ? <th className="px-3 py-2">Roster name</th> : null}
+                {visibleColumns.nickname ? <th className="px-3 py-2">Nickname</th> : null}
+                {visibleColumns.jerseyNumber ? (
+                  <SortableHeader
+                    label="Jersey #"
+                    active={sortKey === 'jersey'}
+                    dir={sortDir}
+                    onClick={() => toggleSort('jersey')}
+                  />
+                ) : null}
+                {visibleColumns.jerseyName ? (
+                  <SortableHeader
+                    label="Jersey name"
+                    active={sortKey === 'jerseyName'}
+                    dir={sortDir}
+                    onClick={() => toggleSort('jerseyName')}
+                  />
+                ) : null}
+                {visibleColumns.gender ? (
+                  <th className="px-3 py-2 align-bottom">
+                    <div className="space-y-1">
+                      <SortableHeaderButton
+                        label="Gender"
+                        active={sortKey === 'gender'}
+                        dir={sortDir}
+                        onClick={() => toggleSort('gender')}
+                      />
+                      <select
+                        aria-label="Filter by gender"
+                        value={genderFilter}
+                        onChange={(e) => setGenderFilter(e.target.value as '' | GenderGroup)}
+                        className="block w-full max-w-[8.5rem] rounded border border-gray-300 bg-white px-1.5 py-1 text-xs text-gray-900"
+                      >
+                        <option value="">All</option>
+                        <option value="w_nb_o">W/NB/O</option>
+                        <option value="men">Men</option>
+                        <option value="unset">Unset</option>
+                      </select>
+                    </div>
+                  </th>
+                ) : null}
+                {visibleColumns.skill ? (
+                  <th className="px-3 py-2 align-bottom">
+                    <div className="space-y-1">
+                      <SortableHeaderButton
+                        label="Skill"
+                        active={sortKey === 'skill'}
+                        dir={sortDir}
+                        onClick={() => toggleSort('skill')}
+                      />
+                      <select
+                        aria-label="Filter by skill"
+                        value={skillFilter}
+                        onChange={(e) => setSkillFilter(e.target.value)}
+                        className="block w-full max-w-[9.5rem] rounded border border-gray-300 bg-white px-1.5 py-1 text-xs text-gray-900"
+                      >
+                        <option value="">All</option>
+                        <option value="unset">Unset</option>
+                        {Object.entries(SKILL_LEVELS).map(([value, label]) => (
+                          <option key={value} value={value}>
+                            {value}: {label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </th>
+                ) : null}
+                {visibleColumns.email ? <th className="px-3 py-2">Email</th> : null}
                 <th className="px-3 py-2">Actions</th>
               </tr>
             </thead>
             <tbody className="text-gray-900">
-              {players.map((p) => (
+              {displayedPlayers.map((p) => (
                 <tr
                   key={p.id}
                   className={`border-t border-gray-100 ${genderRowClass(p.gender, p.isMerged)}`}
@@ -444,44 +788,83 @@ export default function PlayersPage() {
                   <td className="px-3 py-2">
                     <SkillStyledText skillLevel={p.skillLevel}>{p.lastName}</SkillStyledText>
                   </td>
-                  <td className="px-3 py-2">
-                    <SkillStyledText skillLevel={p.skillLevel}>{p.rosterName}</SkillStyledText>
-                  </td>
-                  <td className="px-3 py-2">{p.jerseyNumber ?? '—'}</td>
-                  <td className="px-3 py-2">
-                    <span
-                      className={
-                        genderGroup(p.gender) === 'w_nb_o'
-                          ? 'font-medium text-rose-800'
-                          : genderGroup(p.gender) === 'men'
-                            ? 'text-sky-900'
-                            : 'text-gray-500'
-                      }
-                    >
-                      {genderGroup(p.gender) === 'w_nb_o' ? (
-                        <>
-                          W/NB/O
-                          <span className="ml-1 font-normal text-gray-600">
-                            ({p.genderLabel})
-                          </span>
-                        </>
-                      ) : (
-                        p.genderLabel
-                      )}
-                    </span>
-                  </td>
-                  <td className="px-3 py-2">
-                    <SkillStyledText skillLevel={p.skillLevel}>{p.skillLabel}</SkillStyledText>
-                  </td>
-                  <td className="px-3 py-2">{p.primaryEmail ?? '—'}</td>
+                  {visibleColumns.roster ? (
+                    <td className="px-3 py-2">
+                      <SkillStyledText skillLevel={p.skillLevel}>{p.rosterName}</SkillStyledText>
+                    </td>
+                  ) : null}
+                  {visibleColumns.nickname ? (
+                    <td className="px-3 py-2">
+                      <SkillStyledText skillLevel={p.skillLevel}>{p.nickname}</SkillStyledText>
+                    </td>
+                  ) : null}
+                  {visibleColumns.jerseyNumber ? (
+                    <td className="px-3 py-2">{p.jerseyNumber ?? '—'}</td>
+                  ) : null}
+                  {visibleColumns.jerseyName ? (
+                    <td className="px-3 py-2">
+                      <SkillStyledText skillLevel={p.skillLevel}>{p.jerseyName}</SkillStyledText>
+                    </td>
+                  ) : null}
+                  {visibleColumns.gender ? (
+                    <td className="px-3 py-2">
+                      <span
+                        className={
+                          genderGroup(p.gender) === 'w_nb_o'
+                            ? 'font-medium text-rose-800'
+                            : genderGroup(p.gender) === 'men'
+                              ? 'font-medium text-sky-900'
+                              : 'text-gray-500'
+                        }
+                      >
+                        {genderGroup(p.gender) === 'w_nb_o' ||
+                        genderGroup(p.gender) === 'men' ? (
+                          <>
+                            {p.genderGroupLabel}
+                            <span className="ml-1 font-normal text-gray-600">
+                              ({p.genderLabel})
+                            </span>
+                          </>
+                        ) : (
+                          p.genderLabel
+                        )}
+                      </span>
+                    </td>
+                  ) : null}
+                  {visibleColumns.skill ? (
+                    <td className="px-3 py-2">
+                      <SkillStyledText skillLevel={p.skillLevel}>{p.skillLabel}</SkillStyledText>
+                    </td>
+                  ) : null}
+                  {visibleColumns.email ? (
+                    <td className="px-3 py-2">{p.primaryEmail ?? '—'}</td>
+                  ) : null}
                   <td className="px-3 py-2 space-x-2 whitespace-nowrap">
                     <button
                       type="button"
                       className="text-blue-600 hover:underline"
                       onClick={() => void openEdit(p.id)}
                     >
-                      Edit
+                      {p.isMerged ? 'View' : 'Edit'}
                     </button>
+                    {p.isMerged ? (
+                      <button
+                        type="button"
+                        className="text-amber-700 hover:underline"
+                        disabled={saving}
+                        onClick={() => {
+                          if (
+                            window.confirm(
+                              `Unmerge ${p.rosterName}? Emails and aliases that still sit on the survivor will move back.`
+                            )
+                          ) {
+                            void runUnmerge(p.id)
+                          }
+                        }}
+                      >
+                        Unmerge
+                      </button>
+                    ) : null}
                     <button
                       type="button"
                       className="text-blue-600 hover:underline"
@@ -492,15 +875,19 @@ export default function PlayersPage() {
                   </td>
                 </tr>
               ))}
-              {players.length === 0 ? (
+              {displayedPlayers.length === 0 ? (
                 <tr>
-                  <td colSpan={9} className="px-3 py-8 text-center text-gray-500">
+                  <td
+                    colSpan={visibleColumnCount}
+                    className="px-3 py-8 text-center text-gray-500"
+                  >
                     No players yet. Import a TeamLinkt CSV or add one manually.
                   </td>
                 </tr>
               ) : null}
             </tbody>
           </table>
+          </div>
         </div>
       )}
 
@@ -516,6 +903,7 @@ export default function PlayersPage() {
           onSetPrimary={(id) => void saveEdit({ setPrimaryEmailId: id })}
           onAddAlias={(alias) => void saveEdit({ addAlias: alias })}
           onRemoveAlias={(id) => void saveEdit({ removeAliasId: id })}
+          onUnmerge={() => void runUnmerge(editing.id)}
         />
       ) : null}
 
@@ -586,6 +974,27 @@ export default function PlayersPage() {
         <div className="fixed inset-0 z-40 bg-black/40 flex items-center justify-center p-4">
           <div className="bg-white rounded-lg shadow-xl max-w-3xl w-full max-h-[90vh] overflow-y-auto p-6 space-y-4 text-gray-900">
             <h2 className="text-lg font-semibold text-gray-900">Import TeamLinkt CSV</h2>
+            <p className="text-sm text-gray-600">
+              New players always get skill, gender, and jersey from the CSV. For existing
+              players, those fields are left alone by default so manual edits are preserved.
+            </p>
+            <label className="block text-sm">
+              <span className="text-gray-600">Existing players: skill / gender / jersey</span>
+              <select
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+                value={importProfileFields}
+                onChange={(e) => {
+                  setImportProfileFields(
+                    e.target.value as 'skip' | 'fill_blank' | 'overwrite'
+                  )
+                  setImportPreview(null)
+                }}
+              >
+                <option value="skip">Skip (keep current values)</option>
+                <option value="fill_blank">Fill blanks only</option>
+                <option value="overwrite">Overwrite from CSV</option>
+              </select>
+            </label>
             <label className="block text-sm">
               <span className="text-gray-600">Filename</span>
               <input
@@ -699,14 +1108,17 @@ function EditPanel(props: {
   onSetPrimary: (id: string) => void
   onAddAlias: (alias: string) => void
   onRemoveAlias: (id: string) => void
+  onUnmerge: () => void
 }) {
   const p = props.player
   const [firstName, setFirstName] = useState(p.firstName)
   const [lastName, setLastName] = useState(p.lastName)
   const [rosterName, setRosterName] = useState(p.rosterName)
+  const [nickname, setNickname] = useState(p.nickname)
   const [jerseyNumber, setJerseyNumber] = useState(
     p.jerseyNumber != null ? String(p.jerseyNumber) : ''
   )
+  const [jerseyName, setJerseyName] = useState(p.jerseyName)
   const [skillLevel, setSkillLevel] = useState(
     p.skillLevel != null ? String(p.skillLevel) : ''
   )
@@ -718,10 +1130,15 @@ function EditPanel(props: {
     setFirstName(p.firstName)
     setLastName(p.lastName)
     setRosterName(p.rosterName)
+    setNickname(p.nickname)
     setJerseyNumber(p.jerseyNumber != null ? String(p.jerseyNumber) : '')
+    setJerseyName(p.jerseyName)
     setSkillLevel(p.skillLevel != null ? String(p.skillLevel) : '')
     setGender(p.gender ?? '')
   }, [p])
+
+  const nicknameDefault = defaultNickname(firstName, lastName)
+  const jerseyNameDefault = defaultJerseyName(lastName)
 
   return (
     <div className="fixed inset-0 z-40 bg-black/40 flex items-center justify-center p-4">
@@ -734,9 +1151,34 @@ function EditPanel(props: {
         </div>
 
         {p.isMerged ? (
-          <p className="text-sm text-amber-700 bg-amber-50 rounded px-3 py-2">
-            This player was merged into another record and cannot be edited.
-          </p>
+          <div className="space-y-2 rounded bg-amber-50 px-3 py-2 text-sm text-amber-800">
+            <p>
+              This player was merged
+              {p.mergedIntoPlayerId ? ' into another record' : ''} and cannot be
+              edited until unmerged.
+            </p>
+            <p className="text-amber-700/90">
+              Unmerge reactivates this player and moves emails/aliases that still
+              belong on the survivor back here. It does not undo jersey/skill/gender
+              fills on the survivor.
+            </p>
+            <button
+              type="button"
+              disabled={props.saving}
+              className="rounded border border-amber-700/40 bg-white px-3 py-1.5 text-amber-900 hover:bg-amber-100 disabled:opacity-40"
+              onClick={() => {
+                if (
+                  window.confirm(
+                    `Unmerge ${p.rosterName}? Emails and aliases that still sit on the survivor will move back.`
+                  )
+                ) {
+                  props.onUnmerge()
+                }
+              }}
+            >
+              Unmerge player
+            </button>
+          </div>
         ) : null}
 
         <div className="grid grid-cols-2 gap-3">
@@ -767,6 +1209,21 @@ function EditPanel(props: {
               onChange={(e) => setRosterName(e.target.value)}
             />
           </label>
+          <label className="text-sm col-span-2">
+            Nickname
+            <input
+              className="mt-1 w-full rounded border px-3 py-2"
+              value={nickname}
+              disabled={p.isMerged}
+              onChange={(e) => setNickname(e.target.value)}
+              placeholder={nicknameDefault}
+            />
+            <span className="mt-1 block text-xs text-gray-500">
+              Defaults to first name + last initial ({nicknameDefault}
+              {p.nicknameCustom ? '' : ' — currently using default'}
+              ). Clear or match the default to keep it automatic.
+            </span>
+          </label>
           <label className="text-sm">
             Jersey #
             <input
@@ -775,6 +1232,21 @@ function EditPanel(props: {
               disabled={p.isMerged}
               onChange={(e) => setJerseyNumber(e.target.value)}
             />
+          </label>
+          <label className="text-sm">
+            Jersey name
+            <input
+              className="mt-1 w-full rounded border px-3 py-2"
+              value={jerseyName}
+              disabled={p.isMerged}
+              onChange={(e) => setJerseyName(e.target.value)}
+              placeholder={jerseyNameDefault}
+            />
+            <span className="mt-1 block text-xs text-gray-500">
+              Defaults to last name ({jerseyNameDefault}
+              {p.jerseyNameCustom ? '' : ' — currently using default'}
+              ).
+            </span>
           </label>
           <label className="text-sm">
             Skill
@@ -820,7 +1292,9 @@ function EditPanel(props: {
                 firstName,
                 lastName,
                 rosterName,
+                nickname,
                 jerseyNumber: parseJerseyNumber(jerseyNumber),
+                jerseyName,
                 skillLevel: skillLevel ? Number(skillLevel) : null,
                 gender: gender || null,
               })
@@ -948,7 +1422,9 @@ function CreatePanel(props: {
     firstName: string
     lastName: string
     rosterName?: string
+    nickname?: string | null
     jerseyNumber?: number | null
+    jerseyName?: string | null
     skillLevel?: number | null
     gender?: string | null
     email?: string
@@ -957,10 +1433,14 @@ function CreatePanel(props: {
   const [firstName, setFirstName] = useState('')
   const [lastName, setLastName] = useState('')
   const [rosterName, setRosterName] = useState('')
+  const [nickname, setNickname] = useState('')
   const [jerseyNumber, setJerseyNumber] = useState('')
+  const [jerseyName, setJerseyName] = useState('')
   const [skillLevel, setSkillLevel] = useState('')
   const [gender, setGender] = useState('')
   const [email, setEmail] = useState('')
+  const nicknameDefault = defaultNickname(firstName, lastName)
+  const jerseyNameDefault = defaultJerseyName(lastName)
 
   return (
     <div className="fixed inset-0 z-40 bg-black/40 flex items-center justify-center p-4">
@@ -991,6 +1471,18 @@ function CreatePanel(props: {
               onChange={(e) => setRosterName(e.target.value)}
             />
           </label>
+          <label className="text-sm col-span-2">
+            Nickname (optional)
+            <input
+              className="mt-1 w-full rounded border px-3 py-2"
+              value={nickname}
+              onChange={(e) => setNickname(e.target.value)}
+              placeholder={nicknameDefault || 'First L'}
+            />
+            <span className="mt-1 block text-xs text-gray-500">
+              Leave blank to use {nicknameDefault || 'first name + last initial'}.
+            </span>
+          </label>
           <label className="text-sm">
             Jersey #
             <input
@@ -998,6 +1490,18 @@ function CreatePanel(props: {
               value={jerseyNumber}
               onChange={(e) => setJerseyNumber(e.target.value)}
             />
+          </label>
+          <label className="text-sm">
+            Jersey name (optional)
+            <input
+              className="mt-1 w-full rounded border px-3 py-2"
+              value={jerseyName}
+              onChange={(e) => setJerseyName(e.target.value)}
+              placeholder={jerseyNameDefault || 'Last name'}
+            />
+            <span className="mt-1 block text-xs text-gray-500">
+              Leave blank to use {jerseyNameDefault || 'last name'}.
+            </span>
           </label>
           <label className="text-sm">
             Skill
@@ -1052,7 +1556,9 @@ function CreatePanel(props: {
                 firstName,
                 lastName,
                 rosterName: rosterName.trim() || undefined,
+                nickname: nickname.trim() || null,
                 jerseyNumber: parseJerseyNumber(jerseyNumber),
+                jerseyName: jerseyName.trim() || null,
                 skillLevel: skillLevel ? Number(skillLevel) : null,
                 gender: gender || null,
                 email: email.trim() || undefined,

--- a/drizzle/0002_player_nickname.sql
+++ b/drizzle/0002_player_nickname.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "players" ADD COLUMN IF NOT EXISTS "nickname" text;

--- a/drizzle/0003_player_jersey_name.sql
+++ b/drizzle/0003_player_jersey_name.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "players" ADD COLUMN IF NOT EXISTS "jersey_name" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,20 @@
       "when": 1752614400000,
       "tag": "0001_player_gender",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1752620000000,
+      "tag": "0002_player_nickname",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1752623600000,
+      "tag": "0003_player_jersey_name",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Move players table sort/filter into column headers and add configurable columns (jersey # / jersey name hidden by default)
- Add nickname (defaults to first + last initial) and jersey name (defaults to last name), with migrations
- Skip TeamLinkt skill/gender/jersey updates on existing players by default (optional fill-blank / overwrite)
- Add unmerge for soft-merged players, plus local `next dev` auth bypass for faster iteration

## Test plan
- [ ] Open `/players` and sort/filter via First/Last/Gender/Skill headers
- [ ] Use Columns to show jersey fields; confirm preference persists after refresh
- [ ] Edit a player nickname / jersey name; clear them and confirm defaults return
- [ ] Dry-run TeamLinkt import with default Skip; confirm existing skill/gender/jersey stay put
- [ ] With Show merged, unmerge a player and confirm emails/aliases restore as expected
- [ ] Confirm `npm run db:push` / migrations add `nickname` and `jersey_name`


Made with [Cursor](https://cursor.com)