### PR TITLE
Add event registration tracking for tournament teaming

### DIFF
--- a/app/__tests__/event-draft-group.test.ts
+++ b/app/__tests__/event-draft-group.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isValidDraftGroup,
+  parseDraftGroup,
+} from '@/app/lib/events/types'
+
+describe('parseDraftGroup', () => {
+  it('accepts positive integers and null to clear', () => {
+    expect(parseDraftGroup(1)).toBe(1)
+    expect(parseDraftGroup('3')).toBe(3)
+    expect(parseDraftGroup(null)).toBeNull()
+    expect(parseDraftGroup('')).toBeNull()
+    expect(parseDraftGroup(undefined)).toBeUndefined()
+  })
+
+  it('rejects zero, negatives, and non-integers', () => {
+    expect(() => parseDraftGroup(0)).toThrow(/positive integer/)
+    expect(() => parseDraftGroup(-1)).toThrow(/positive integer/)
+    expect(() => parseDraftGroup(1.5)).toThrow(/positive integer/)
+    expect(() => parseDraftGroup('nope')).toThrow(/positive integer/)
+  })
+
+  it('isValidDraftGroup mirrors parse rules', () => {
+    expect(isValidDraftGroup(2)).toBe(true)
+    expect(isValidDraftGroup(null)).toBe(true)
+    expect(isValidDraftGroup(0)).toBe(false)
+    expect(isValidDraftGroup(undefined)).toBe(false)
+  })
+})

--- a/app/__tests__/event-draft-group.test.ts
+++ b/app/__tests__/event-draft-group.test.ts
@@ -3,6 +3,7 @@ import {
   isValidDraftGroup,
   parseDraftGroup,
 } from '@/app/lib/events/types'
+import { parseEventDate } from '@/app/lib/events/mutations'
 
 describe('parseDraftGroup', () => {
   it('accepts positive integers and null to clear', () => {
@@ -25,5 +26,18 @@ describe('parseDraftGroup', () => {
     expect(isValidDraftGroup(null)).toBe(true)
     expect(isValidDraftGroup(0)).toBe(false)
     expect(isValidDraftGroup(undefined)).toBe(false)
+  })
+})
+
+describe('parseEventDate', () => {
+  it('accepts valid calendar dates', () => {
+    expect(parseEventDate('2026-08-08')).toBe('2026-08-08')
+    expect(parseEventDate(' 2026-02-28 ')).toBe('2026-02-28')
+  })
+
+  it('rejects malformed and overflow calendar dates', () => {
+    expect(() => parseEventDate('08/08/2026')).toThrow(/YYYY-MM-DD/)
+    expect(() => parseEventDate('2026-02-31')).toThrow(/not a valid date/)
+    expect(() => parseEventDate('2026-13-01')).toThrow(/not a valid date/)
   })
 })

--- a/app/__tests__/teamlinkt-import.test.ts
+++ b/app/__tests__/teamlinkt-import.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest'
 import {
   parseCsv,
   parseTeamlinktCsv,
+  playerIdForRegistration,
   shouldApplyProfileField,
+  summarizeRegistrationPreview,
+  type ImportPreviewAction,
+  type TeamlinktRow,
 } from '@/app/lib/players/teamlinkt-import'
 import {
   defaultJerseyName,
@@ -14,6 +18,20 @@ import {
   resolveNickname,
 } from '@/app/lib/players/skill'
 import { genderGroup, parseGender } from '@/app/lib/players/gender'
+
+function sampleRow(overrides: Partial<TeamlinktRow> = {}): TeamlinktRow {
+  return {
+    rowNumber: 2,
+    firstName: 'Jess',
+    lastName: 'Sartin',
+    email: 'jess@example.com',
+    jerseyNumber: null,
+    skillLevel: null,
+    gender: null,
+    raw: {},
+    ...overrides,
+  }
+}
 
 describe('parseSkillLevel', () => {
   it('maps intermediate/advanced and numeric levels', () => {
@@ -169,5 +187,93 @@ describe('teamlinkt csv parse', () => {
     const parsed = parseTeamlinktCsv(csv)
     expect(parsed.error).toBeUndefined()
     expect(parsed.rows[0].firstName).toBe('Jess')
+  })
+})
+
+describe('event-scoped registration preview', () => {
+  it('resolves player ids for update and matched skip rows', () => {
+    const update: ImportPreviewAction = {
+      action: 'update',
+      row: sampleRow(),
+      playerId: 'p1',
+      notes: ['Add email'],
+    }
+    const matchedSkip: ImportPreviewAction = {
+      action: 'skip',
+      row: sampleRow({ rowNumber: 3 }),
+      reason: 'Already up to date',
+      playerId: 'p2',
+    }
+    const create: ImportPreviewAction = {
+      action: 'create',
+      row: sampleRow({ rowNumber: 4 }),
+    }
+    const ambiguous: ImportPreviewAction = {
+      action: 'ambiguous',
+      row: sampleRow({ rowNumber: 5 }),
+      reason: 'Multiple players',
+      playerIds: ['a', 'b'],
+    }
+
+    expect(playerIdForRegistration(update)).toBe('p1')
+    expect(playerIdForRegistration(matchedSkip)).toBe('p2')
+    expect(playerIdForRegistration(create)).toBeNull()
+    expect(playerIdForRegistration(ambiguous)).toBeNull()
+  })
+
+  it('counts new vs already-registered players for event imports', () => {
+    const actions: ImportPreviewAction[] = [
+      { action: 'create', row: sampleRow() },
+      {
+        action: 'update',
+        row: sampleRow({ rowNumber: 3, firstName: 'Alex' }),
+        playerId: 'existing-new',
+        notes: ['Add email'],
+      },
+      {
+        action: 'skip',
+        row: sampleRow({ rowNumber: 4, firstName: 'Sam' }),
+        reason: 'Already up to date',
+        playerId: 'already-on-event',
+      },
+      {
+        action: 'skip',
+        row: sampleRow({ rowNumber: 5, firstName: 'Pat' }),
+        reason: 'Already up to date',
+        playerId: 'already-on-event',
+      },
+      {
+        action: 'ambiguous',
+        row: sampleRow({ rowNumber: 6 }),
+        reason: 'dup',
+        playerIds: ['x', 'y'],
+      },
+      {
+        action: 'skip',
+        row: sampleRow({ rowNumber: 7 }),
+        reason: 'Missing first or last name',
+      },
+    ]
+
+    const summary = summarizeRegistrationPreview(
+      actions,
+      new Set(['already-on-event'])
+    )
+    expect(summary).toEqual({ register: 2, alreadyRegistered: 1 })
+  })
+
+  it('without event-linked players treats matched skips as new registrations', () => {
+    const actions: ImportPreviewAction[] = [
+      {
+        action: 'skip',
+        row: sampleRow(),
+        reason: 'Already up to date',
+        playerId: 'p1',
+      },
+    ]
+    expect(summarizeRegistrationPreview(actions, new Set())).toEqual({
+      register: 1,
+      alreadyRegistered: 0,
+    })
   })
 })

--- a/app/__tests__/teamlinkt-import.test.ts
+++ b/app/__tests__/teamlinkt-import.test.ts
@@ -219,6 +219,15 @@ describe('event-scoped registration preview', () => {
     expect(playerIdForRegistration(matchedSkip)).toBe('p2')
     expect(playerIdForRegistration(create)).toBeNull()
     expect(playerIdForRegistration(ambiguous)).toBeNull()
+    expect(
+      playerIdForRegistration({
+        action: 'skip',
+        row: sampleRow({ rowNumber: 8 }),
+        reason: 'Matched a merged player record',
+        playerId: 'merged-p',
+        excludeFromRegistration: true,
+      })
+    ).toBeNull()
   })
 
   it('counts new vs already-registered players for event imports', () => {

--- a/app/api/events/[id]/registrations/[registrationId]/route.ts
+++ b/app/api/events/[id]/registrations/[registrationId]/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import { updateRegistrationDraftGroup } from '@/app/lib/events/mutations'
+import { getEvent } from '@/app/lib/events/queries'
+import { parseDraftGroup } from '@/app/lib/events/types'
+
+type RouteContext = {
+  params: Promise<{ id: string; registrationId: string }>
+}
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id, registrationId } = await context.params
+    const event = await getEvent(id)
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    }
+
+    const body = (await request.json()) as { draftGroup?: unknown }
+    if (!('draftGroup' in body)) {
+      return NextResponse.json({ error: 'draftGroup is required' }, { status: 400 })
+    }
+
+    // Validate early for clear API errors
+    parseDraftGroup(body.draftGroup)
+
+    const registration = await updateRegistrationDraftGroup(
+      id,
+      registrationId,
+      body.draftGroup
+    )
+    return NextResponse.json({ registration })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to update registration'
+    const status =
+      message === 'Registration not found'
+        ? 404
+        : message.includes('draftGroup')
+          ? 400
+          : 400
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/events/[id]/registrations/[registrationId]/route.ts
+++ b/app/api/events/[id]/registrations/[registrationId]/route.ts
@@ -44,7 +44,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
         ? 404
         : message.includes('draftGroup')
           ? 400
-          : 400
+          : 500
     return NextResponse.json({ error: message }, { status })
   }
 }

--- a/app/api/events/[id]/registrations/route.ts
+++ b/app/api/events/[id]/registrations/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import { getEvent, listEventRegistrations } from '@/app/lib/events/queries'
+
+type RouteContext = { params: Promise<{ id: string }> }
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id } = await context.params
+    const event = await getEvent(id)
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    }
+
+    const registrations = await listEventRegistrations(id)
+    return NextResponse.json({ registrations })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to list registrations'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import { updateEvent } from '@/app/lib/events/mutations'
+import { getEvent } from '@/app/lib/events/queries'
+import { eventTypeLabel, isValidEventType } from '@/app/lib/events/types'
+
+type RouteContext = { params: Promise<{ id: string }> }
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id } = await context.params
+    const event = await getEvent(id)
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    }
+    return NextResponse.json({
+      event: {
+        ...event,
+        eventTypeLabel: eventTypeLabel(event.eventType),
+      },
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to load event'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id } = await context.params
+    const body = (await request.json()) as {
+      name?: string
+      eventDate?: string
+      eventType?: string | null
+      notes?: string | null
+    }
+
+    if (
+      body.eventType != null &&
+      body.eventType !== '' &&
+      !isValidEventType(body.eventType)
+    ) {
+      return NextResponse.json({ error: 'Invalid eventType' }, { status: 400 })
+    }
+
+    const event = await updateEvent(id, body)
+    return NextResponse.json({
+      event: {
+        ...event,
+        eventTypeLabel: eventTypeLabel(event.eventType),
+      },
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to update event'
+    const status = message === 'Event not found' ? 404 : 400
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import { createEvent } from '@/app/lib/events/mutations'
+import { listEvents } from '@/app/lib/events/queries'
+import { isValidEventType } from '@/app/lib/events/types'
+
+export async function GET(request: NextRequest) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const events = await listEvents()
+    return NextResponse.json({ events })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to list events'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const body = (await request.json()) as {
+      name?: string
+      eventDate?: string
+      eventType?: string | null
+      notes?: string | null
+    }
+
+    if (!body.name?.trim()) {
+      return NextResponse.json({ error: 'name is required' }, { status: 400 })
+    }
+    if (!body.eventDate?.trim()) {
+      return NextResponse.json({ error: 'eventDate is required' }, { status: 400 })
+    }
+    if (
+      body.eventType != null &&
+      body.eventType !== '' &&
+      !isValidEventType(body.eventType)
+    ) {
+      return NextResponse.json({ error: 'Invalid eventType' }, { status: 400 })
+    }
+
+    const event = await createEvent({
+      name: body.name,
+      eventDate: body.eventDate,
+      eventType: body.eventType,
+      notes: body.notes,
+    })
+
+    return NextResponse.json({ event }, { status: 201 })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to create event'
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+}

--- a/app/api/players/import/route.ts
+++ b/app/api/players/import/route.ts
@@ -24,6 +24,7 @@ async function readJsonBody(request: NextRequest): Promise<
         filename?: string
         dryRun?: boolean
         profileFields?: ImportProfileFieldsMode
+        eventId?: string | null
       }
     }
   | { ok: false; error: string }
@@ -34,6 +35,7 @@ async function readJsonBody(request: NextRequest): Promise<
       filename?: string
       dryRun?: boolean
       profileFields?: ImportProfileFieldsMode
+      eventId?: string | null
     }
     return { ok: true, body }
   } catch {
@@ -52,13 +54,14 @@ export async function POST(request: NextRequest) {
     }
     const body = parsedBody.body
     const options = { profileFields: parseProfileFieldsMode(body.profileFields) }
+    const eventId = body.eventId?.trim() || null
 
     if (!body.csv?.trim()) {
       return NextResponse.json({ error: 'csv is required' }, { status: 400 })
     }
 
     if (body.dryRun !== false) {
-      const preview = await previewTeamlinktImport(body.csv, options)
+      const preview = await previewTeamlinktImport(body.csv, options, eventId)
       if (preview.error) {
         return NextResponse.json({ error: preview.error }, { status: 400 })
       }
@@ -72,6 +75,7 @@ export async function POST(request: NextRequest) {
           update: preview.actions.filter((a) => a.action === 'update').length,
           skip: preview.actions.filter((a) => a.action === 'skip').length,
           ambiguous: preview.actions.filter((a) => a.action === 'ambiguous').length,
+          ...(preview.registrationSummary ?? {}),
         },
       })
     }
@@ -81,6 +85,7 @@ export async function POST(request: NextRequest) {
       filename: body.filename?.trim() || 'teamlinkt.csv',
       actor: session.email,
       options,
+      eventId,
     })
 
     return NextResponse.json({ dryRun: false, ...result })

--- a/app/components/TopNav.tsx
+++ b/app/components/TopNav.tsx
@@ -46,6 +46,9 @@ export default function TopNav() {
         <Link href={withDevMode('/players', devMode)} className="hover:underline">
           Players
         </Link>
+        <Link href={withDevMode('/events', devMode)} className="hover:underline">
+          Events
+        </Link>
         {devMode && (
           <>
             <Link href={withDevMode('/tournament', devMode)} className="hover:underline">

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -1,5 +1,6 @@
 import {
   boolean,
+  date,
   integer,
   jsonb,
   pgTable,
@@ -65,12 +66,28 @@ export const playerAliases = pgTable(
   ]
 )
 
+export const events = pgTable(
+  'events',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    name: text('name').notNull(),
+    eventDate: date('event_date').notNull(),
+    /** Canonical: tournament | open_gym | other */
+    eventType: text('event_type').notNull().default('tournament'),
+    notes: text('notes'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index('events_event_date_idx').on(table.eventDate)]
+)
+
 export const importBatches = pgTable('import_batches', {
   id: uuid('id').defaultRandom().primaryKey(),
   filename: text('filename').notNull(),
   actor: text('actor').notNull(),
   rowCount: integer('row_count').notNull().default(0),
   summary: jsonb('summary').$type<Record<string, unknown>>().notNull().default({}),
+  eventId: uuid('event_id').references(() => events.id, { onDelete: 'set null' }),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 })
 
@@ -92,4 +109,31 @@ export const playerChanges = pgTable(
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [index('player_changes_player_id_idx').on(table.playerId)]
+)
+
+export const eventRegistrations = pgTable(
+  'event_registrations',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    eventId: uuid('event_id')
+      .notNull()
+      .references(() => events.id, { onDelete: 'cascade' }),
+    playerId: uuid('player_id')
+      .notNull()
+      .references(() => players.id, { onDelete: 'cascade' }),
+    /** Canonical for v1: registered (room for attended/cancelled later) */
+    status: text('status').notNull().default('registered'),
+    /** Positive int draft bucket; null = unassigned */
+    draftGroup: integer('draft_group'),
+    importBatchId: uuid('import_batch_id').references(() => importBatches.id, {
+      onDelete: 'set null',
+    }),
+    registeredAt: timestamp('registered_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('event_registrations_event_player_uidx').on(table.eventId, table.playerId),
+    index('event_registrations_event_id_idx').on(table.eventId),
+    index('event_registrations_player_id_idx').on(table.playerId),
+  ]
 )

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -1,0 +1,602 @@
+'use client'
+
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { withDevMode } from '@/app/lib/devMode'
+import { useDevMode } from '@/app/hooks/useDevMode'
+import { genderGroup } from '@/app/lib/players/gender'
+import { SKILL_LEVELS, skillLevelLabel } from '@/app/lib/players/skill'
+import type { EventRegistrationListItem } from '@/app/lib/events/types'
+
+type EventDetail = {
+  id: string
+  name: string
+  eventDate: string
+  eventType: string
+  eventTypeLabel: string
+  notes: string | null
+}
+
+type ImportAction = {
+  action: 'create' | 'update' | 'skip' | 'ambiguous'
+  row: {
+    rowNumber: number
+    firstName: string
+    lastName: string
+    email: string | null
+    jerseyNumber: number | null
+    skillLevel: number | null
+  }
+  notes?: string[]
+  reason?: string
+  playerId?: string
+}
+
+function formatDisplayDate(isoDate: string): string {
+  const d = new Date(`${isoDate}T12:00:00`)
+  if (Number.isNaN(d.getTime())) return isoDate
+  return d.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+function SkillStyledText(props: {
+  skillLevel: number | null
+  children: ReactNode
+}) {
+  const { skillLevel, children } = props
+  if (skillLevel === 1) {
+    return <span className="italic">({children})</span>
+  }
+  if (skillLevel === 3) {
+    return <span className="font-bold">{children}</span>
+  }
+  if (skillLevel === 4) {
+    return <span className="font-bold underline">{children}</span>
+  }
+  return <span>{children}</span>
+}
+
+function genderRowClass(gender: string | null): string {
+  const group = genderGroup(gender)
+  if (group === 'w_nb_o') return 'bg-rose-50/70 text-gray-900'
+  if (group === 'men') return 'bg-sky-50/70 text-gray-900'
+  return 'text-gray-900'
+}
+
+export default function EventTrackerPage() {
+  const params = useParams()
+  const eventId = String(params.id ?? '')
+  const { devMode } = useDevMode()
+
+  const [event, setEvent] = useState<EventDetail | null>(null)
+  const [registrations, setRegistrations] = useState<EventRegistrationListItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
+  const [draftFilter, setDraftFilter] = useState<'all' | 'unassigned' | number>('all')
+  const [savingId, setSavingId] = useState<string | null>(null)
+  const [maxGroup, setMaxGroup] = useState(4)
+
+  const [importOpen, setImportOpen] = useState(false)
+  const [importCsv, setImportCsv] = useState('')
+  const [importFilename, setImportFilename] = useState('teamlinkt.csv')
+  const [importProfileFields, setImportProfileFields] = useState<
+    'skip' | 'fill_blank' | 'overwrite'
+  >('skip')
+  const [importPreview, setImportPreview] = useState<{
+    actions: ImportAction[]
+    summary: Record<string, number>
+  } | null>(null)
+  const [importBusy, setImportBusy] = useState(false)
+  const [formError, setFormError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    if (!eventId) return
+    setLoading(true)
+    setError(null)
+    try {
+      const [eventRes, regRes] = await Promise.all([
+        fetch(`/api/events/${eventId}`),
+        fetch(`/api/events/${eventId}/registrations`),
+      ])
+      const eventData = await eventRes.json()
+      const regData = await regRes.json()
+      if (!eventRes.ok) throw new Error(eventData.error || 'Failed to load event')
+      if (!regRes.ok) throw new Error(regData.error || 'Failed to load roster')
+      setEvent(eventData.event)
+      setRegistrations(regData.registrations)
+      const groups = (regData.registrations as EventRegistrationListItem[])
+        .map((r) => r.draftGroup)
+        .filter((g): g is number => g != null)
+      if (groups.length > 0) {
+        setMaxGroup((prev) => Math.max(prev, ...groups))
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load event')
+    } finally {
+      setLoading(false)
+    }
+  }, [eventId])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const counts = useMemo(() => {
+    const bySkill: Record<string, number> = { unset: 0 }
+    for (const level of Object.keys(SKILL_LEVELS)) {
+      bySkill[level] = 0
+    }
+    let wNbO = 0
+    let men = 0
+    let genderUnset = 0
+    let unassigned = 0
+    let assigned = 0
+    const byGroup = new Map<number, number>()
+
+    for (const r of registrations) {
+      if (r.skillLevel == null) bySkill.unset++
+      else bySkill[String(r.skillLevel)] = (bySkill[String(r.skillLevel)] ?? 0) + 1
+
+      const g = genderGroup(r.gender)
+      if (g === 'w_nb_o') wNbO++
+      else if (g === 'men') men++
+      else genderUnset++
+
+      if (r.draftGroup == null) unassigned++
+      else {
+        assigned++
+        byGroup.set(r.draftGroup, (byGroup.get(r.draftGroup) ?? 0) + 1)
+      }
+    }
+
+    return {
+      total: registrations.length,
+      bySkill,
+      wNbO,
+      men,
+      genderUnset,
+      unassigned,
+      assigned,
+      byGroup,
+    }
+  }, [registrations])
+
+  const groupOptions = useMemo(() => {
+    const fromData = registrations
+      .map((r) => r.draftGroup)
+      .filter((g): g is number => g != null)
+    const max = Math.max(maxGroup, ...(fromData.length ? fromData : [0]))
+    return Array.from({ length: max }, (_, i) => i + 1)
+  }, [registrations, maxGroup])
+
+  const filtered = useMemo(() => {
+    if (draftFilter === 'all') return registrations
+    if (draftFilter === 'unassigned') {
+      return registrations.filter((r) => r.draftGroup == null)
+    }
+    return registrations.filter((r) => r.draftGroup === draftFilter)
+  }, [registrations, draftFilter])
+
+  async function setDraftGroup(registrationId: string, draftGroup: number | null) {
+    setSavingId(registrationId)
+    setFormError(null)
+    try {
+      const res = await fetch(
+        `/api/events/${eventId}/registrations/${registrationId}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ draftGroup }),
+        }
+      )
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to update draft group')
+      setRegistrations((prev) =>
+        prev.map((r) =>
+          r.id === registrationId
+            ? { ...r, draftGroup: data.registration.draftGroup }
+            : r
+        )
+      )
+      if (draftGroup != null) {
+        setMaxGroup((prev) => Math.max(prev, draftGroup))
+      }
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Failed to update draft group')
+    } finally {
+      setSavingId(null)
+    }
+  }
+
+  async function previewImport() {
+    setImportBusy(true)
+    setFormError(null)
+    try {
+      const res = await fetch('/api/players/import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          csv: importCsv,
+          filename: importFilename,
+          dryRun: true,
+          profileFields: importProfileFields,
+          eventId,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Preview failed')
+      setImportPreview({
+        actions: data.actions as ImportAction[],
+        summary: data.summary as Record<string, number>,
+      })
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Preview failed')
+    } finally {
+      setImportBusy(false)
+    }
+  }
+
+  async function commitImport() {
+    setImportBusy(true)
+    setFormError(null)
+    try {
+      const res = await fetch('/api/players/import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          csv: importCsv,
+          filename: importFilename,
+          dryRun: false,
+          profileFields: importProfileFields,
+          eventId,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(String(data.error || 'Import failed'))
+      const summary = data.summary as Record<string, number>
+      setImportOpen(false)
+      setImportCsv('')
+      setImportPreview(null)
+      setImportProfileFields('skip')
+      setMessage(
+        `Import done: ${summary.created ?? 0} created, ${summary.updated ?? 0} updated, ${summary.register ?? 0} registered, ${summary.alreadyRegistered ?? 0} already registered`
+      )
+      await load()
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Import failed')
+    } finally {
+      setImportBusy(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-6xl p-6 text-sm text-gray-600">Loading…</div>
+    )
+  }
+
+  if (!event) {
+    return (
+      <div className="mx-auto max-w-6xl p-6 space-y-3">
+        <p className="text-sm text-red-600">{error || 'Event not found'}</p>
+        <Link
+          href={withDevMode('/events', devMode)}
+          className="text-sm text-blue-700 hover:underline"
+        >
+          ← Events
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl p-6 space-y-6 text-gray-900">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <Link
+            href={withDevMode('/events', devMode)}
+            className="text-sm text-blue-700 hover:underline"
+          >
+            ← Events
+          </Link>
+          <h1 className="text-2xl font-semibold mt-1">{event.name}</h1>
+          <p className="text-sm text-gray-600">
+            {formatDisplayDate(event.eventDate)} · {event.eventTypeLabel}
+          </p>
+          {event.notes ? (
+            <p className="text-sm text-gray-600 mt-1">{event.notes}</p>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          className="rounded bg-blue-600 px-3 py-2 text-sm text-white"
+          onClick={() => {
+            setImportOpen(true)
+            setImportPreview(null)
+            setImportProfileFields('skip')
+            setFormError(null)
+          }}
+        >
+          Import TeamLinkt CSV
+        </button>
+      </div>
+
+      {error ? <p className="text-sm text-red-600">{error}</p> : null}
+      {message ? <p className="text-sm text-green-700">{message}</p> : null}
+      {formError && !importOpen ? (
+        <p className="text-sm text-red-600">{formError}</p>
+      ) : null}
+
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4 text-sm">
+        <div className="rounded border border-gray-200 px-3 py-2">
+          <div className="text-gray-500">Total</div>
+          <div className="text-xl font-semibold">{counts.total}</div>
+        </div>
+        <div className="rounded border border-gray-200 px-3 py-2">
+          <div className="text-gray-500">Gender</div>
+          <div>
+            W/NB/O {counts.wNbO} · M {counts.men}
+            {counts.genderUnset ? ` · — ${counts.genderUnset}` : ''}
+          </div>
+        </div>
+        <div className="rounded border border-gray-200 px-3 py-2">
+          <div className="text-gray-500">Skill</div>
+          <div className="text-xs space-y-0.5">
+            {Object.entries(SKILL_LEVELS).map(([level, label]) => (
+              <div key={level}>
+                {label}: {counts.bySkill[level] ?? 0}
+              </div>
+            ))}
+            <div>Unset: {counts.bySkill.unset}</div>
+          </div>
+        </div>
+        <div className="rounded border border-gray-200 px-3 py-2">
+          <div className="text-gray-500">Draft buckets</div>
+          <div>
+            Unassigned {counts.unassigned} · Assigned {counts.assigned}
+          </div>
+          {groupOptions.length > 0 ? (
+            <div className="text-xs mt-1 text-gray-600">
+              {groupOptions
+                .map((g) => `G${g}: ${counts.byGroup.get(g) ?? 0}`)
+                .join(' · ')}
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <label className="text-sm flex items-center gap-2">
+          <span className="text-gray-600">Filter</span>
+          <select
+            className="rounded border border-gray-300 px-2 py-1"
+            value={
+              draftFilter === 'all' || draftFilter === 'unassigned'
+                ? draftFilter
+                : String(draftFilter)
+            }
+            onChange={(e) => {
+              const v = e.target.value
+              if (v === 'all' || v === 'unassigned') setDraftFilter(v)
+              else setDraftFilter(Number.parseInt(v, 10))
+            }}
+          >
+            <option value="all">All</option>
+            <option value="unassigned">Unassigned</option>
+            {groupOptions.map((g) => (
+              <option key={g} value={g}>
+                Group {g}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button
+          type="button"
+          className="rounded border px-2 py-1 text-sm"
+          onClick={() => setMaxGroup((n) => n + 1)}
+        >
+          Add group {maxGroup + 1}
+        </button>
+      </div>
+
+      <div className="overflow-x-auto rounded border border-gray-200">
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-50 text-left">
+            <tr>
+              <th className="px-3 py-2 font-medium">Name</th>
+              <th className="px-3 py-2 font-medium">Skill</th>
+              <th className="px-3 py-2 font-medium">Gender</th>
+              <th className="px-3 py-2 font-medium">Email</th>
+              <th className="px-3 py-2 font-medium">Draft group</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-3 py-6 text-center text-gray-500">
+                  {registrations.length === 0
+                    ? 'No registrations yet. Import a TeamLinkt CSV for this event.'
+                    : 'No players match this filter.'}
+                </td>
+              </tr>
+            ) : (
+              filtered.map((r) => (
+                <tr key={r.id} className={`border-t border-gray-100 ${genderRowClass(r.gender)}`}>
+                  <td className="px-3 py-2">
+                    <SkillStyledText skillLevel={r.skillLevel}>
+                      {r.nickname || `${r.firstName} ${r.lastName}`}
+                    </SkillStyledText>
+                    <div className="text-xs text-gray-500">
+                      {r.firstName} {r.lastName}
+                    </div>
+                  </td>
+                  <td className="px-3 py-2">
+                    {r.skillLevel != null ? skillLevelLabel(r.skillLevel) : '—'}
+                  </td>
+                  <td className="px-3 py-2">{r.genderGroupLabel}</td>
+                  <td className="px-3 py-2 text-xs">{r.primaryEmail ?? '—'}</td>
+                  <td className="px-3 py-2">
+                    <select
+                      className="rounded border border-gray-300 px-2 py-1 disabled:opacity-40"
+                      disabled={savingId === r.id}
+                      value={r.draftGroup == null ? '' : String(r.draftGroup)}
+                      onChange={(e) => {
+                        const v = e.target.value
+                        void setDraftGroup(r.id, v === '' ? null : Number.parseInt(v, 10))
+                      }}
+                    >
+                      <option value="">Unassigned</option>
+                      {groupOptions.map((g) => (
+                        <option key={g} value={g}>
+                          Group {g}
+                        </option>
+                      ))}
+                    </select>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {importOpen ? (
+        <div className="fixed inset-0 z-40 bg-black/40 flex items-center justify-center p-4">
+          <div className="bg-white rounded-lg shadow-xl max-w-3xl w-full max-h-[90vh] overflow-y-auto p-6 space-y-4 text-gray-900">
+            <h2 className="text-lg font-semibold text-gray-900">
+              Import TeamLinkt CSV for {event.name}
+            </h2>
+            <p className="text-sm text-gray-600">
+              Players are upserted as usual, and each matched/created player is
+              registered for this event. Re-imports keep draft group assignments.
+            </p>
+            <label className="block text-sm">
+              <span className="text-gray-600">Existing players: skill / gender / jersey</span>
+              <select
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+                value={importProfileFields}
+                onChange={(e) => {
+                  setImportProfileFields(
+                    e.target.value as 'skip' | 'fill_blank' | 'overwrite'
+                  )
+                  setImportPreview(null)
+                }}
+              >
+                <option value="skip">Skip (keep current values)</option>
+                <option value="fill_blank">Fill blanks only</option>
+                <option value="overwrite">Overwrite from CSV</option>
+              </select>
+            </label>
+            <label className="block text-sm">
+              <span className="text-gray-600">Filename</span>
+              <input
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+                value={importFilename}
+                onChange={(e) => setImportFilename(e.target.value)}
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="text-gray-600">CSV file</span>
+              <input
+                type="file"
+                accept=".csv,text/csv"
+                className="mt-1 block w-full text-sm"
+                onChange={(e) => {
+                  const file = e.target.files?.[0]
+                  if (!file) return
+                  setImportFilename(file.name)
+                  void file.text().then((text) => {
+                    setImportCsv(text)
+                    setImportPreview(null)
+                  })
+                }}
+              />
+            </label>
+            <textarea
+              className="w-full h-40 rounded border border-gray-300 px-3 py-2 font-mono text-xs"
+              value={importCsv}
+              onChange={(e) => {
+                setImportCsv(e.target.value)
+                setImportPreview(null)
+              }}
+              placeholder="Or paste CSV contents here…"
+            />
+            {formError ? <p className="text-sm text-red-600">{formError}</p> : null}
+            {importPreview ? (
+              <div className="space-y-2 text-sm">
+                <p>
+                  Preview: {importPreview.summary.create} create,{' '}
+                  {importPreview.summary.update} update, {importPreview.summary.skip} skip,{' '}
+                  {importPreview.summary.ambiguous} ambiguous
+                  {typeof importPreview.summary.register === 'number' ? (
+                    <>
+                      ; {importPreview.summary.register} will register,{' '}
+                      {importPreview.summary.alreadyRegistered ?? 0} already registered
+                    </>
+                  ) : null}
+                </p>
+                <div className="max-h-48 overflow-y-auto border rounded">
+                  <table className="min-w-full text-xs">
+                    <thead className="bg-gray-50">
+                      <tr>
+                        <th className="px-2 py-1 text-left">Row</th>
+                        <th className="px-2 py-1 text-left">Action</th>
+                        <th className="px-2 py-1 text-left">Name</th>
+                        <th className="px-2 py-1 text-left">Detail</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {importPreview.actions.map((a, idx) => (
+                        <tr key={idx} className="border-t">
+                          <td className="px-2 py-1">{a.row.rowNumber}</td>
+                          <td className="px-2 py-1">{a.action}</td>
+                          <td className="px-2 py-1">
+                            {a.row.firstName} {a.row.lastName}
+                          </td>
+                          <td className="px-2 py-1">
+                            {a.notes?.join('; ') || a.reason || '—'}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            ) : null}
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                className="rounded border px-3 py-2 text-sm"
+                onClick={() => setImportOpen(false)}
+              >
+                Close
+              </button>
+              <button
+                type="button"
+                disabled={importBusy || !importCsv.trim()}
+                className="rounded border px-3 py-2 text-sm disabled:opacity-40"
+                onClick={() => void previewImport()}
+              >
+                Dry run
+              </button>
+              <button
+                type="button"
+                disabled={importBusy || !importPreview}
+                className="rounded bg-blue-600 px-3 py-2 text-sm text-white disabled:opacity-40"
+                onClick={() => void commitImport()}
+              >
+                Commit import
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -2,7 +2,14 @@
 
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
+import {
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
 import { withDevMode } from '@/app/lib/devMode'
 import { useDevMode } from '@/app/hooks/useDevMode'
 import { genderGroup } from '@/app/lib/players/gender'
@@ -69,6 +76,18 @@ function genderRowClass(gender: string | null): string {
 }
 
 export default function EventTrackerPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="mx-auto max-w-6xl p-6 text-sm text-gray-600">Loading…</div>
+      }
+    >
+      <EventTrackerPageContent />
+    </Suspense>
+  )
+}
+
+function EventTrackerPageContent() {
   const params = useParams()
   const eventId = String(params.id ?? '')
   const { devMode } = useDevMode()

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,0 +1,213 @@
+'use client'
+
+import Link from 'next/link'
+import { useCallback, useEffect, useState } from 'react'
+import { withDevMode } from '@/app/lib/devMode'
+import { useDevMode } from '@/app/hooks/useDevMode'
+import { EVENT_TYPES, type EventListItem } from '@/app/lib/events/types'
+
+function formatDisplayDate(isoDate: string): string {
+  const d = new Date(`${isoDate}T12:00:00`)
+  if (Number.isNaN(d.getTime())) return isoDate
+  return d.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+export default function EventsPage() {
+  const { devMode } = useDevMode()
+  const [events, setEvents] = useState<EventListItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [createOpen, setCreateOpen] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [formError, setFormError] = useState<string | null>(null)
+  const [name, setName] = useState('')
+  const [eventDate, setEventDate] = useState('')
+  const [eventType, setEventType] = useState<string>('tournament')
+  const [notes, setNotes] = useState('')
+
+  const loadEvents = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/events')
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to load events')
+      setEvents(data.events)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load events')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadEvents()
+  }, [loadEvents])
+
+  async function createEvent() {
+    setSaving(true)
+    setFormError(null)
+    try {
+      const res = await fetch('/api/events', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name,
+          eventDate,
+          eventType,
+          notes: notes.trim() || null,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to create event')
+      setCreateOpen(false)
+      setName('')
+      setEventDate('')
+      setEventType('tournament')
+      setNotes('')
+      await loadEvents()
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Failed to create event')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl p-6 space-y-6 text-gray-900">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold">Events</h1>
+          <p className="text-sm text-gray-600 mt-1">
+            Track registrations per event for team-making and historical insights.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="rounded bg-blue-600 px-3 py-2 text-sm text-white"
+          onClick={() => {
+            setCreateOpen(true)
+            setFormError(null)
+          }}
+        >
+          New event
+        </button>
+      </div>
+
+      {error ? <p className="text-sm text-red-600">{error}</p> : null}
+
+      {loading ? (
+        <p className="text-sm text-gray-600">Loading…</p>
+      ) : events.length === 0 ? (
+        <p className="text-sm text-gray-600">
+          No events yet. Create one (e.g. August 8 tournament) to import TeamLinkt
+          registrations.
+        </p>
+      ) : (
+        <div className="overflow-x-auto rounded border border-gray-200">
+          <table className="min-w-full text-sm">
+            <thead className="bg-gray-50 text-left">
+              <tr>
+                <th className="px-3 py-2 font-medium">Date</th>
+                <th className="px-3 py-2 font-medium">Name</th>
+                <th className="px-3 py-2 font-medium">Type</th>
+                <th className="px-3 py-2 font-medium">Registrations</th>
+              </tr>
+            </thead>
+            <tbody>
+              {events.map((event) => (
+                <tr key={event.id} className="border-t border-gray-100 hover:bg-gray-50">
+                  <td className="px-3 py-2 whitespace-nowrap">
+                    {formatDisplayDate(event.eventDate)}
+                  </td>
+                  <td className="px-3 py-2">
+                    <Link
+                      href={withDevMode(`/events/${event.id}`, devMode)}
+                      className="text-blue-700 hover:underline font-medium"
+                    >
+                      {event.name}
+                    </Link>
+                  </td>
+                  <td className="px-3 py-2">{event.eventTypeLabel}</td>
+                  <td className="px-3 py-2">{event.registrationCount}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {createOpen ? (
+        <div className="fixed inset-0 z-40 bg-black/40 flex items-center justify-center p-4">
+          <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-6 space-y-4">
+            <h2 className="text-lg font-semibold">New event</h2>
+            <label className="block text-sm">
+              <span className="text-gray-600">Name</span>
+              <input
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="August 8 Tournament"
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="text-gray-600">Date</span>
+              <input
+                type="date"
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+                value={eventDate}
+                onChange={(e) => setEventDate(e.target.value)}
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="text-gray-600">Type</span>
+              <select
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+                value={eventType}
+                onChange={(e) => setEventType(e.target.value)}
+              >
+                {Object.entries(EVENT_TYPES).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="block text-sm">
+              <span className="text-gray-600">Notes (optional)</span>
+              <textarea
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+                rows={3}
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+              />
+            </label>
+            {formError ? <p className="text-sm text-red-600">{formError}</p> : null}
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                className="rounded border px-3 py-2 text-sm"
+                onClick={() => setCreateOpen(false)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                disabled={saving || !name.trim() || !eventDate}
+                className="rounded bg-blue-600 px-3 py-2 text-sm text-white disabled:opacity-40"
+                onClick={() => void createEvent()}
+              >
+                Create
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useCallback, useEffect, useState } from 'react'
+import { Suspense, useCallback, useEffect, useState } from 'react'
 import { withDevMode } from '@/app/lib/devMode'
 import { useDevMode } from '@/app/hooks/useDevMode'
 import { EVENT_TYPES, type EventListItem } from '@/app/lib/events/types'
@@ -18,6 +18,18 @@ function formatDisplayDate(isoDate: string): string {
 }
 
 export default function EventsPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="mx-auto max-w-5xl p-6 text-sm text-gray-600">Loading…</div>
+      }
+    >
+      <EventsPageContent />
+    </Suspense>
+  )
+}
+
+function EventsPageContent() {
   const { devMode } = useDevMode()
   const [events, setEvents] = useState<EventListItem[]>([])
   const [loading, setLoading] = useState(true)

--- a/app/lib/events/mutations.ts
+++ b/app/lib/events/mutations.ts
@@ -1,0 +1,175 @@
+import { and, eq } from 'drizzle-orm'
+import { getDb } from '@/app/lib/db'
+import { eventRegistrations, events } from '@/app/db/schema'
+import {
+  isValidEventType,
+  parseDraftGroup,
+  type EventRecord,
+  type EventType,
+} from '@/app/lib/events/types'
+
+function parseEventDate(value: string): string {
+  const trimmed = value.trim()
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    throw new Error('eventDate must be YYYY-MM-DD')
+  }
+  const d = new Date(`${trimmed}T00:00:00.000Z`)
+  if (Number.isNaN(d.getTime())) {
+    throw new Error('eventDate is not a valid date')
+  }
+  return trimmed
+}
+
+export async function createEvent(input: {
+  name: string
+  eventDate: string
+  eventType?: string | null
+  notes?: string | null
+}): Promise<EventRecord> {
+  const db = getDb()
+  const name = input.name.trim()
+  if (!name) throw new Error('name is required')
+
+  const eventDate = parseEventDate(input.eventDate)
+  let eventType: EventType = 'tournament'
+  if (input.eventType != null && input.eventType !== '') {
+    if (!isValidEventType(input.eventType)) throw new Error('Invalid eventType')
+    eventType = input.eventType
+  }
+
+  const notes = input.notes?.trim() ? input.notes.trim() : null
+
+  const [created] = await db
+    .insert(events)
+    .values({ name, eventDate, eventType, notes })
+    .returning()
+
+  return created
+}
+
+export async function updateEvent(
+  id: string,
+  patch: {
+    name?: string
+    eventDate?: string
+    eventType?: string | null
+    notes?: string | null
+  }
+): Promise<EventRecord> {
+  const db = getDb()
+  const updates: {
+    name?: string
+    eventDate?: string
+    eventType?: string
+    notes?: string | null
+    updatedAt: Date
+  } = { updatedAt: new Date() }
+
+  if (patch.name !== undefined) {
+    const name = patch.name.trim()
+    if (!name) throw new Error('name is required')
+    updates.name = name
+  }
+  if (patch.eventDate !== undefined) {
+    updates.eventDate = parseEventDate(patch.eventDate)
+  }
+  if (patch.eventType !== undefined) {
+    if (patch.eventType == null || patch.eventType === '') {
+      updates.eventType = 'tournament'
+    } else if (!isValidEventType(patch.eventType)) {
+      throw new Error('Invalid eventType')
+    } else {
+      updates.eventType = patch.eventType
+    }
+  }
+  if (patch.notes !== undefined) {
+    updates.notes = patch.notes?.trim() ? patch.notes.trim() : null
+  }
+
+  const [updated] = await db
+    .update(events)
+    .set(updates)
+    .where(eq(events.id, id))
+    .returning()
+
+  if (!updated) throw new Error('Event not found')
+  return updated
+}
+
+/**
+ * Create registration if missing; if present only refresh importBatchId / updatedAt.
+ * Never clears draftGroup.
+ */
+export async function upsertEventRegistration(input: {
+  eventId: string
+  playerId: string
+  importBatchId?: string | null
+}): Promise<{ created: boolean; id: string }> {
+  const db = getDb()
+  const [existing] = await db
+    .select({
+      id: eventRegistrations.id,
+    })
+    .from(eventRegistrations)
+    .where(
+      and(
+        eq(eventRegistrations.eventId, input.eventId),
+        eq(eventRegistrations.playerId, input.playerId)
+      )
+    )
+    .limit(1)
+
+  if (existing) {
+    // Do not touch draftGroup on re-import
+    await db
+      .update(eventRegistrations)
+      .set({
+        importBatchId: input.importBatchId ?? null,
+        updatedAt: new Date(),
+      })
+      .where(eq(eventRegistrations.id, existing.id))
+    return { created: false, id: existing.id }
+  }
+
+  const [created] = await db
+    .insert(eventRegistrations)
+    .values({
+      eventId: input.eventId,
+      playerId: input.playerId,
+      status: 'registered',
+      draftGroup: null,
+      importBatchId: input.importBatchId ?? null,
+    })
+    .returning({ id: eventRegistrations.id })
+
+  return { created: true, id: created.id }
+}
+
+export async function updateRegistrationDraftGroup(
+  eventId: string,
+  registrationId: string,
+  draftGroupInput: unknown
+): Promise<{ id: string; draftGroup: number | null }> {
+  const draftGroup = parseDraftGroup(draftGroupInput)
+  if (draftGroup === undefined) {
+    throw new Error('draftGroup is required')
+  }
+
+  const db = getDb()
+  const [updated] = await db
+    .update(eventRegistrations)
+    .set({ draftGroup, updatedAt: new Date() })
+    .where(
+      and(
+        eq(eventRegistrations.id, registrationId),
+        eq(eventRegistrations.eventId, eventId)
+      )
+    )
+    .returning({
+      id: eventRegistrations.id,
+      draftGroup: eventRegistrations.draftGroup,
+    })
+
+  if (!updated) throw new Error('Registration not found')
+  return updated
+}

--- a/app/lib/events/mutations.ts
+++ b/app/lib/events/mutations.ts
@@ -8,13 +8,17 @@ import {
   type EventType,
 } from '@/app/lib/events/types'
 
-function parseEventDate(value: string): string {
+export function parseEventDate(value: string): string {
   const trimmed = value.trim()
   if (!/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
     throw new Error('eventDate must be YYYY-MM-DD')
   }
   const d = new Date(`${trimmed}T00:00:00.000Z`)
   if (Number.isNaN(d.getTime())) {
+    throw new Error('eventDate is not a valid date')
+  }
+  // Reject overflow dates that Date normalizes (e.g. 2026-02-31 → March)
+  if (d.toISOString().slice(0, 10) !== trimmed) {
     throw new Error('eventDate is not a valid date')
   }
   return trimmed

--- a/app/lib/events/queries.ts
+++ b/app/lib/events/queries.ts
@@ -1,0 +1,136 @@
+import { and, asc, count, desc, eq, inArray, sql } from 'drizzle-orm'
+import { getDb } from '@/app/lib/db'
+import {
+  eventRegistrations,
+  events,
+  playerEmails,
+  players,
+} from '@/app/db/schema'
+import {
+  eventTypeLabel,
+  type EventListItem,
+  type EventRecord,
+  type EventRegistrationListItem,
+} from '@/app/lib/events/types'
+import {
+  resolveNickname,
+  skillLevelLabel,
+} from '@/app/lib/players/skill'
+import { genderGroupLabel, genderLabel } from '@/app/lib/players/gender'
+
+export async function listEvents(): Promise<EventListItem[]> {
+  const db = getDb()
+  const rows = await db
+    .select({
+      id: events.id,
+      name: events.name,
+      eventDate: events.eventDate,
+      eventType: events.eventType,
+      notes: events.notes,
+      registrationCount: count(eventRegistrations.id),
+    })
+    .from(events)
+    .leftJoin(eventRegistrations, eq(eventRegistrations.eventId, events.id))
+    .groupBy(events.id)
+    .orderBy(desc(events.eventDate), asc(events.name))
+
+  return rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    eventDate: r.eventDate,
+    eventType: r.eventType,
+    eventTypeLabel: eventTypeLabel(r.eventType),
+    notes: r.notes,
+    registrationCount: Number(r.registrationCount),
+  }))
+}
+
+export async function getEvent(id: string): Promise<EventRecord | null> {
+  const db = getDb()
+  const [row] = await db.select().from(events).where(eq(events.id, id)).limit(1)
+  return row ?? null
+}
+
+export async function listEventRegistrations(
+  eventId: string
+): Promise<EventRegistrationListItem[]> {
+  const db = getDb()
+  const rows = await db
+    .select({
+      id: eventRegistrations.id,
+      eventId: eventRegistrations.eventId,
+      playerId: eventRegistrations.playerId,
+      status: eventRegistrations.status,
+      draftGroup: eventRegistrations.draftGroup,
+      registeredAt: eventRegistrations.registeredAt,
+      updatedAt: eventRegistrations.updatedAt,
+      firstName: players.firstName,
+      lastName: players.lastName,
+      rosterName: players.rosterName,
+      nickname: players.nickname,
+      jerseyNumber: players.jerseyNumber,
+      skillLevel: players.skillLevel,
+      gender: players.gender,
+    })
+    .from(eventRegistrations)
+    .innerJoin(players, eq(players.id, eventRegistrations.playerId))
+    .where(eq(eventRegistrations.eventId, eventId))
+    .orderBy(
+      sql`CASE WHEN ${eventRegistrations.draftGroup} IS NULL THEN 1 ELSE 0 END`,
+      asc(eventRegistrations.draftGroup),
+      sql`CASE WHEN ${players.skillLevel} IS NULL THEN 1 ELSE 0 END`,
+      desc(players.skillLevel),
+      asc(players.lastName),
+      asc(players.firstName)
+    )
+
+  if (rows.length === 0) return []
+
+  const playerIds = rows.map((r) => r.playerId)
+  const emails = await db
+    .select()
+    .from(playerEmails)
+    .where(inArray(playerEmails.playerId, playerIds))
+
+  const primaryByPlayer = new Map<string, string>()
+  for (const e of emails) {
+    if (e.isPrimary && !primaryByPlayer.has(e.playerId)) {
+      primaryByPlayer.set(e.playerId, e.email)
+    }
+  }
+  for (const e of emails) {
+    if (!primaryByPlayer.has(e.playerId)) {
+      primaryByPlayer.set(e.playerId, e.email)
+    }
+  }
+
+  return rows.map((r) => ({
+    id: r.id,
+    eventId: r.eventId,
+    playerId: r.playerId,
+    status: r.status,
+    draftGroup: r.draftGroup,
+    registeredAt: r.registeredAt,
+    updatedAt: r.updatedAt,
+    firstName: r.firstName,
+    lastName: r.lastName,
+    rosterName: r.rosterName,
+    nickname: resolveNickname(r.nickname, r.firstName, r.lastName),
+    jerseyNumber: r.jerseyNumber,
+    skillLevel: r.skillLevel,
+    skillLabel: skillLevelLabel(r.skillLevel),
+    gender: r.gender,
+    genderLabel: genderLabel(r.gender),
+    genderGroupLabel: genderGroupLabel(r.gender),
+    primaryEmail: primaryByPlayer.get(r.playerId) ?? null,
+  }))
+}
+
+export async function getRegisteredPlayerIds(eventId: string): Promise<Set<string>> {
+  const db = getDb()
+  const rows = await db
+    .select({ playerId: eventRegistrations.playerId })
+    .from(eventRegistrations)
+    .where(eq(eventRegistrations.eventId, eventId))
+  return new Set(rows.map((r) => r.playerId))
+}

--- a/app/lib/events/queries.ts
+++ b/app/lib/events/queries.ts
@@ -1,4 +1,4 @@
-import { and, asc, count, desc, eq, inArray, sql } from 'drizzle-orm'
+import { asc, count, desc, eq, inArray, sql } from 'drizzle-orm'
 import { getDb } from '@/app/lib/db'
 import {
   eventRegistrations,

--- a/app/lib/events/types.ts
+++ b/app/lib/events/types.ts
@@ -1,0 +1,83 @@
+export const EVENT_TYPES = {
+  tournament: 'Tournament',
+  open_gym: 'Open gym',
+  other: 'Other',
+} as const
+
+export type EventType = keyof typeof EVENT_TYPES
+
+export const REGISTRATION_STATUS = {
+  registered: 'Registered',
+} as const
+
+export type RegistrationStatus = keyof typeof REGISTRATION_STATUS
+
+export type EventRecord = {
+  id: string
+  name: string
+  eventDate: string
+  eventType: string
+  notes: string | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+export type EventListItem = {
+  id: string
+  name: string
+  eventDate: string
+  eventType: string
+  eventTypeLabel: string
+  notes: string | null
+  registrationCount: number
+}
+
+export type EventRegistrationListItem = {
+  id: string
+  eventId: string
+  playerId: string
+  status: string
+  draftGroup: number | null
+  registeredAt: Date
+  updatedAt: Date
+  firstName: string
+  lastName: string
+  rosterName: string
+  nickname: string
+  jerseyNumber: number | null
+  skillLevel: number | null
+  skillLabel: string
+  gender: string | null
+  genderLabel: string
+  genderGroupLabel: string
+  primaryEmail: string | null
+}
+
+export function isValidEventType(value: unknown): value is EventType {
+  return value === 'tournament' || value === 'open_gym' || value === 'other'
+}
+
+export function eventTypeLabel(type: string | null | undefined): string {
+  if (type && isValidEventType(type)) return EVENT_TYPES[type]
+  return EVENT_TYPES.other
+}
+
+/** Positive integer draft bucket, or null to clear / unassigned. */
+export function parseDraftGroup(value: unknown): number | null | undefined {
+  if (value === undefined) return undefined
+  if (value === null || value === '') return null
+  const n = typeof value === 'number' ? value : Number.parseInt(String(value), 10)
+  if (!Number.isInteger(n) || n < 1) {
+    throw new Error('draftGroup must be a positive integer or null')
+  }
+  return n
+}
+
+export function isValidDraftGroup(value: unknown): value is number | null {
+  try {
+    const parsed = parseDraftGroup(value)
+    return parsed !== undefined
+  } catch {
+    return false
+  }
+}

--- a/app/lib/players/teamlinkt-import.ts
+++ b/app/lib/players/teamlinkt-import.ts
@@ -33,7 +33,14 @@ export type TeamlinktRow = {
 export type ImportPreviewAction =
   | { action: 'create'; row: TeamlinktRow }
   | { action: 'update'; row: TeamlinktRow; playerId: string; notes: string[] }
-  | { action: 'skip'; row: TeamlinktRow; reason: string; playerId?: string }
+  | {
+      action: 'skip'
+      row: TeamlinktRow
+      reason: string
+      playerId?: string
+      /** When true, event-scoped import should not enroll this playerId. */
+      excludeFromRegistration?: boolean
+    }
   | { action: 'ambiguous'; row: TeamlinktRow; reason: string; playerIds: string[] }
 
 /** Player ids that will be registered for an event-scoped import. */
@@ -41,7 +48,13 @@ export function playerIdForRegistration(
   action: ImportPreviewAction
 ): string | null {
   if (action.action === 'update') return action.playerId
-  if (action.action === 'skip' && action.playerId) return action.playerId
+  if (
+    action.action === 'skip' &&
+    action.playerId &&
+    !action.excludeFromRegistration
+  ) {
+    return action.playerId
+  }
   return null
 }
 
@@ -459,6 +472,7 @@ export async function previewTeamlinktImport(
         row,
         reason: 'Matched a merged player record',
         playerId,
+        excludeFromRegistration: true,
       })
       continue
     }
@@ -609,13 +623,10 @@ export async function commitTeamlinktImport(input: {
       if (item.action === 'skip') {
         skipped++
         // Matched players still get registered on event-scoped imports
-        // (except merged records — those keep playerId but should not enroll)
-        if (
-          eventId &&
-          item.playerId &&
-          item.reason !== 'Matched a merged player record'
-        ) {
-          await registerPlayer(item.playerId)
+        // (except records flagged excludeFromRegistration, e.g. merged players)
+        const registerId = playerIdForRegistration(item)
+        if (eventId && registerId) {
+          await registerPlayer(registerId)
         }
         continue
       }

--- a/app/lib/players/teamlinkt-import.ts
+++ b/app/lib/players/teamlinkt-import.ts
@@ -1,6 +1,8 @@
 import { eq } from 'drizzle-orm'
 import { getDb } from '@/app/lib/db'
 import { importBatches, playerEmails, players } from '@/app/db/schema'
+import { upsertEventRegistration } from '@/app/lib/events/mutations'
+import { getEvent, getRegisteredPlayerIds } from '@/app/lib/events/queries'
 import {
   createPlayer,
   ensurePlayerAlias,
@@ -31,8 +33,40 @@ export type TeamlinktRow = {
 export type ImportPreviewAction =
   | { action: 'create'; row: TeamlinktRow }
   | { action: 'update'; row: TeamlinktRow; playerId: string; notes: string[] }
-  | { action: 'skip'; row: TeamlinktRow; reason: string }
+  | { action: 'skip'; row: TeamlinktRow; reason: string; playerId?: string }
   | { action: 'ambiguous'; row: TeamlinktRow; reason: string; playerIds: string[] }
+
+/** Player ids that will be registered for an event-scoped import. */
+export function playerIdForRegistration(
+  action: ImportPreviewAction
+): string | null {
+  if (action.action === 'update') return action.playerId
+  if (action.action === 'skip' && action.playerId) return action.playerId
+  return null
+}
+
+export function summarizeRegistrationPreview(
+  actions: ImportPreviewAction[],
+  registeredPlayerIds: Set<string>
+): { register: number; alreadyRegistered: number } {
+  let register = 0
+  let alreadyRegistered = 0
+  const seen = new Set<string>()
+
+  for (const action of actions) {
+    if (action.action === 'create') {
+      register++
+      continue
+    }
+    const playerId = playerIdForRegistration(action)
+    if (!playerId || seen.has(playerId)) continue
+    seen.add(playerId)
+    if (registeredPlayerIds.has(playerId)) alreadyRegistered++
+    else register++
+  }
+
+  return { register, alreadyRegistered }
+}
 
 /**
  * How TeamLinkt updates skill / gender / jersey on existing players.
@@ -338,16 +372,27 @@ async function loadMatchIndex(): Promise<MatchIndex> {
 
 export async function previewTeamlinktImport(
   csvText: string,
-  options?: TeamlinktImportOptions
+  options?: TeamlinktImportOptions,
+  eventId?: string | null
 ): Promise<{
   actions: ImportPreviewAction[]
   headers: string[]
+  registrationSummary?: { register: number; alreadyRegistered: number }
   error?: string
 }> {
   const profileFields = resolveProfileFieldsMode(options)
   const parsed = parseTeamlinktCsv(csvText)
   if (parsed.error) {
     return { actions: [], headers: parsed.headers, error: parsed.error }
+  }
+
+  let registeredPlayerIds = new Set<string>()
+  if (eventId) {
+    const event = await getEvent(eventId)
+    if (!event) {
+      return { actions: [], headers: parsed.headers, error: 'Event not found' }
+    }
+    registeredPlayerIds = await getRegisteredPlayerIds(eventId)
   }
 
   const index = await loadMatchIndex()
@@ -413,6 +458,7 @@ export async function previewTeamlinktImport(
         action: 'skip',
         row,
         reason: 'Matched a merged player record',
+        playerId,
       })
       continue
     }
@@ -491,6 +537,7 @@ export async function previewTeamlinktImport(
           ignored.length > 0
             ? `Already up to date; ${ignored.join('; ')}`
             : 'Already up to date',
+        playerId,
       })
     } else {
       if (ignored.length > 0) notes.push(...ignored.map((n) => `Skipped: ${n}`))
@@ -498,7 +545,13 @@ export async function previewTeamlinktImport(
     }
   }
 
-  return { actions, headers: parsed.headers }
+  return {
+    actions,
+    headers: parsed.headers,
+    registrationSummary: eventId
+      ? summarizeRegistrationPreview(actions, registeredPlayerIds)
+      : undefined,
+  }
 }
 
 export async function commitTeamlinktImport(input: {
@@ -506,9 +559,11 @@ export async function commitTeamlinktImport(input: {
   filename: string
   actor: string
   options?: TeamlinktImportOptions
+  eventId?: string | null
 }) {
   const profileFields = resolveProfileFieldsMode(input.options)
-  const preview = await previewTeamlinktImport(input.csvText, input.options)
+  const eventId = input.eventId?.trim() || null
+  const preview = await previewTeamlinktImport(input.csvText, input.options, eventId)
   if (preview.error) {
     throw new Error(preview.error)
   }
@@ -521,6 +576,7 @@ export async function commitTeamlinktImport(input: {
       actor: input.actor,
       rowCount: preview.actions.length,
       summary: {},
+      eventId: eventId ?? undefined,
     })
     .returning()
 
@@ -528,21 +584,44 @@ export async function commitTeamlinktImport(input: {
   let updated = 0
   let skipped = 0
   let ambiguous = 0
+  let register = 0
+  let alreadyRegistered = 0
   const errors: string[] = []
+
+  async function registerPlayer(playerId: string) {
+    if (!eventId) return
+    const result = await upsertEventRegistration({
+      eventId,
+      playerId,
+      importBatchId: batch.id,
+    })
+    if (result.created) register++
+    else alreadyRegistered++
+  }
 
   for (const item of preview.actions) {
     try {
-      if (item.action === 'skip') {
-        skipped++
-        continue
-      }
       if (item.action === 'ambiguous') {
         ambiguous++
         continue
       }
 
+      if (item.action === 'skip') {
+        skipped++
+        // Matched players still get registered on event-scoped imports
+        // (except merged records — those keep playerId but should not enroll)
+        if (
+          eventId &&
+          item.playerId &&
+          item.reason !== 'Matched a merged player record'
+        ) {
+          await registerPlayer(item.playerId)
+        }
+        continue
+      }
+
       if (item.action === 'create') {
-        await createPlayer({
+        const snap = await createPlayer({
           firstName: item.row.firstName,
           lastName: item.row.lastName,
           jerseyNumber: item.row.jerseyNumber,
@@ -554,6 +633,7 @@ export async function commitTeamlinktImport(input: {
           importBatchId: batch.id,
         })
         created++
+        if (snap?.id) await registerPlayer(snap.id)
         continue
       }
 
@@ -600,6 +680,7 @@ export async function commitTeamlinktImport(input: {
       }
 
       updated++
+      await registerPlayer(item.playerId)
     } catch (err) {
       errors.push(
         `Row ${item.row.rowNumber}: ${err instanceof Error ? err.message : 'Unknown error'}`
@@ -607,7 +688,15 @@ export async function commitTeamlinktImport(input: {
     }
   }
 
-  const summary = { created, updated, skipped, ambiguous, errors, profileFields }
+  const summary = {
+    created,
+    updated,
+    skipped,
+    ambiguous,
+    errors,
+    profileFields,
+    ...(eventId ? { register, alreadyRegistered, eventId } : {}),
+  }
   await db.update(importBatches).set({ summary }).where(eq(importBatches.id, batch.id))
 
   return { batchId: batch.id, summary, actions: preview.actions }

--- a/app/players/page.tsx
+++ b/app/players/page.tsx
@@ -977,6 +977,8 @@ export default function PlayersPage() {
             <p className="text-sm text-gray-600">
               New players always get skill, gender, and jersey from the CSV. For existing
               players, those fields are left alone by default so manual edits are preserved.
+              To attach registrations to a tournament or other event, import from the Events
+              page instead.
             </p>
             <label className="block text-sm">
               <span className="text-gray-600">Existing players: skill / gender / jersey</span>

--- a/drizzle/0004_events.sql
+++ b/drizzle/0004_events.sql
@@ -1,0 +1,54 @@
+CREATE TABLE IF NOT EXISTS "events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"event_date" date NOT NULL,
+	"event_type" text DEFAULT 'tournament' NOT NULL,
+	"notes" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "import_batches" ADD COLUMN IF NOT EXISTS "event_id" uuid;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "event_registrations" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"event_id" uuid NOT NULL,
+	"player_id" uuid NOT NULL,
+	"status" text DEFAULT 'registered' NOT NULL,
+	"draft_group" integer,
+	"import_batch_id" uuid,
+	"registered_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "import_batches" ADD CONSTRAINT "import_batches_event_id_events_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."events"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "event_registrations" ADD CONSTRAINT "event_registrations_event_id_events_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."events"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "event_registrations" ADD CONSTRAINT "event_registrations_player_id_players_id_fk" FOREIGN KEY ("player_id") REFERENCES "public"."players"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "event_registrations" ADD CONSTRAINT "event_registrations_import_batch_id_import_batches_id_fk" FOREIGN KEY ("import_batch_id") REFERENCES "public"."import_batches"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "events_event_date_idx" ON "events" USING btree ("event_date");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "event_registrations_event_player_uidx" ON "event_registrations" USING btree ("event_id","player_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "event_registrations_event_id_idx" ON "event_registrations" USING btree ("event_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "event_registrations_player_id_idx" ON "event_registrations" USING btree ("player_id");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1752623600000,
       "tag": "0003_player_jersey_name",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1752630000000,
+      "tag": "0004_events",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `events` and `event_registrations` (with draft buckets) so TeamLinkt imports can be tied to a specific event
- Extends player import with optional `eventId`; re-imports are idempotent and never clear draft groups or remove prior registrations
- Ships Events list + event tracker UI for roster counts, CSV import, and numbered draft-group assignment (August 8 tournament use case)

## Test plan
- [ ] Run migration (`npm run db:migrate`) on preview/prod DB
- [ ] Create an event (e.g. August 8 tournament) from `/events`
- [ ] Dry-run then commit a TeamLinkt CSV from the event page; confirm players appear on the roster
- [ ] Re-import the same CSV; confirm `alreadyRegistered` increments and draft groups are unchanged after assigning buckets
- [ ] Assign players to draft groups / add a new group; filter by group
- [ ] Confirm Players-page import still works without attaching registrations
- [ ] `npm run test:run -- app/__tests__/teamlinkt-import.test.ts app/__tests__/event-draft-group.test.ts`


Made with [Cursor](https://cursor.com)