### PR TITLE
Add event registration tracking and draft mode

### DIFF
--- a/app/__tests__/event-draft-seed.test.ts
+++ b/app/__tests__/event-draft-seed.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import {
+  autoSeedDraftGroups,
+  copyExistingDraftGroups,
+  defaultTeamCount,
+  emptySeedDraftGroups,
+  teamGenderCounts,
+  teamSkillTotal,
+  type DraftSeedPlayer,
+} from '@/app/lib/events/draft-seed'
+
+function player(
+  id: string,
+  skillLevel: number | null,
+  gender: string | null
+): DraftSeedPlayer {
+  return { id, skillLevel, gender }
+}
+
+describe('defaultTeamCount', () => {
+  it('targets roughly 7–8 players per team', () => {
+    expect(defaultTeamCount(0)).toBe(1)
+    expect(defaultTeamCount(7)).toBe(1)
+    expect(defaultTeamCount(8)).toBe(1)
+    expect(defaultTeamCount(15)).toBe(2)
+    expect(defaultTeamCount(56)).toBe(7)
+    expect(defaultTeamCount(60)).toBe(8)
+  })
+})
+
+describe('autoSeedDraftGroups', () => {
+  it('assigns every player to a team 1..N', () => {
+    const players = [
+      player('a', 4, 'woman'),
+      player('b', 3, 'man'),
+      player('c', 2, 'woman'),
+      player('d', 1, 'man'),
+      player('e', 3, 'nonbinary'),
+      player('f', 2, 'man'),
+    ]
+    const result = autoSeedDraftGroups(players, 2)
+    expect(result.size).toBe(6)
+    for (const team of result.values()) {
+      expect(team).toBeGreaterThanOrEqual(1)
+      expect(team).toBeLessThanOrEqual(2)
+    }
+  })
+
+  it('keeps team sizes within 1 of each other', () => {
+    const players = Array.from({ length: 20 }, (_, i) =>
+      player(
+        `p${i}`,
+        (i % 4) + 1,
+        i % 2 === 0 ? 'woman' : 'man'
+      )
+    )
+    const teamCount = 3
+    const result = autoSeedDraftGroups(players, teamCount)
+    const sizes = Array.from({ length: teamCount }, () => 0)
+    for (const team of result.values()) {
+      sizes[team - 1]++
+    }
+    expect(Math.max(...sizes) - Math.min(...sizes)).toBeLessThanOrEqual(1)
+  })
+
+  it('spreads gender groups across teams', () => {
+    const players = [
+      ...Array.from({ length: 6 }, (_, i) => player(`w${i}`, 3, 'woman')),
+      ...Array.from({ length: 6 }, (_, i) => player(`m${i}`, 3, 'man')),
+    ]
+    const result = autoSeedDraftGroups(players, 3)
+    const byTeam = Array.from({ length: 3 }, () =>
+      [] as DraftSeedPlayer[]
+    )
+    for (const p of players) {
+      const team = result.get(p.id)!
+      byTeam[team - 1].push(p)
+    }
+    for (const teamPlayers of byTeam) {
+      const { wNbO, men } = teamGenderCounts(teamPlayers)
+      expect(Math.abs(wNbO - men)).toBeLessThanOrEqual(1)
+    }
+  })
+
+  it('balances skill totals across teams', () => {
+    const players = [
+      player('a', 4, 'woman'),
+      player('b', 4, 'man'),
+      player('c', 1, 'woman'),
+      player('d', 1, 'man'),
+      player('e', 3, 'woman'),
+      player('f', 3, 'man'),
+      player('g', 2, 'woman'),
+      player('h', 2, 'man'),
+    ]
+    const result = autoSeedDraftGroups(players, 2)
+    const teams = [[], []] as DraftSeedPlayer[][]
+    for (const p of players) {
+      teams[result.get(p.id)! - 1].push(p)
+    }
+    const scores = teams.map(teamSkillTotal)
+    expect(Math.abs(scores[0] - scores[1])).toBeLessThanOrEqual(2)
+  })
+
+  it('places unset gender into teams without crashing', () => {
+    const players = [
+      player('a', 3, null),
+      player('b', 2, 'man'),
+      player('c', 4, 'woman'),
+    ]
+    const result = autoSeedDraftGroups(players, 2)
+    expect(result.size).toBe(3)
+  })
+})
+
+describe('emptySeedDraftGroups', () => {
+  it('marks everyone unassigned', () => {
+    const players = [player('a', 1, 'man'), player('b', 2, 'woman')]
+    const result = emptySeedDraftGroups(players)
+    expect(result.get('a')).toBeNull()
+    expect(result.get('b')).toBeNull()
+  })
+})
+
+describe('copyExistingDraftGroups', () => {
+  it('copies permanent draft groups into the workspace map', () => {
+    const result = copyExistingDraftGroups([
+      { id: 'a', skillLevel: 1, gender: 'man', draftGroup: 2 },
+      { id: 'b', skillLevel: 2, gender: 'woman', draftGroup: null },
+    ])
+    expect(result.get('a')).toBe(2)
+    expect(result.get('b')).toBeNull()
+  })
+})

--- a/app/api/events/[id]/registrations/[registrationId]/route.ts
+++ b/app/api/events/[id]/registrations/[registrationId]/route.ts
@@ -3,7 +3,10 @@ import {
   adminUnauthorizedResponse,
   getAdminSessionFromRequest,
 } from '@/app/lib/admin-auth'
-import { updateRegistrationDraftGroup } from '@/app/lib/events/mutations'
+import {
+  deleteEventRegistration,
+  updateRegistrationDraftGroup,
+} from '@/app/lib/events/mutations'
 import { getEvent } from '@/app/lib/events/queries'
 import { parseDraftGroup } from '@/app/lib/events/types'
 
@@ -45,6 +48,27 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
         : message.includes('draftGroup')
           ? 400
           : 500
+    return NextResponse.json({ error: message }, { status })
+  }
+}
+
+export async function DELETE(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id, registrationId } = await context.params
+    const event = await getEvent(id)
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    }
+
+    await deleteEventRegistration(id, registrationId)
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to remove registration'
+    const status = message === 'Registration not found' ? 404 : 500
     return NextResponse.json({ error: message }, { status })
   }
 }

--- a/app/api/events/[id]/registrations/bulk/route.ts
+++ b/app/api/events/[id]/registrations/bulk/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import { bulkUpdateRegistrationDraftGroups } from '@/app/lib/events/mutations'
+import { getEvent } from '@/app/lib/events/queries'
+import { parseDraftGroup } from '@/app/lib/events/types'
+
+type RouteContext = { params: Promise<{ id: string }> }
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id } = await context.params
+    const event = await getEvent(id)
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    }
+
+    const body = (await request.json()) as {
+      assignments?: Array<{ registrationId?: unknown; draftGroup?: unknown }>
+    }
+
+    if (!Array.isArray(body.assignments)) {
+      return NextResponse.json(
+        { error: 'assignments must be an array' },
+        { status: 400 }
+      )
+    }
+
+    // Validate early for clear API errors
+    for (const item of body.assignments) {
+      if (!item || typeof item.registrationId !== 'string' || !item.registrationId) {
+        return NextResponse.json(
+          { error: 'Each assignment needs a registrationId string' },
+          { status: 400 }
+        )
+      }
+      if (!('draftGroup' in item)) {
+        return NextResponse.json(
+          { error: 'Each assignment needs a draftGroup' },
+          { status: 400 }
+        )
+      }
+      parseDraftGroup(item.draftGroup)
+    }
+
+    const registrations = await bulkUpdateRegistrationDraftGroups(
+      id,
+      body.assignments.map((a) => ({
+        registrationId: a.registrationId as string,
+        draftGroup: a.draftGroup as number | null,
+      }))
+    )
+
+    return NextResponse.json({ registrations })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to update registrations'
+    const status =
+      message.startsWith('Registration not found')
+        ? 404
+        : message.includes('draftGroup') || message.includes('registrationId')
+          ? 400
+          : 500
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/events/[id]/registrations/bulk/route.ts
+++ b/app/api/events/[id]/registrations/bulk/route.ts
@@ -45,7 +45,13 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
           { status: 400 }
         )
       }
-      parseDraftGroup(item.draftGroup)
+      const draftGroup = parseDraftGroup(item.draftGroup)
+      if (draftGroup === undefined) {
+        return NextResponse.json(
+          { error: 'Each assignment needs a draftGroup' },
+          { status: 400 }
+        )
+      }
     }
 
     const registrations = await bulkUpdateRegistrationDraftGroups(

--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -3,7 +3,7 @@ import {
   adminUnauthorizedResponse,
   getAdminSessionFromRequest,
 } from '@/app/lib/admin-auth'
-import { updateEvent } from '@/app/lib/events/mutations'
+import { deleteEvent, updateEvent } from '@/app/lib/events/mutations'
 import { getEvent } from '@/app/lib/events/queries'
 import { eventTypeLabel, isValidEventType } from '@/app/lib/events/types'
 
@@ -62,6 +62,21 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Failed to update event'
     const status = message === 'Event not found' ? 404 : 400
+    return NextResponse.json({ error: message }, { status })
+  }
+}
+
+export async function DELETE(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id } = await context.params
+    await deleteEvent(id)
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to delete event'
+    const status = message === 'Event not found' ? 404 : 500
     return NextResponse.json({ error: message }, { status })
   }
 }

--- a/app/components/events/EventDraftBoard.tsx
+++ b/app/components/events/EventDraftBoard.tsx
@@ -1,0 +1,294 @@
+'use client'
+
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  closestCorners,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core'
+import { CSS } from '@dnd-kit/utilities'
+import { useMemo, useState } from 'react'
+import {
+  teamGenderCounts,
+  teamSkillTotal,
+} from '@/app/lib/events/draft-seed'
+import type { EventRegistrationListItem } from '@/app/lib/events/types'
+import { genderGroup } from '@/app/lib/players/gender'
+import { skillLevelLabel } from '@/app/lib/players/skill'
+
+type DraftAssignment = Map<string, number | null>
+
+type Props = {
+  registrations: EventRegistrationListItem[]
+  teamCount: number
+  assignments: DraftAssignment
+  onAssignmentsChange: (next: DraftAssignment) => void
+  onApply: () => void
+  onDiscard: () => void
+  applying: boolean
+  error: string | null
+}
+
+function columnId(team: number | null): string {
+  return team == null ? 'unassigned' : `team-${team}`
+}
+
+function parseColumnId(id: string): number | null {
+  if (id === 'unassigned') return null
+  const m = /^team-(\d+)$/.exec(id)
+  if (!m) return null
+  return Number.parseInt(m[1], 10)
+}
+
+function playerCardClass(gender: string | null): string {
+  const g = genderGroup(gender)
+  if (g === 'w_nb_o') return 'border-rose-200 bg-rose-50/80'
+  if (g === 'men') return 'border-sky-200 bg-sky-50/80'
+  return 'border-gray-200 bg-white'
+}
+
+function DraftPlayerCard(props: {
+  player: EventRegistrationListItem
+  dragging?: boolean
+}) {
+  const { player, dragging } = props
+  return (
+    <div
+      className={`rounded border px-2 py-1.5 text-xs shadow-sm ${playerCardClass(player.gender)} ${
+        dragging ? 'opacity-90 shadow-md ring-2 ring-blue-400' : ''
+      }`}
+    >
+      <div className="font-medium text-gray-900">
+        {player.nickname || `${player.firstName} ${player.lastName}`}
+      </div>
+      <div className="text-gray-600">
+        {player.skillLevel != null ? skillLevelLabel(player.skillLevel) : '—'} ·{' '}
+        {player.genderGroupLabel}
+        {player.skillLevel != null ? ` · ${player.skillLevel}` : ''}
+      </div>
+    </div>
+  )
+}
+
+function DraggablePlayer(props: { player: EventRegistrationListItem }) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({ id: props.player.id })
+  const style = transform
+    ? { transform: CSS.Translate.toString(transform) }
+    : undefined
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`cursor-grab active:cursor-grabbing ${isDragging ? 'opacity-40' : ''}`}
+      {...listeners}
+      {...attributes}
+    >
+      <DraftPlayerCard player={props.player} />
+    </div>
+  )
+}
+
+function TeamColumn(props: {
+  team: number | null
+  label: string
+  players: EventRegistrationListItem[]
+  scoreImbalanced?: boolean
+  genderImbalanced?: boolean
+}) {
+  const id = columnId(props.team)
+  const { setNodeRef, isOver } = useDroppable({ id })
+  const score = teamSkillTotal(props.players)
+  const gender = teamGenderCounts(props.players)
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`flex min-h-[220px] w-56 shrink-0 flex-col rounded-lg border ${
+        isOver ? 'border-blue-400 bg-blue-50/40' : 'border-gray-200 bg-gray-50/50'
+      }`}
+    >
+      <div className="border-b border-gray-200 px-2 py-2">
+        <div className="flex items-baseline justify-between gap-2">
+          <span className="text-sm font-semibold text-gray-900">{props.label}</span>
+          <span className="text-xs text-gray-500">{props.players.length}</span>
+        </div>
+        {props.team != null ? (
+          <div className="mt-1 space-y-0.5 text-xs text-gray-600">
+            <div className={props.scoreImbalanced ? 'font-semibold text-amber-700' : ''}>
+              Score {score}
+            </div>
+            <div className={props.genderImbalanced ? 'font-semibold text-amber-700' : ''}>
+              W/NB/O {gender.wNbO} · M {gender.men}
+              {gender.unset ? ` · — ${gender.unset}` : ''}
+            </div>
+          </div>
+        ) : (
+          <div className="mt-1 text-xs text-gray-500">Drag onto a team</div>
+        )}
+      </div>
+      <div className="flex flex-1 flex-col gap-1.5 overflow-y-auto p-2">
+        {props.players.map((p) => (
+          <DraggablePlayer key={p.id} player={p} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function EventDraftBoard(props: Props) {
+  const {
+    registrations,
+    teamCount,
+    assignments,
+    onAssignmentsChange,
+    onApply,
+    onDiscard,
+    applying,
+    error,
+  } = props
+
+  const [activeId, setActiveId] = useState<string | null>(null)
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } })
+  )
+
+  const byColumn = useMemo(() => {
+    const map = new Map<string, EventRegistrationListItem[]>()
+    map.set(columnId(null), [])
+    for (let t = 1; t <= teamCount; t++) {
+      map.set(columnId(t), [])
+    }
+    for (const r of registrations) {
+      const team = assignments.get(r.id) ?? null
+      const key = columnId(team != null && team >= 1 && team <= teamCount ? team : null)
+      const list = map.get(key) ?? []
+      list.push(r)
+      map.set(key, list)
+    }
+    return map
+  }, [registrations, assignments, teamCount])
+
+  const teamStats = useMemo(() => {
+    const scores: number[] = []
+    const genderDeltas: number[] = []
+    for (let t = 1; t <= teamCount; t++) {
+      const players = byColumn.get(columnId(t)) ?? []
+      scores.push(teamSkillTotal(players))
+      const g = teamGenderCounts(players)
+      genderDeltas.push(Math.abs(g.wNbO - g.men))
+    }
+    const avgScore =
+      scores.length > 0 ? scores.reduce((a, b) => a + b, 0) / scores.length : 0
+    const avgGenderDelta =
+      genderDeltas.length > 0
+        ? genderDeltas.reduce((a, b) => a + b, 0) / genderDeltas.length
+        : 0
+    return { scores, genderDeltas, avgScore, avgGenderDelta }
+  }, [byColumn, teamCount])
+
+  const activePlayer = activeId
+    ? registrations.find((r) => r.id === activeId) ?? null
+    : null
+
+  function handleDragStart(event: DragStartEvent) {
+    setActiveId(String(event.active.id))
+  }
+
+  function handleDragEnd(event: DragEndEvent) {
+    setActiveId(null)
+    const { active, over } = event
+    if (!over) return
+
+    const playerId = String(active.id)
+    let targetTeam: number | null = null
+
+    const overId = String(over.id)
+    if (overId === 'unassigned' || overId.startsWith('team-')) {
+      targetTeam = parseColumnId(overId)
+    } else {
+      // Dropped on another player — use that player's column
+      targetTeam = assignments.get(overId) ?? null
+    }
+
+    const current = assignments.get(playerId) ?? null
+    if (current === targetTeam) return
+
+    const next = new Map(assignments)
+    next.set(playerId, targetTeam)
+    onAssignmentsChange(next)
+  }
+
+  return (
+    <div className="space-y-4 rounded-lg border border-blue-200 bg-blue-50/30 p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900">Draft mode</h2>
+          <p className="text-sm text-gray-600">
+            Working copy only — permanent draft groups are unchanged until you Apply.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            className="rounded border border-gray-300 bg-white px-3 py-2 text-sm"
+            disabled={applying}
+            onClick={onDiscard}
+          >
+            Discard
+          </button>
+          <button
+            type="button"
+            className="rounded bg-blue-600 px-3 py-2 text-sm text-white disabled:opacity-40"
+            disabled={applying}
+            onClick={onApply}
+          >
+            {applying ? 'Applying…' : 'Apply to event'}
+          </button>
+        </div>
+      </div>
+
+      {error ? <p className="text-sm text-red-600">{error}</p> : null}
+
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCorners}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+      >
+        <div className="flex gap-3 overflow-x-auto pb-2">
+          <TeamColumn
+            team={null}
+            label="Unassigned"
+            players={byColumn.get(columnId(null)) ?? []}
+          />
+          {Array.from({ length: teamCount }, (_, i) => i + 1).map((t) => (
+            <TeamColumn
+              key={t}
+              team={t}
+              label={`Team ${t}`}
+              players={byColumn.get(columnId(t)) ?? []}
+              scoreImbalanced={
+                Math.abs(teamStats.scores[t - 1] - teamStats.avgScore) > 2
+              }
+              genderImbalanced={
+                teamStats.genderDeltas[t - 1] > Math.max(1, teamStats.avgGenderDelta + 1)
+              }
+            />
+          ))}
+        </div>
+        <DragOverlay>
+          {activePlayer ? <DraftPlayerCard player={activePlayer} dragging /> : null}
+        </DragOverlay>
+      </DndContext>
+    </div>
+  )
+}

--- a/app/components/events/EventDraftBoard.tsx
+++ b/app/components/events/EventDraftBoard.tsx
@@ -3,6 +3,7 @@
 import {
   DndContext,
   DragOverlay,
+  KeyboardSensor,
   PointerSensor,
   closestCorners,
   useDraggable,
@@ -12,6 +13,7 @@ import {
   type DragEndEvent,
   type DragStartEvent,
 } from '@dnd-kit/core'
+import { sortableKeyboardCoordinates } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { useMemo, useState } from 'react'
 import {
@@ -158,7 +160,10 @@ export function EventDraftBoard(props: Props) {
   const [activeId, setActiveId] = useState<string | null>(null)
 
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 6 } })
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
   )
 
   const byColumn = useMemo(() => {

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -21,7 +21,11 @@ import {
 } from '@/app/lib/events/draft-seed'
 import type { EventRegistrationListItem } from '@/app/lib/events/types'
 import { genderGroup } from '@/app/lib/players/gender'
-import { SKILL_LEVELS, skillLevelLabel } from '@/app/lib/players/skill'
+import {
+  SKILL_LEVELS,
+  isValidSkillLevel,
+  skillLevelLabel,
+} from '@/app/lib/players/skill'
 
 type EventDetail = {
   id: string
@@ -203,7 +207,9 @@ function EventTrackerPageContent() {
 
     for (const r of registrations) {
       const g = genderGroup(r.gender)
-      const skillKey = r.skillLevel == null ? 'unset' : String(r.skillLevel)
+      const skillKey = isValidSkillLevel(r.skillLevel)
+        ? String(r.skillLevel)
+        : 'unset'
       matrix[g][skillKey] = (matrix[g][skillKey] ?? 0) + 1
 
       if (r.draftGroup == null) unassigned++

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useParams } from 'next/navigation'
+import { useParams, useRouter } from 'next/navigation'
 import {
   Suspense,
   useCallback,
@@ -10,11 +10,18 @@ import {
   useState,
   type ReactNode,
 } from 'react'
+import { EventDraftBoard } from '@/app/components/events/EventDraftBoard'
 import { withDevMode } from '@/app/lib/devMode'
 import { useDevMode } from '@/app/hooks/useDevMode'
+import {
+  autoSeedDraftGroups,
+  copyExistingDraftGroups,
+  defaultTeamCount,
+  emptySeedDraftGroups,
+} from '@/app/lib/events/draft-seed'
+import type { EventRegistrationListItem } from '@/app/lib/events/types'
 import { genderGroup } from '@/app/lib/players/gender'
 import { SKILL_LEVELS, skillLevelLabel } from '@/app/lib/players/skill'
-import type { EventRegistrationListItem } from '@/app/lib/events/types'
 
 type EventDetail = {
   id: string
@@ -39,6 +46,13 @@ type ImportAction = {
   reason?: string
   playerId?: string
 }
+
+type DraftPhase = 'off' | 'setup' | 'board'
+
+type SeedMode = 'auto' | 'empty' | 'existing'
+
+const SKILL_COLS = [...Object.keys(SKILL_LEVELS).map(Number), null] as const
+const GENDER_ROWS = ['w_nb_o', 'men', 'unset'] as const
 
 function formatDisplayDate(isoDate: string): string {
   const d = new Date(`${isoDate}T12:00:00`)
@@ -75,6 +89,17 @@ function genderRowClass(gender: string | null): string {
   return 'text-gray-900'
 }
 
+function skillColLabel(level: number | null): string {
+  if (level == null) return 'Unset'
+  return SKILL_LEVELS[level as keyof typeof SKILL_LEVELS] ?? 'Unset'
+}
+
+function genderRowLabel(row: (typeof GENDER_ROWS)[number]): string {
+  if (row === 'w_nb_o') return 'W/NB/O'
+  if (row === 'men') return 'Men'
+  return 'Unset'
+}
+
 export default function EventTrackerPage() {
   return (
     <Suspense
@@ -89,6 +114,7 @@ export default function EventTrackerPage() {
 
 function EventTrackerPageContent() {
   const params = useParams()
+  const router = useRouter()
   const eventId = String(params.id ?? '')
   const { devMode } = useDevMode()
 
@@ -99,6 +125,8 @@ function EventTrackerPageContent() {
   const [message, setMessage] = useState<string | null>(null)
   const [draftFilter, setDraftFilter] = useState<'all' | 'unassigned' | number>('all')
   const [savingId, setSavingId] = useState<string | null>(null)
+  const [removingId, setRemovingId] = useState<string | null>(null)
+  const [deletingEvent, setDeletingEvent] = useState(false)
   const [maxGroup, setMaxGroup] = useState(4)
 
   const [importOpen, setImportOpen] = useState(false)
@@ -113,6 +141,15 @@ function EventTrackerPageContent() {
   } | null>(null)
   const [importBusy, setImportBusy] = useState(false)
   const [formError, setFormError] = useState<string | null>(null)
+
+  const [draftPhase, setDraftPhase] = useState<DraftPhase>('off')
+  const [draftTeamCount, setDraftTeamCount] = useState(1)
+  const [draftSeedMode, setDraftSeedMode] = useState<SeedMode>('auto')
+  const [draftAssignments, setDraftAssignments] = useState<Map<string, number | null>>(
+    () => new Map()
+  )
+  const [draftApplying, setDraftApplying] = useState(false)
+  const [draftError, setDraftError] = useState<string | null>(null)
 
   const load = useCallback(async () => {
     if (!eventId) return
@@ -146,26 +183,28 @@ function EventTrackerPageContent() {
     void load()
   }, [load])
 
+  const hasExistingGroups = useMemo(
+    () => registrations.some((r) => r.draftGroup != null),
+    [registrations]
+  )
+
   const counts = useMemo(() => {
-    const bySkill: Record<string, number> = { unset: 0 }
-    for (const level of Object.keys(SKILL_LEVELS)) {
-      bySkill[level] = 0
-    }
-    let wNbO = 0
-    let men = 0
-    let genderUnset = 0
     let unassigned = 0
     let assigned = 0
     const byGroup = new Map<number, number>()
 
-    for (const r of registrations) {
-      if (r.skillLevel == null) bySkill.unset++
-      else bySkill[String(r.skillLevel)] = (bySkill[String(r.skillLevel)] ?? 0) + 1
+    const matrix: Record<string, Record<string, number>> = {}
+    for (const row of GENDER_ROWS) {
+      matrix[row] = { unset: 0 }
+      for (const level of Object.keys(SKILL_LEVELS)) {
+        matrix[row][level] = 0
+      }
+    }
 
+    for (const r of registrations) {
       const g = genderGroup(r.gender)
-      if (g === 'w_nb_o') wNbO++
-      else if (g === 'men') men++
-      else genderUnset++
+      const skillKey = r.skillLevel == null ? 'unset' : String(r.skillLevel)
+      matrix[g][skillKey] = (matrix[g][skillKey] ?? 0) + 1
 
       if (r.draftGroup == null) unassigned++
       else {
@@ -174,12 +213,27 @@ function EventTrackerPageContent() {
       }
     }
 
+    const colTotals: Record<string, number> = { unset: 0 }
+    for (const level of Object.keys(SKILL_LEVELS)) {
+      colTotals[level] = 0
+    }
+    const rowTotals: Record<string, number> = {
+      w_nb_o: 0,
+      men: 0,
+      unset: 0,
+    }
+    for (const row of GENDER_ROWS) {
+      for (const [skill, n] of Object.entries(matrix[row])) {
+        rowTotals[row] += n
+        colTotals[skill] = (colTotals[skill] ?? 0) + n
+      }
+    }
+
     return {
       total: registrations.length,
-      bySkill,
-      wNbO,
-      men,
-      genderUnset,
+      matrix,
+      rowTotals,
+      colTotals,
       unassigned,
       assigned,
       byGroup,
@@ -230,6 +284,122 @@ function EventTrackerPageContent() {
       setFormError(err instanceof Error ? err.message : 'Failed to update draft group')
     } finally {
       setSavingId(null)
+    }
+  }
+
+  async function removeRegistration(registrationId: string, label: string) {
+    if (!window.confirm(`Remove ${label} from this event?`)) return
+    setRemovingId(registrationId)
+    setFormError(null)
+    try {
+      const res = await fetch(
+        `/api/events/${eventId}/registrations/${registrationId}`,
+        { method: 'DELETE' }
+      )
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to remove player')
+      setRegistrations((prev) => prev.filter((r) => r.id !== registrationId))
+      setMessage(`Removed ${label} from event`)
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Failed to remove player')
+    } finally {
+      setRemovingId(null)
+    }
+  }
+
+  async function deleteEvent() {
+    if (
+      !window.confirm(
+        `Delete “${event?.name}”? This removes the event and all its registrations.`
+      )
+    ) {
+      return
+    }
+    setDeletingEvent(true)
+    setFormError(null)
+    try {
+      const res = await fetch(`/api/events/${eventId}`, { method: 'DELETE' })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to delete event')
+      router.push(withDevMode('/events', devMode))
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Failed to delete event')
+      setDeletingEvent(false)
+    }
+  }
+
+  function openDraftSetup() {
+    setDraftError(null)
+    setDraftTeamCount(defaultTeamCount(registrations.length))
+    setDraftSeedMode(hasExistingGroups ? 'existing' : 'auto')
+    setDraftPhase('setup')
+  }
+
+  function startDraftBoard() {
+    const seeds = registrations.map((r) => ({
+      id: r.id,
+      skillLevel: r.skillLevel,
+      gender: r.gender,
+      draftGroup: r.draftGroup,
+    }))
+    const n = Math.max(1, Math.floor(draftTeamCount))
+    let next: Map<string, number | null>
+    if (draftSeedMode === 'auto') {
+      const seeded = autoSeedDraftGroups(seeds, n)
+      next = new Map()
+      for (const r of registrations) {
+        next.set(r.id, seeded.get(r.id) ?? null)
+      }
+    } else if (draftSeedMode === 'existing') {
+      next = copyExistingDraftGroups(seeds)
+    } else {
+      next = emptySeedDraftGroups(seeds)
+    }
+    setDraftAssignments(next)
+    setDraftTeamCount(n)
+    setMaxGroup((prev) => Math.max(prev, n))
+    setDraftPhase('board')
+  }
+
+  function discardDraft() {
+    setDraftPhase('off')
+    setDraftAssignments(new Map())
+    setDraftError(null)
+  }
+
+  async function applyDraft() {
+    setDraftApplying(true)
+    setDraftError(null)
+    try {
+      const assignments = registrations.map((r) => ({
+        registrationId: r.id,
+        draftGroup: draftAssignments.get(r.id) ?? null,
+      }))
+      const res = await fetch(`/api/events/${eventId}/registrations/bulk`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ assignments }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to apply draft')
+      setRegistrations((prev) =>
+        prev.map((r) => ({
+          ...r,
+          draftGroup: draftAssignments.get(r.id) ?? null,
+        }))
+      )
+      const maxAssigned = Math.max(
+        0,
+        ...[...draftAssignments.values()].filter((g): g is number => g != null)
+      )
+      if (maxAssigned > 0) setMaxGroup((prev) => Math.max(prev, maxAssigned))
+      setDraftPhase('off')
+      setDraftAssignments(new Map())
+      setMessage('Draft applied to event')
+    } catch (err) {
+      setDraftError(err instanceof Error ? err.message : 'Failed to apply draft')
+    } finally {
+      setDraftApplying(false)
     }
   }
 
@@ -332,18 +502,38 @@ function EventTrackerPageContent() {
             <p className="text-sm text-gray-600 mt-1">{event.notes}</p>
           ) : null}
         </div>
-        <button
-          type="button"
-          className="rounded bg-blue-600 px-3 py-2 text-sm text-white"
-          onClick={() => {
-            setImportOpen(true)
-            setImportPreview(null)
-            setImportProfileFields('skip')
-            setFormError(null)
-          }}
-        >
-          Import TeamLinkt CSV
-        </button>
+        <div className="flex flex-wrap gap-2">
+          {draftPhase === 'off' ? (
+            <button
+              type="button"
+              className="rounded border border-blue-600 px-3 py-2 text-sm text-blue-700"
+              disabled={registrations.length === 0}
+              onClick={openDraftSetup}
+            >
+              Enter draft mode
+            </button>
+          ) : null}
+          <button
+            type="button"
+            className="rounded bg-blue-600 px-3 py-2 text-sm text-white"
+            onClick={() => {
+              setImportOpen(true)
+              setImportPreview(null)
+              setImportProfileFields('skip')
+              setFormError(null)
+            }}
+          >
+            Import TeamLinkt CSV
+          </button>
+          <button
+            type="button"
+            className="rounded border border-red-300 px-3 py-2 text-sm text-red-700 disabled:opacity-40"
+            disabled={deletingEvent}
+            onClick={() => void deleteEvent()}
+          >
+            {deletingEvent ? 'Deleting…' : 'Delete event'}
+          </button>
+        </div>
       </div>
 
       {error ? <p className="text-sm text-red-600">{error}</p> : null}
@@ -352,28 +542,102 @@ function EventTrackerPageContent() {
         <p className="text-sm text-red-600">{formError}</p>
       ) : null}
 
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4 text-sm">
+      {draftPhase === 'setup' ? (
+        <div className="rounded-lg border border-blue-200 bg-blue-50/30 p-4 space-y-4">
+          <div>
+            <h2 className="text-lg font-semibold">Draft setup</h2>
+            <p className="text-sm text-gray-600">
+              Local workspace only until you Apply. Default team size targets ~7–8
+              players.
+            </p>
+          </div>
+          <label className="block text-sm max-w-xs">
+            <span className="text-gray-600">Number of teams</span>
+            <input
+              type="number"
+              min={1}
+              max={Math.max(1, registrations.length)}
+              className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+              value={draftTeamCount}
+              onChange={(e) =>
+                setDraftTeamCount(Number.parseInt(e.target.value, 10) || 1)
+              }
+            />
+            <span className="mt-1 block text-xs text-gray-500">
+              ~{registrations.length > 0
+                ? (registrations.length / Math.max(1, draftTeamCount)).toFixed(1)
+                : 0}{' '}
+              players per team
+            </span>
+          </label>
+          <fieldset className="space-y-2 text-sm">
+            <legend className="text-gray-600 mb-1">Start with</legend>
+            <label className="flex items-center gap-2">
+              <input
+                type="radio"
+                name="seedMode"
+                checked={draftSeedMode === 'auto'}
+                onChange={() => setDraftSeedMode('auto')}
+              />
+              Auto-seed (gender-balanced, skill-aware)
+            </label>
+            <label className="flex items-center gap-2">
+              <input
+                type="radio"
+                name="seedMode"
+                checked={draftSeedMode === 'empty'}
+                onChange={() => setDraftSeedMode('empty')}
+              />
+              Empty teams (all players unassigned)
+            </label>
+            {hasExistingGroups ? (
+              <label className="flex items-center gap-2">
+                <input
+                  type="radio"
+                  name="seedMode"
+                  checked={draftSeedMode === 'existing'}
+                  onChange={() => setDraftSeedMode('existing')}
+                />
+                Copy current draft groups
+              </label>
+            ) : null}
+          </fieldset>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              className="rounded border px-3 py-2 text-sm"
+              onClick={discardDraft}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="rounded bg-blue-600 px-3 py-2 text-sm text-white"
+              onClick={startDraftBoard}
+            >
+              Start drafting
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {draftPhase === 'board' ? (
+        <EventDraftBoard
+          registrations={registrations}
+          teamCount={draftTeamCount}
+          assignments={draftAssignments}
+          onAssignmentsChange={setDraftAssignments}
+          onApply={() => void applyDraft()}
+          onDiscard={discardDraft}
+          applying={draftApplying}
+          error={draftError}
+        />
+      ) : null}
+
+      <div className="grid gap-3 sm:grid-cols-2 text-sm">
         <div className="rounded border border-gray-200 px-3 py-2">
           <div className="text-gray-500">Total</div>
           <div className="text-xl font-semibold">{counts.total}</div>
-        </div>
-        <div className="rounded border border-gray-200 px-3 py-2">
-          <div className="text-gray-500">Gender</div>
-          <div>
-            W/NB/O {counts.wNbO} · M {counts.men}
-            {counts.genderUnset ? ` · — ${counts.genderUnset}` : ''}
-          </div>
-        </div>
-        <div className="rounded border border-gray-200 px-3 py-2">
-          <div className="text-gray-500">Skill</div>
-          <div className="text-xs space-y-0.5">
-            {Object.entries(SKILL_LEVELS).map(([level, label]) => (
-              <div key={level}>
-                {label}: {counts.bySkill[level] ?? 0}
-              </div>
-            ))}
-            <div>Unset: {counts.bySkill.unset}</div>
-          </div>
         </div>
         <div className="rounded border border-gray-200 px-3 py-2">
           <div className="text-gray-500">Draft buckets</div>
@@ -390,100 +654,172 @@ function EventTrackerPageContent() {
         </div>
       </div>
 
-      <div className="flex flex-wrap items-center gap-3">
-        <label className="text-sm flex items-center gap-2">
-          <span className="text-gray-600">Filter</span>
-          <select
-            className="rounded border border-gray-300 px-2 py-1"
-            value={
-              draftFilter === 'all' || draftFilter === 'unassigned'
-                ? draftFilter
-                : String(draftFilter)
-            }
-            onChange={(e) => {
-              const v = e.target.value
-              if (v === 'all' || v === 'unassigned') setDraftFilter(v)
-              else setDraftFilter(Number.parseInt(v, 10))
-            }}
-          >
-            <option value="all">All</option>
-            <option value="unassigned">Unassigned</option>
-            {groupOptions.map((g) => (
-              <option key={g} value={g}>
-                Group {g}
-              </option>
-            ))}
-          </select>
-        </label>
-        <button
-          type="button"
-          className="rounded border px-2 py-1 text-sm"
-          onClick={() => setMaxGroup((n) => n + 1)}
-        >
-          Add group {maxGroup + 1}
-        </button>
-      </div>
-
       <div className="overflow-x-auto rounded border border-gray-200">
         <table className="min-w-full text-sm">
+          <caption className="sr-only">Gender by skill matrix</caption>
           <thead className="bg-gray-50 text-left">
             <tr>
-              <th className="px-3 py-2 font-medium">Name</th>
-              <th className="px-3 py-2 font-medium">Skill</th>
-              <th className="px-3 py-2 font-medium">Gender</th>
-              <th className="px-3 py-2 font-medium">Email</th>
-              <th className="px-3 py-2 font-medium">Draft group</th>
+              <th className="px-3 py-2 font-medium">Gender \\ Skill</th>
+              {SKILL_COLS.map((level) => (
+                <th key={String(level)} className="px-3 py-2 font-medium whitespace-nowrap">
+                  {skillColLabel(level)}
+                </th>
+              ))}
+              <th className="px-3 py-2 font-medium">Total</th>
             </tr>
           </thead>
           <tbody>
-            {filtered.length === 0 ? (
-              <tr>
-                <td colSpan={5} className="px-3 py-6 text-center text-gray-500">
-                  {registrations.length === 0
-                    ? 'No registrations yet. Import a TeamLinkt CSV for this event.'
-                    : 'No players match this filter.'}
+            {GENDER_ROWS.map((row) => (
+              <tr key={row} className="border-t border-gray-100">
+                <td className="px-3 py-2 font-medium">{genderRowLabel(row)}</td>
+                {SKILL_COLS.map((level) => {
+                  const key = level == null ? 'unset' : String(level)
+                  return (
+                    <td key={key} className="px-3 py-2 tabular-nums">
+                      {counts.matrix[row][key] ?? 0}
+                    </td>
+                  )
+                })}
+                <td className="px-3 py-2 font-medium tabular-nums">
+                  {counts.rowTotals[row]}
                 </td>
               </tr>
-            ) : (
-              filtered.map((r) => (
-                <tr key={r.id} className={`border-t border-gray-100 ${genderRowClass(r.gender)}`}>
-                  <td className="px-3 py-2">
-                    <SkillStyledText skillLevel={r.skillLevel}>
-                      {r.nickname || `${r.firstName} ${r.lastName}`}
-                    </SkillStyledText>
-                    <div className="text-xs text-gray-500">
-                      {r.firstName} {r.lastName}
-                    </div>
+            ))}
+            <tr className="border-t border-gray-200 bg-gray-50">
+              <td className="px-3 py-2 font-medium">Total</td>
+              {SKILL_COLS.map((level) => {
+                const key = level == null ? 'unset' : String(level)
+                return (
+                  <td key={key} className="px-3 py-2 font-medium tabular-nums">
+                    {counts.colTotals[key] ?? 0}
                   </td>
-                  <td className="px-3 py-2">
-                    {r.skillLevel != null ? skillLevelLabel(r.skillLevel) : '—'}
-                  </td>
-                  <td className="px-3 py-2">{r.genderGroupLabel}</td>
-                  <td className="px-3 py-2 text-xs">{r.primaryEmail ?? '—'}</td>
-                  <td className="px-3 py-2">
-                    <select
-                      className="rounded border border-gray-300 px-2 py-1 disabled:opacity-40"
-                      disabled={savingId === r.id}
-                      value={r.draftGroup == null ? '' : String(r.draftGroup)}
-                      onChange={(e) => {
-                        const v = e.target.value
-                        void setDraftGroup(r.id, v === '' ? null : Number.parseInt(v, 10))
-                      }}
-                    >
-                      <option value="">Unassigned</option>
-                      {groupOptions.map((g) => (
-                        <option key={g} value={g}>
-                          Group {g}
-                        </option>
-                      ))}
-                    </select>
-                  </td>
-                </tr>
-              ))
-            )}
+                )
+              })}
+              <td className="px-3 py-2 font-semibold tabular-nums">{counts.total}</td>
+            </tr>
           </tbody>
         </table>
       </div>
+
+      {draftPhase === 'off' ? (
+        <>
+          <div className="flex flex-wrap items-center gap-3">
+            <label className="text-sm flex items-center gap-2">
+              <span className="text-gray-600">Filter</span>
+              <select
+                className="rounded border border-gray-300 px-2 py-1"
+                value={
+                  draftFilter === 'all' || draftFilter === 'unassigned'
+                    ? draftFilter
+                    : String(draftFilter)
+                }
+                onChange={(e) => {
+                  const v = e.target.value
+                  if (v === 'all' || v === 'unassigned') setDraftFilter(v)
+                  else setDraftFilter(Number.parseInt(v, 10))
+                }}
+              >
+                <option value="all">All</option>
+                <option value="unassigned">Unassigned</option>
+                {groupOptions.map((g) => (
+                  <option key={g} value={g}>
+                    Group {g}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button
+              type="button"
+              className="rounded border px-2 py-1 text-sm"
+              onClick={() => setMaxGroup((n) => n + 1)}
+            >
+              Add group {maxGroup + 1}
+            </button>
+          </div>
+
+          <div className="overflow-x-auto rounded border border-gray-200">
+            <table className="min-w-full text-sm">
+              <thead className="bg-gray-50 text-left">
+                <tr>
+                  <th className="px-3 py-2 font-medium">Name</th>
+                  <th className="px-3 py-2 font-medium">Skill</th>
+                  <th className="px-3 py-2 font-medium">Gender</th>
+                  <th className="px-3 py-2 font-medium">Email</th>
+                  <th className="px-3 py-2 font-medium">Draft group</th>
+                  <th className="px-3 py-2 font-medium"> </th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className="px-3 py-6 text-center text-gray-500">
+                      {registrations.length === 0
+                        ? 'No registrations yet. Import a TeamLinkt CSV for this event.'
+                        : 'No players match this filter.'}
+                    </td>
+                  </tr>
+                ) : (
+                  filtered.map((r) => {
+                    const label =
+                      r.nickname || `${r.firstName} ${r.lastName}`
+                    return (
+                      <tr
+                        key={r.id}
+                        className={`border-t border-gray-100 ${genderRowClass(r.gender)}`}
+                      >
+                        <td className="px-3 py-2">
+                          <SkillStyledText skillLevel={r.skillLevel}>
+                            {label}
+                          </SkillStyledText>
+                          <div className="text-xs text-gray-500">
+                            {r.firstName} {r.lastName}
+                          </div>
+                        </td>
+                        <td className="px-3 py-2">
+                          {r.skillLevel != null ? skillLevelLabel(r.skillLevel) : '—'}
+                        </td>
+                        <td className="px-3 py-2">{r.genderGroupLabel}</td>
+                        <td className="px-3 py-2 text-xs">{r.primaryEmail ?? '—'}</td>
+                        <td className="px-3 py-2">
+                          <select
+                            className="rounded border border-gray-300 px-2 py-1 disabled:opacity-40"
+                            disabled={savingId === r.id}
+                            value={r.draftGroup == null ? '' : String(r.draftGroup)}
+                            onChange={(e) => {
+                              const v = e.target.value
+                              void setDraftGroup(
+                                r.id,
+                                v === '' ? null : Number.parseInt(v, 10)
+                              )
+                            }}
+                          >
+                            <option value="">Unassigned</option>
+                            {groupOptions.map((g) => (
+                              <option key={g} value={g}>
+                                Group {g}
+                              </option>
+                            ))}
+                          </select>
+                        </td>
+                        <td className="px-3 py-2">
+                          <button
+                            type="button"
+                            className="text-xs text-red-700 hover:underline disabled:opacity-40"
+                            disabled={removingId === r.id}
+                            onClick={() => void removeRegistration(r.id, label)}
+                          >
+                            Remove
+                          </button>
+                        </td>
+                      </tr>
+                    )
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+        </>
+      ) : null}
 
       {importOpen ? (
         <div className="fixed inset-0 z-40 bg-black/40 flex items-center justify-center p-4">

--- a/app/lib/events/draft-seed.ts
+++ b/app/lib/events/draft-seed.ts
@@ -1,0 +1,173 @@
+import { genderGroup, type GenderGroup } from '@/app/lib/players/gender'
+
+export type DraftSeedPlayer = {
+  id: string
+  skillLevel: number | null
+  gender: string | null
+}
+
+/** Default team count targeting ~7–8 players per team. */
+export function defaultTeamCount(playerCount: number): number {
+  if (playerCount <= 0) return 1
+  return Math.max(1, Math.round(playerCount / 7.5))
+}
+
+function skillScore(skillLevel: number | null): number {
+  return skillLevel ?? 0
+}
+
+function sortBySkillDesc(players: DraftSeedPlayer[]): DraftSeedPlayer[] {
+  return [...players].sort((a, b) => {
+    const skillDiff = skillScore(b.skillLevel) - skillScore(a.skillLevel)
+    if (skillDiff !== 0) return skillDiff
+    return a.id.localeCompare(b.id)
+  })
+}
+
+/**
+ * Auto-seed teams: gender-balanced (W/NB/O vs men), skill-aware snake draft.
+ * Returns map of player id → team number (1..teamCount). Unset gender players
+ * are placed last into the currently smallest / lowest-score teams.
+ */
+export function autoSeedDraftGroups(
+  players: DraftSeedPlayer[],
+  teamCount: number
+): Map<string, number> {
+  const n = Math.max(1, Math.floor(teamCount))
+  const assignments = new Map<string, number>()
+
+  if (players.length === 0) return assignments
+
+  const pools: Record<GenderGroup, DraftSeedPlayer[]> = {
+    w_nb_o: [],
+    men: [],
+    unset: [],
+  }
+  for (const p of players) {
+    pools[genderGroup(p.gender)].push(p)
+  }
+  for (const key of Object.keys(pools) as GenderGroup[]) {
+    pools[key] = sortBySkillDesc(pools[key])
+  }
+
+  const teamSizes = Array.from({ length: n }, () => 0)
+  const teamScores = Array.from({ length: n }, () => 0)
+  const teamGender = Array.from({ length: n }, () => ({ w_nb_o: 0, men: 0 }))
+
+  function pickTeam(preferGender: 'w_nb_o' | 'men' | null): number {
+    let best = 0
+    let bestKey: [number, number, number, number] | null = null
+
+    for (let i = 0; i < n; i++) {
+      const genderImbalance =
+        preferGender == null
+          ? 0
+          : preferGender === 'w_nb_o'
+            ? teamGender[i].w_nb_o - teamGender[i].men
+            : teamGender[i].men - teamGender[i].w_nb_o
+      // Prefer: smaller size, then lower gender imbalance for preferred group,
+      // then lower skill total, then lower index (stable).
+      const key: [number, number, number, number] = [
+        teamSizes[i],
+        genderImbalance,
+        teamScores[i],
+        i,
+      ]
+      if (
+        bestKey == null ||
+        key[0] < bestKey[0] ||
+        (key[0] === bestKey[0] && key[1] < bestKey[1]) ||
+        (key[0] === bestKey[0] && key[1] === bestKey[1] && key[2] < bestKey[2]) ||
+        (key[0] === bestKey[0] &&
+          key[1] === bestKey[1] &&
+          key[2] === bestKey[2] &&
+          key[3] < bestKey[3])
+      ) {
+        best = i
+        bestKey = key
+      }
+    }
+    return best
+  }
+
+  function assign(player: DraftSeedPlayer, teamIndex: number) {
+    const team = teamIndex + 1
+    assignments.set(player.id, team)
+    teamSizes[teamIndex]++
+    teamScores[teamIndex] += skillScore(player.skillLevel)
+    const g = genderGroup(player.gender)
+    if (g === 'w_nb_o') teamGender[teamIndex].w_nb_o++
+    else if (g === 'men') teamGender[teamIndex].men++
+  }
+
+  // Interleave W/NB/O and men by skill (snake-style via pickTeam heuristics).
+  const primary = pools.w_nb_o
+  const secondary = pools.men
+  let i = 0
+  let j = 0
+  let takePrimary = primary.length >= secondary.length
+
+  while (i < primary.length || j < secondary.length) {
+    if (takePrimary && i < primary.length) {
+      assign(primary[i++], pickTeam('w_nb_o'))
+    } else if (!takePrimary && j < secondary.length) {
+      assign(secondary[j++], pickTeam('men'))
+    } else if (i < primary.length) {
+      assign(primary[i++], pickTeam('w_nb_o'))
+    } else if (j < secondary.length) {
+      assign(secondary[j++], pickTeam('men'))
+    }
+    takePrimary = !takePrimary
+  }
+
+  for (const player of pools.unset) {
+    assign(player, pickTeam(null))
+  }
+
+  return assignments
+}
+
+/** Empty seed: everyone unassigned. */
+export function emptySeedDraftGroups(
+  players: DraftSeedPlayer[]
+): Map<string, number | null> {
+  const assignments = new Map<string, number | null>()
+  for (const p of players) {
+    assignments.set(p.id, null)
+  }
+  return assignments
+}
+
+/** Copy permanent draftGroup into local workspace. */
+export function copyExistingDraftGroups(
+  players: Array<DraftSeedPlayer & { draftGroup: number | null }>
+): Map<string, number | null> {
+  const assignments = new Map<string, number | null>()
+  for (const p of players) {
+    assignments.set(p.id, p.draftGroup)
+  }
+  return assignments
+}
+
+export function teamSkillTotal(
+  players: Array<{ skillLevel: number | null }>
+): number {
+  return players.reduce((sum, p) => sum + skillScore(p.skillLevel), 0)
+}
+
+export function teamGenderCounts(players: Array<{ gender: string | null }>): {
+  wNbO: number
+  men: number
+  unset: number
+} {
+  let wNbO = 0
+  let men = 0
+  let unset = 0
+  for (const p of players) {
+    const g = genderGroup(p.gender)
+    if (g === 'w_nb_o') wNbO++
+    else if (g === 'men') men++
+    else unset++
+  }
+  return { wNbO, men, unset }
+}

--- a/app/lib/events/mutations.ts
+++ b/app/lib/events/mutations.ts
@@ -100,6 +100,12 @@ export async function updateEvent(
   return updated
 }
 
+export async function deleteEvent(id: string): Promise<void> {
+  const db = getDb()
+  const deleted = await db.delete(events).where(eq(events.id, id)).returning({ id: events.id })
+  if (deleted.length === 0) throw new Error('Event not found')
+}
+
 /**
  * Create registration if missing; if present only refresh importBatchId / updatedAt.
  * Never clears draftGroup.
@@ -176,4 +182,67 @@ export async function updateRegistrationDraftGroup(
 
   if (!updated) throw new Error('Registration not found')
   return updated
+}
+
+export async function deleteEventRegistration(
+  eventId: string,
+  registrationId: string
+): Promise<void> {
+  const db = getDb()
+  const deleted = await db
+    .delete(eventRegistrations)
+    .where(
+      and(
+        eq(eventRegistrations.id, registrationId),
+        eq(eventRegistrations.eventId, eventId)
+      )
+    )
+    .returning({ id: eventRegistrations.id })
+
+  if (deleted.length === 0) throw new Error('Registration not found')
+}
+
+export async function bulkUpdateRegistrationDraftGroups(
+  eventId: string,
+  assignments: Array<{ registrationId: string; draftGroup: number | null }>
+): Promise<Array<{ id: string; draftGroup: number | null }>> {
+  if (assignments.length === 0) return []
+
+  const parsed = assignments.map((a) => {
+    const draftGroup = parseDraftGroup(a.draftGroup)
+    if (draftGroup === undefined) {
+      throw new Error('draftGroup is required for each assignment')
+    }
+    if (!a.registrationId || typeof a.registrationId !== 'string') {
+      throw new Error('registrationId is required for each assignment')
+    }
+    return { registrationId: a.registrationId, draftGroup }
+  })
+
+  const db = getDb()
+  const now = new Date()
+  const results: Array<{ id: string; draftGroup: number | null }> = []
+
+  for (const { registrationId, draftGroup } of parsed) {
+    const [updated] = await db
+      .update(eventRegistrations)
+      .set({ draftGroup, updatedAt: now })
+      .where(
+        and(
+          eq(eventRegistrations.id, registrationId),
+          eq(eventRegistrations.eventId, eventId)
+        )
+      )
+      .returning({
+        id: eventRegistrations.id,
+        draftGroup: eventRegistrations.draftGroup,
+      })
+
+    if (!updated) {
+      throw new Error(`Registration not found: ${registrationId}`)
+    }
+    results.push(updated)
+  }
+
+  return results
 }

--- a/app/lib/events/mutations.ts
+++ b/app/lib/events/mutations.ts
@@ -1,4 +1,4 @@
-import { and, eq } from 'drizzle-orm'
+import { and, eq, inArray } from 'drizzle-orm'
 import { getDb } from '@/app/lib/db'
 import { eventRegistrations, events } from '@/app/db/schema'
 import {
@@ -220,6 +220,25 @@ export async function bulkUpdateRegistrationDraftGroups(
   })
 
   const db = getDb()
+  const ids = parsed.map((p) => p.registrationId)
+  const existing = await db
+    .select({ id: eventRegistrations.id })
+    .from(eventRegistrations)
+    .where(
+      and(
+        eq(eventRegistrations.eventId, eventId),
+        inArray(eventRegistrations.id, ids)
+      )
+    )
+  const existingIds = new Set(existing.map((row) => row.id))
+  for (const registrationId of ids) {
+    if (!existingIds.has(registrationId)) {
+      throw new Error(`Registration not found: ${registrationId}`)
+    }
+  }
+
+  // Neon HTTP has no multi-statement transactions; preflight above avoids
+  // partial applies from missing/mismatched IDs before any writes.
   const now = new Date()
   const results: Array<{ id: string; draftGroup: number | null }> = []
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "bdl-admin",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@ffmpeg/core": "^0.12.10",
         "@ffmpeg/ffmpeg": "^0.12.15",
         "@ffmpeg/util": "^0.12.2",
@@ -526,6 +529,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@drizzle-team/brocli": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "node": ">=20.0.0"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@ffmpeg/core": "^0.12.10",
     "@ffmpeg/ffmpeg": "^0.12.15",
     "@ffmpeg/util": "^0.12.2",


### PR DESCRIPTION
## Summary
- Add events and registrations (TeamLinkt import into an event, roster view, draft group buckets) with gender × skill matrix on the event detail page
- Support deleting events and removing players from an event roster
- Add draft mode as a local working copy: choose team count (~7–8 players), auto-seed or empty teams, drag-and-drop, team skill totals, then Apply or Discard

## Test plan
- [ ] Create an event and import a TeamLinkt CSV; confirm players appear on the roster
- [ ] Confirm gender × skill matrix counts match the roster
- [ ] Remove a player from the event; confirm they stay in Players but leave the event
- [ ] Enter draft mode with auto-seed and with empty teams; drag players between teams; verify scores and gender splits update
- [ ] Discard draft and confirm permanent draft groups are unchanged; Apply and confirm groups persist
- [ ] Delete an event and confirm redirect to `/events` and cascade of registrations


Made with [Cursor](https://cursor.com)