### PR TITLE
Improve draft team sizing and add reshuffle

### DIFF
--- a/app/__tests__/event-draft-seed.test.ts
+++ b/app/__tests__/event-draft-seed.test.ts
@@ -4,6 +4,7 @@ import {
   copyExistingDraftGroups,
   defaultTeamCount,
   emptySeedDraftGroups,
+  playersPerTeamLabel,
   teamGenderCounts,
   teamSkillTotal,
   type DraftSeedPlayer,
@@ -17,6 +18,29 @@ function player(
   return { id, skillLevel, gender }
 }
 
+/** Deterministic PRNG for shuffle tests (mulberry32). */
+function mulberry32(seed: number): () => number {
+  let t = seed >>> 0
+  return () => {
+    t = (t + 0x6d2b79f5) >>> 0
+    let r = Math.imul(t ^ (t >>> 15), 1 | t)
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r)
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+describe('playersPerTeamLabel', () => {
+  it('shows a single size when even', () => {
+    expect(playersPerTeamLabel(14, 2)).toBe('7')
+    expect(playersPerTeamLabel(0, 2)).toBe('0')
+  })
+
+  it('shows a range when uneven', () => {
+    expect(playersPerTeamLabel(15, 2)).toBe('7–8')
+    expect(playersPerTeamLabel(22, 3)).toBe('7–8')
+  })
+})
+
 describe('defaultTeamCount', () => {
   it('targets roughly 7–8 players per team', () => {
     expect(defaultTeamCount(0)).toBe(1)
@@ -25,6 +49,10 @@ describe('defaultTeamCount', () => {
     expect(defaultTeamCount(15)).toBe(2)
     expect(defaultTeamCount(56)).toBe(7)
     expect(defaultTeamCount(60)).toBe(8)
+  })
+
+  it('prefers 6 over 9', () => {
+    expect(defaultTeamCount(18)).toBe(3) // 3×6, not 2×9
   })
 })
 
@@ -110,6 +138,35 @@ describe('autoSeedDraftGroups', () => {
     ]
     const result = autoSeedDraftGroups(players, 2)
     expect(result.size).toBe(3)
+  })
+
+  it('can produce different layouts when shuffled with different seeds', () => {
+    const players = Array.from({ length: 16 }, (_, i) =>
+      player(
+        `p${i}`,
+        (i % 4) + 1,
+        i % 2 === 0 ? 'woman' : 'man'
+      )
+    )
+    const a = autoSeedDraftGroups(players, 2, {
+      shuffle: true,
+      random: mulberry32(1),
+    })
+    const b = autoSeedDraftGroups(players, 2, {
+      shuffle: true,
+      random: mulberry32(99),
+    })
+    const same = [...a.entries()].every(([id, team]) => b.get(id) === team)
+    expect(same).toBe(false)
+  })
+
+  it('is deterministic when shuffle is off', () => {
+    const players = Array.from({ length: 12 }, (_, i) =>
+      player(`p${i}`, (i % 3) + 1, i % 2 === 0 ? 'woman' : 'man')
+    )
+    const a = autoSeedDraftGroups(players, 3)
+    const b = autoSeedDraftGroups(players, 3)
+    expect([...a.entries()]).toEqual([...b.entries()])
   })
 })
 

--- a/app/components/events/EventDraftBoard.tsx
+++ b/app/components/events/EventDraftBoard.tsx
@@ -33,6 +33,7 @@ type Props = {
   teamCount: number
   assignments: DraftAssignment
   onAssignmentsChange: (next: DraftAssignment) => void
+  onReshuffle: () => void
   onApply: () => void
   onDiscard: () => void
   applying: boolean
@@ -187,6 +188,7 @@ export function EventDraftBoard(props: Props) {
     teamCount,
     assignments,
     onAssignmentsChange,
+    onReshuffle,
     onApply,
     onDiscard,
     applying,
@@ -319,6 +321,14 @@ export function EventDraftBoard(props: Props) {
               <option value="skill">Skill (high → low)</option>
             </select>
           </label>
+          <button
+            type="button"
+            className="rounded border border-gray-300 bg-white px-3 py-2 text-sm"
+            disabled={applying}
+            onClick={onReshuffle}
+          >
+            Reshuffle
+          </button>
           <button
             type="button"
             className="rounded border border-gray-300 bg-white px-3 py-2 text-sm"

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -18,6 +18,7 @@ import {
   copyExistingDraftGroups,
   defaultTeamCount,
   emptySeedDraftGroups,
+  playersPerTeamLabel,
 } from '@/app/lib/events/draft-seed'
 import type { EventRegistrationListItem } from '@/app/lib/events/types'
 import { genderGroup } from '@/app/lib/players/gender'
@@ -367,6 +368,21 @@ function EventTrackerPageContent() {
     setDraftPhase('board')
   }
 
+  function reshuffleDraft() {
+    const seeds = registrations.map((r) => ({
+      id: r.id,
+      skillLevel: r.skillLevel,
+      gender: r.gender,
+    }))
+    const n = Math.max(1, Math.floor(draftTeamCount))
+    const seeded = autoSeedDraftGroups(seeds, n, { shuffle: true })
+    const next = new Map<string, number | null>()
+    for (const r of registrations) {
+      next.set(r.id, seeded.get(r.id) ?? null)
+    }
+    setDraftAssignments(next)
+  }
+
   function discardDraft() {
     setDraftPhase('off')
     setDraftAssignments(new Map())
@@ -570,9 +586,7 @@ function EventTrackerPageContent() {
               }
             />
             <span className="mt-1 block text-xs text-gray-500">
-              ~{registrations.length > 0
-                ? (registrations.length / Math.max(1, draftTeamCount)).toFixed(1)
-                : 0}{' '}
+              ~{playersPerTeamLabel(registrations.length, draftTeamCount)}{' '}
               players per team
             </span>
           </label>
@@ -633,6 +647,7 @@ function EventTrackerPageContent() {
           teamCount={draftTeamCount}
           assignments={draftAssignments}
           onAssignmentsChange={setDraftAssignments}
+          onReshuffle={reshuffleDraft}
           onApply={() => void applyDraft()}
           onDiscard={discardDraft}
           applying={draftApplying}

--- a/app/lib/events/draft-seed.ts
+++ b/app/lib/events/draft-seed.ts
@@ -6,10 +6,63 @@ export type DraftSeedPlayer = {
   gender: string | null
 }
 
-/** Default team count targeting ~7–8 players per team. */
+export type AutoSeedOptions = {
+  /** When true, randomize equal-skill order and team index tie-breaks. */
+  shuffle?: boolean
+  /** RNG in [0, 1). Defaults to Math.random. Inject for tests. */
+  random?: () => number
+}
+
+/**
+ * Format expected players-per-team as an integer or range (e.g. "7" or "7–8").
+ */
+export function playersPerTeamLabel(
+  playerCount: number,
+  teamCount: number
+): string {
+  if (playerCount <= 0 || teamCount <= 0) return '0'
+  const t = Math.max(1, Math.floor(teamCount))
+  const base = Math.floor(playerCount / t)
+  const rem = playerCount % t
+  if (rem === 0) return String(base)
+  return `${base}–${base + 1}`
+}
+
+/** Penalty for a single team size. Ideal band is 7–8; 6 beats 9. */
+function sizePenalty(size: number): number {
+  if (size >= 7 && size <= 8) return 0
+  if (size < 7) {
+    const d = 7 - size
+    return d * d // 6→1, 5→4, 4→9, …
+  }
+  const d = size - 8
+  return d * d * 3 // 9→3, 10→12, … (oversized costs more than undersized)
+}
+
+function configPenalty(playerCount: number, teams: number): number {
+  const base = Math.floor(playerCount / teams)
+  const large = playerCount % teams
+  const small = teams - large
+  return large * sizePenalty(base + 1) + small * sizePenalty(base)
+}
+
+/**
+ * Default team count targeting 7–8 players per team.
+ * Prefers 6 over 9 when the ideal band is unreachable.
+ * Tie-break: fewer teams (larger teams when equally good).
+ */
 export function defaultTeamCount(playerCount: number): number {
   if (playerCount <= 0) return 1
-  return Math.max(1, Math.round(playerCount / 7.5))
+  let bestTeams = 1
+  let bestPenalty = configPenalty(playerCount, 1)
+  for (let t = 2; t <= playerCount; t++) {
+    const penalty = configPenalty(playerCount, t)
+    if (penalty < bestPenalty) {
+      bestPenalty = penalty
+      bestTeams = t
+    }
+  }
+  return bestTeams
 }
 
 function skillScore(skillLevel: number | null): number {
@@ -24,6 +77,46 @@ function sortBySkillDesc(players: DraftSeedPlayer[]): DraftSeedPlayer[] {
   })
 }
 
+/** Fisher–Yates shuffle within equal-skill bands (list already skill-sorted). */
+function shuffleEqualSkillBands(
+  players: DraftSeedPlayer[],
+  random: () => number
+): DraftSeedPlayer[] {
+  const result = [...players]
+  let i = 0
+  while (i < result.length) {
+    let j = i + 1
+    const skill = skillScore(result[i].skillLevel)
+    while (j < result.length && skillScore(result[j].skillLevel) === skill) {
+      j++
+    }
+    for (let k = j - 1; k > i; k--) {
+      const r = i + Math.floor(random() * (k - i + 1))
+      const tmp = result[k]
+      result[k] = result[r]
+      result[r] = tmp
+    }
+    i = j
+  }
+  return result
+}
+
+/** Fixed random permutation used as stable tie-break ranks for teams. */
+function teamTieBreakRanks(n: number, random: () => number): number[] {
+  const order = Array.from({ length: n }, (_, i) => i)
+  for (let k = n - 1; k > 0; k--) {
+    const r = Math.floor(random() * (k + 1))
+    const tmp = order[k]
+    order[k] = order[r]
+    order[r] = tmp
+  }
+  const ranks = Array.from({ length: n }, () => 0)
+  for (let rank = 0; rank < n; rank++) {
+    ranks[order[rank]] = rank
+  }
+  return ranks
+}
+
 /**
  * Auto-seed teams: gender-balanced (W/NB/O vs men), skill-aware snake draft.
  * Returns map of player id → team number (1..teamCount). Unset gender players
@@ -31,10 +124,13 @@ function sortBySkillDesc(players: DraftSeedPlayer[]): DraftSeedPlayer[] {
  */
 export function autoSeedDraftGroups(
   players: DraftSeedPlayer[],
-  teamCount: number
+  teamCount: number,
+  options?: AutoSeedOptions
 ): Map<string, number> {
   const n = Math.max(1, Math.floor(teamCount))
   const assignments = new Map<string, number>()
+  const shuffle = options?.shuffle === true
+  const random = options?.random ?? Math.random
 
   if (players.length === 0) return assignments
 
@@ -47,12 +143,16 @@ export function autoSeedDraftGroups(
     pools[genderGroup(p.gender)].push(p)
   }
   for (const key of Object.keys(pools) as GenderGroup[]) {
-    pools[key] = sortBySkillDesc(pools[key])
+    const sorted = sortBySkillDesc(pools[key])
+    pools[key] = shuffle ? shuffleEqualSkillBands(sorted, random) : sorted
   }
 
   const teamSizes = Array.from({ length: n }, () => 0)
   const teamScores = Array.from({ length: n }, () => 0)
   const teamGender = Array.from({ length: n }, () => ({ w_nb_o: 0, men: 0 }))
+  const tieBreak = shuffle
+    ? teamTieBreakRanks(n, random)
+    : Array.from({ length: n }, (_, i) => i)
 
   function pickTeam(preferGender: 'w_nb_o' | 'men' | null): number {
     let best = 0
@@ -66,12 +166,12 @@ export function autoSeedDraftGroups(
             ? teamGender[i].w_nb_o - teamGender[i].men
             : teamGender[i].men - teamGender[i].w_nb_o
       // Prefer: smaller size, then lower gender imbalance for preferred group,
-      // then lower skill total, then lower index (stable).
+      // then lower skill total, then lower tie-break rank (stable or shuffled).
       const key: [number, number, number, number] = [
         teamSizes[i],
         genderImbalance,
         teamScores[i],
-        i,
+        tieBreak[i],
       ]
       if (
         bestKey == null ||


### PR DESCRIPTION
## Summary
- Show players-per-team as an integer range (e.g. `7–8`) instead of a decimal average
- Score default team counts to prefer 7–8 players per team, with 6 preferred over 9
- Add a Reshuffle button on the draft board that re-runs auto-seed with randomized tie-breaks while keeping gender/skill balancing

## Test plan
- [ ] Open event draft setup and confirm players-per-team shows `~7–8` (or `~7` when even)
- [ ] Confirm default team count for 18 players is 3 (teams of 6), not 2 (teams of 9)
- [ ] Start draft board, click Reshuffle, and confirm team assignments change but remain balanced
- [ ] Run `npx vitest run app/__tests__/event-draft-seed.test.ts`


Made with [Cursor](https://cursor.com)