### PR TITLE
Events: unassigned visibility, pair signups, and draft snapshots (#83 #85 #82)

### DIFF
--- a/app/__tests__/event-draft-seed.test.ts
+++ b/app/__tests__/event-draft-seed.test.ts
@@ -5,6 +5,7 @@ import {
   defaultTeamCount,
   emptySeedDraftGroups,
   playersPerTeamLabel,
+  summarizeDraftAssignments,
   teamGenderCounts,
   teamSkillTotal,
   type DraftSeedPlayer,
@@ -167,6 +168,56 @@ describe('autoSeedDraftGroups', () => {
     const a = autoSeedDraftGroups(players, 3)
     const b = autoSeedDraftGroups(players, 3)
     expect([...a.entries()]).toEqual([...b.entries()])
+  })
+
+  it('keeps paired players on the same team', () => {
+    const players: DraftSeedPlayer[] = [
+      { id: 'a', skillLevel: 4, gender: 'woman', pairId: 'pair-1' },
+      { id: 'b', skillLevel: 3, gender: 'man', pairId: 'pair-1' },
+      { id: 'c', skillLevel: 2, gender: 'woman' },
+      { id: 'd', skillLevel: 2, gender: 'man' },
+      { id: 'e', skillLevel: 1, gender: 'woman' },
+      { id: 'f', skillLevel: 1, gender: 'man' },
+    ]
+    const result = autoSeedDraftGroups(players, 2)
+    expect(result.get('a')).toBe(result.get('b'))
+    expect(result.get('a')).toBeGreaterThanOrEqual(1)
+  })
+
+  it('still assigns all players when pairs are present', () => {
+    const players: DraftSeedPlayer[] = [
+      { id: 'a', skillLevel: 4, gender: 'woman', pairId: 'p1' },
+      { id: 'b', skillLevel: 4, gender: 'man', pairId: 'p1' },
+      { id: 'c', skillLevel: 3, gender: 'woman', pairId: 'p2' },
+      { id: 'd', skillLevel: 3, gender: 'man', pairId: 'p2' },
+      { id: 'e', skillLevel: 2, gender: 'woman' },
+      { id: 'f', skillLevel: 2, gender: 'man' },
+    ]
+    const result = autoSeedDraftGroups(players, 3)
+    expect(result.size).toBe(6)
+    expect(result.get('a')).toBe(result.get('b'))
+    expect(result.get('c')).toBe(result.get('d'))
+  })
+})
+
+describe('summarizeDraftAssignments', () => {
+  it('summarizes unassigned and per-team stats', () => {
+    const registrations = [
+      { id: 'a', skillLevel: 4, gender: 'woman' },
+      { id: 'b', skillLevel: 2, gender: 'man' },
+      { id: 'c', skillLevel: 3, gender: 'woman' },
+    ]
+    const summary = summarizeDraftAssignments(
+      registrations,
+      { a: 1, b: 1, c: null },
+      2
+    )
+    expect(summary.unassigned).toBe(1)
+    expect(summary.teams[0].size).toBe(2)
+    expect(summary.teams[0].skillTotal).toBe(6)
+    expect(summary.teams[0].gender.wNbO).toBe(1)
+    expect(summary.teams[0].gender.men).toBe(1)
+    expect(summary.teams[1].size).toBe(0)
   })
 })
 

--- a/app/__tests__/event-draft-snapshots.test.ts
+++ b/app/__tests__/event-draft-snapshots.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { parseDraftGroup } from '@/app/lib/events/types'
+
+describe('snapshot assignment parsing via parseDraftGroup', () => {
+  it('accepts null and positive teams used in snapshot JSON', () => {
+    expect(parseDraftGroup(null)).toBeNull()
+    expect(parseDraftGroup(1)).toBe(1)
+    expect(parseDraftGroup(4)).toBe(4)
+  })
+
+  it('rejects invalid draft groups that snapshots must not store', () => {
+    expect(() => parseDraftGroup(0)).toThrow(/positive integer/)
+    expect(() => parseDraftGroup(-2)).toThrow(/positive integer/)
+  })
+})

--- a/app/api/events/[id]/draft-snapshots/[snapshotId]/promote/route.ts
+++ b/app/api/events/[id]/draft-snapshots/[snapshotId]/promote/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import { promoteEventDraftSnapshot } from '@/app/lib/events/mutations'
+import { getEvent } from '@/app/lib/events/queries'
+
+type RouteContext = {
+  params: Promise<{ id: string; snapshotId: string }>
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id, snapshotId } = await context.params
+    const event = await getEvent(id)
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    }
+
+    const results = await promoteEventDraftSnapshot(id, snapshotId)
+    return NextResponse.json({ ok: true, results })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to promote snapshot'
+    const status =
+      message === 'Snapshot not found' || message.includes('Registration not found')
+        ? 404
+        : message.includes('draftGroup') || message.includes('assignments')
+          ? 400
+          : 500
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/events/[id]/draft-snapshots/[snapshotId]/route.ts
+++ b/app/api/events/[id]/draft-snapshots/[snapshotId]/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import {
+  deleteEventDraftSnapshot,
+  getEventDraftSnapshot,
+  renameEventDraftSnapshot,
+} from '@/app/lib/events/mutations'
+import { getEvent } from '@/app/lib/events/queries'
+
+type RouteContext = {
+  params: Promise<{ id: string; snapshotId: string }>
+}
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id, snapshotId } = await context.params
+    const event = await getEvent(id)
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    }
+    const snapshot = await getEventDraftSnapshot(id, snapshotId)
+    if (!snapshot) {
+      return NextResponse.json({ error: 'Snapshot not found' }, { status: 404 })
+    }
+    return NextResponse.json({ snapshot })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to load snapshot'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id, snapshotId } = await context.params
+    const event = await getEvent(id)
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    }
+
+    const body = (await request.json()) as { name?: unknown }
+    if (typeof body.name !== 'string') {
+      return NextResponse.json({ error: 'name is required' }, { status: 400 })
+    }
+
+    const snapshot = await renameEventDraftSnapshot(id, snapshotId, body.name)
+    return NextResponse.json({ snapshot })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to rename snapshot'
+    const status =
+      message === 'Snapshot not found'
+        ? 404
+        : message.includes('required')
+          ? 400
+          : 500
+    return NextResponse.json({ error: message }, { status })
+  }
+}
+
+export async function DELETE(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id, snapshotId } = await context.params
+    const event = await getEvent(id)
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    }
+    await deleteEventDraftSnapshot(id, snapshotId)
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to delete snapshot'
+    const status = message === 'Snapshot not found' ? 404 : 500
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/events/[id]/draft-snapshots/route.ts
+++ b/app/api/events/[id]/draft-snapshots/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import {
+  createEventDraftSnapshot,
+  listEventDraftSnapshots,
+} from '@/app/lib/events/mutations'
+import { getEvent } from '@/app/lib/events/queries'
+
+type RouteContext = { params: Promise<{ id: string }> }
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id } = await context.params
+    const event = await getEvent(id)
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    }
+    const snapshots = await listEventDraftSnapshots(id)
+    return NextResponse.json({ snapshots })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to list snapshots'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id } = await context.params
+    const event = await getEvent(id)
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    }
+
+    const body = (await request.json()) as {
+      name?: unknown
+      assignments?: unknown
+    }
+    if (typeof body.name !== 'string') {
+      return NextResponse.json({ error: 'name is required' }, { status: 400 })
+    }
+
+    const snapshot = await createEventDraftSnapshot({
+      eventId: id,
+      name: body.name,
+      assignments: body.assignments,
+    })
+    return NextResponse.json({ snapshot }, { status: 201 })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to create snapshot'
+    const status =
+      message.includes('required') || message.includes('assignments')
+        ? 400
+        : 500
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/events/[id]/registrations/[registrationId]/route.ts
+++ b/app/api/events/[id]/registrations/[registrationId]/route.ts
@@ -5,6 +5,8 @@ import {
 } from '@/app/lib/admin-auth'
 import {
   deleteEventRegistration,
+  pairRegistrations,
+  unpairRegistration,
   updateRegistrationCaptain,
   updateRegistrationDraftGroup,
 } from '@/app/lib/events/mutations'
@@ -26,7 +28,35 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       return NextResponse.json({ error: 'Event not found' }, { status: 404 })
     }
 
-    const body = (await request.json()) as { draftGroup?: unknown; isCaptain?: unknown }
+    const body = (await request.json()) as {
+      draftGroup?: unknown
+      isCaptain?: unknown
+      pairWithRegistrationId?: unknown
+      unpair?: unknown
+    }
+
+    if (body.unpair === true) {
+      const result = await unpairRegistration(id, registrationId)
+      return NextResponse.json({ result })
+    }
+
+    if ('pairWithRegistrationId' in body) {
+      if (
+        typeof body.pairWithRegistrationId !== 'string' ||
+        !body.pairWithRegistrationId
+      ) {
+        return NextResponse.json(
+          { error: 'pairWithRegistrationId must be a registration id' },
+          { status: 400 }
+        )
+      }
+      const result = await pairRegistrations(
+        id,
+        registrationId,
+        body.pairWithRegistrationId
+      )
+      return NextResponse.json({ result })
+    }
 
     if ('isCaptain' in body) {
       if (typeof body.isCaptain !== 'boolean') {
@@ -55,7 +85,10 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     const status =
       message === 'Registration not found'
         ? 404
-        : message.includes('draftGroup')
+        : message.includes('draftGroup') ||
+            message.includes('pair') ||
+            message.includes('Cannot pair') ||
+            message.includes('already paired')
           ? 400
           : 500
     return NextResponse.json({ error: message }, { status })

--- a/app/components/events/EventDraftBoard.tsx
+++ b/app/components/events/EventDraftBoard.tsx
@@ -17,10 +17,14 @@ import { sortableKeyboardCoordinates } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import {
+  summarizeDraftAssignments,
   teamGenderCounts,
   teamSkillTotal,
 } from '@/app/lib/events/draft-seed'
-import type { EventRegistrationListItem } from '@/app/lib/events/types'
+import type {
+  EventDraftSnapshotListItem,
+  EventRegistrationListItem,
+} from '@/app/lib/events/types'
 import { genderGroup, genderGroupSortKey } from '@/app/lib/players/gender'
 import { skillLevelLabel } from '@/app/lib/players/skill'
 
@@ -40,6 +44,13 @@ type Props = {
   onDiscard: () => void
   applying: boolean
   error: string | null
+  snapshots: EventDraftSnapshotListItem[]
+  snapshotsBusy: boolean
+  onSaveSnapshot: (name: string) => Promise<void>
+  onLoadSnapshot: (snapshotId: string) => void
+  onRenameSnapshot: (snapshotId: string, name: string) => Promise<void>
+  onDeleteSnapshot: (snapshotId: string) => Promise<void>
+  onPromoteSnapshot: (snapshotId: string) => Promise<void>
 }
 
 function columnId(team: number | null): string {
@@ -105,6 +116,19 @@ function DraftPlayerCard(props: {
             ⚡
           </span>
         ) : null}
+        {player.pairId ? (
+          <span
+            className="ml-1 text-[10px] font-semibold uppercase tracking-wide text-violet-700"
+            title={
+              player.partnerNickname
+                ? `Paired with ${player.partnerNickname}`
+                : 'Paired'
+            }
+          >
+            Pair
+            {player.partnerNickname ? ` · ${player.partnerNickname}` : ''}
+          </span>
+        ) : null}
       </div>
       <div className="text-gray-600">
         {player.skillLevel != null ? skillLevelLabel(player.skillLevel) : '—'} ·{' '}
@@ -163,6 +187,7 @@ function TeamColumn(props: {
   showAverage?: boolean
   scoreImbalanced?: boolean
   genderImbalanced?: boolean
+  emphasizeUnassigned?: boolean
   onCopy?: () => Promise<void>
 }) {
   const id = columnId(props.team)
@@ -179,6 +204,7 @@ function TeamColumn(props: {
   const [copyError, setCopyError] = useState(false)
   const [isCopying, setIsCopying] = useState(false)
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const emphasizeUnassigned = Boolean(props.emphasizeUnassigned && count > 0)
 
   useEffect(() => {
     return () => {
@@ -213,14 +239,36 @@ function TeamColumn(props: {
     <div
       ref={setNodeRef}
       className={`flex min-h-[220px] w-56 shrink-0 flex-col rounded-lg border ${
-        isOver ? 'border-blue-400 bg-blue-50/40' : 'border-gray-200 bg-gray-50/50'
+        isOver
+          ? 'border-blue-400 bg-blue-50/40'
+          : emphasizeUnassigned
+            ? 'border-amber-300 bg-amber-50/50'
+            : 'border-gray-200 bg-gray-50/50'
       }`}
     >
-      <div className="border-b border-gray-200 px-2 py-2">
+      <div
+        className={`border-b px-2 py-2 ${
+          emphasizeUnassigned ? 'border-amber-200' : 'border-gray-200'
+        }`}
+      >
         <div className="flex items-baseline justify-between gap-2">
-          <span className="text-sm font-semibold text-gray-900">{props.label}</span>
+          <span
+            className={`text-sm font-semibold ${
+              emphasizeUnassigned ? 'text-amber-900' : 'text-gray-900'
+            }`}
+          >
+            {props.label}
+          </span>
           <div className="flex items-center gap-1.5">
-            <span className="text-xs text-gray-500">{count}</span>
+            <span
+              className={`text-xs ${
+                emphasizeUnassigned
+                  ? 'font-semibold text-amber-800'
+                  : 'text-gray-500'
+              }`}
+            >
+              {count}
+            </span>
             {props.onCopy && props.team != null ? (
               <button
                 type="button"
@@ -254,7 +302,15 @@ function TeamColumn(props: {
             </div>
           </div>
         ) : (
-          <div className="mt-1 text-xs text-gray-500">Drag onto a team</div>
+          <div
+            className={`mt-1 text-xs ${
+              emphasizeUnassigned ? 'font-medium text-amber-800' : 'text-gray-500'
+            }`}
+          >
+            {emphasizeUnassigned
+              ? `${count} not on a team — drag onto a team`
+              : 'Drag onto a team'}
+          </div>
         )}
       </div>
       <div className="flex flex-1 flex-col gap-1.5 overflow-y-auto p-2">
@@ -277,12 +333,22 @@ export function EventDraftBoard(props: Props) {
     onDiscard,
     applying,
     error,
+    snapshots,
+    snapshotsBusy,
+    onSaveSnapshot,
+    onLoadSnapshot,
+    onRenameSnapshot,
+    onDeleteSnapshot,
+    onPromoteSnapshot,
   } = props
 
   const [activeId, setActiveId] = useState<string | null>(null)
   const [playerSort, setPlayerSort] = useState<PlayerSort>('name')
   const [copyIncludeJersey, setCopyIncludeJersey] = useState(false)
   const [copyUseRosterName, setCopyUseRosterName] = useState(false)
+  const [snapshotName, setSnapshotName] = useState('')
+  const [compareA, setCompareA] = useState<'workspace' | string>('workspace')
+  const [compareB, setCompareB] = useState<string>('')
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
@@ -357,6 +423,27 @@ export function EventDraftBoard(props: Props) {
     ? registrations.find((r) => r.id === activeId) ?? null
     : null
 
+  const unassignedPlayers = byColumn.get(columnId(null)) ?? []
+  const unassignedCount = unassignedPlayers.length
+
+  const compareSummary = useMemo(() => {
+    if (!compareB) return null
+    const resolve = (key: 'workspace' | string) => {
+      if (key === 'workspace') return assignments
+      const snap = snapshots.find((s) => s.id === key)
+      return snap?.assignments ?? {}
+    }
+    return {
+      a: summarizeDraftAssignments(registrations, resolve(compareA), teamCount),
+      b: summarizeDraftAssignments(registrations, resolve(compareB), teamCount),
+      aLabel:
+        compareA === 'workspace'
+          ? 'Current workspace'
+          : (snapshots.find((s) => s.id === compareA)?.name ?? 'A'),
+      bLabel: snapshots.find((s) => s.id === compareB)?.name ?? 'B',
+    }
+  }, [assignments, compareA, compareB, registrations, snapshots, teamCount])
+
   async function copyTeam(teamPlayers: EventRegistrationListItem[]): Promise<void> {
     const sorted = sortPlayers(teamPlayers, playerSort)
     const lines = sorted.map((p) => {
@@ -398,7 +485,18 @@ export function EventDraftBoard(props: Props) {
 
     const next = new Map(assignments)
     next.set(playerId, targetTeam)
+    const dragged = registrations.find((r) => r.id === playerId)
+    if (dragged?.partnerRegistrationId) {
+      next.set(dragged.partnerRegistrationId, targetTeam)
+    }
     onAssignmentsChange(next)
+  }
+
+  async function handleSaveSnapshot() {
+    const name = snapshotName.trim()
+    if (!name) return
+    await onSaveSnapshot(name)
+    setSnapshotName('')
   }
 
   return (
@@ -408,9 +506,19 @@ export function EventDraftBoard(props: Props) {
           <h2 className="text-lg font-semibold text-gray-900">Draft mode</h2>
           <p className="text-sm text-gray-600">
             Working copy only — permanent draft groups are unchanged until you Apply.
+            Paired players move together.
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
+          {unassignedCount > 0 ? (
+            <span className="rounded border border-amber-300 bg-amber-50 px-2.5 py-1.5 text-sm font-semibold text-amber-900">
+              Unassigned {unassignedCount}
+            </span>
+          ) : (
+            <span className="rounded border border-gray-200 bg-white px-2.5 py-1.5 text-sm text-gray-600">
+              Unassigned 0
+            </span>
+          )}
           <label className="flex items-center gap-2 text-sm text-gray-700">
             <span className="text-gray-600">Sort within teams</span>
             <select
@@ -452,6 +560,182 @@ export function EventDraftBoard(props: Props) {
 
       {error ? <p className="text-sm text-red-600">{error}</p> : null}
 
+      <div className="space-y-3 rounded border border-violet-200 bg-white px-3 py-3">
+        <div className="flex flex-wrap items-end gap-2">
+          <label className="text-sm">
+            <span className="text-gray-600">Save draft as</span>
+            <input
+              className="mt-1 block w-52 rounded border border-gray-300 px-2 py-1.5"
+              value={snapshotName}
+              disabled={snapshotsBusy || applying}
+              onChange={(e) => setSnapshotName(e.target.value)}
+              placeholder="e.g. Balanced A"
+            />
+          </label>
+          <button
+            type="button"
+            className="rounded border border-violet-300 bg-violet-50 px-3 py-2 text-sm text-violet-900 disabled:opacity-40"
+            disabled={snapshotsBusy || applying || !snapshotName.trim()}
+            onClick={() => void handleSaveSnapshot()}
+          >
+            Save snapshot
+          </button>
+        </div>
+
+        {snapshots.length > 0 ? (
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead className="text-left text-gray-600">
+                <tr>
+                  <th className="py-1 pr-3 font-medium">Saved drafts</th>
+                  <th className="py-1 pr-3 font-medium"> </th>
+                </tr>
+              </thead>
+              <tbody>
+                {snapshots.map((s) => (
+                  <tr key={s.id} className="border-t border-gray-100">
+                    <td className="py-2 pr-3">
+                      <div className="font-medium text-gray-900">{s.name}</div>
+                      <div className="text-xs text-gray-500">
+                        {new Date(s.createdAt).toLocaleString()}
+                      </div>
+                    </td>
+                    <td className="py-2">
+                      <div className="flex flex-wrap gap-2">
+                        <button
+                          type="button"
+                          className="text-xs text-blue-700 hover:underline disabled:opacity-40"
+                          disabled={snapshotsBusy || applying}
+                          onClick={() => onLoadSnapshot(s.id)}
+                        >
+                          Load
+                        </button>
+                        <button
+                          type="button"
+                          className="text-xs text-gray-700 hover:underline disabled:opacity-40"
+                          disabled={snapshotsBusy || applying}
+                          onClick={() => {
+                            const next = window.prompt('Rename snapshot', s.name)
+                            if (next == null) return
+                            void onRenameSnapshot(s.id, next)
+                          }}
+                        >
+                          Rename
+                        </button>
+                        <button
+                          type="button"
+                          className="text-xs text-violet-700 hover:underline disabled:opacity-40"
+                          disabled={snapshotsBusy || applying}
+                          onClick={() => {
+                            if (
+                              !window.confirm(
+                                `Promote “${s.name}” to the live event roster?`
+                              )
+                            ) {
+                              return
+                            }
+                            void onPromoteSnapshot(s.id)
+                          }}
+                        >
+                          Promote
+                        </button>
+                        <button
+                          type="button"
+                          className="text-xs text-red-700 hover:underline disabled:opacity-40"
+                          disabled={snapshotsBusy || applying}
+                          onClick={() => {
+                            if (!window.confirm(`Delete snapshot “${s.name}”?`)) {
+                              return
+                            }
+                            void onDeleteSnapshot(s.id)
+                          }}
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <p className="text-xs text-gray-500">No saved drafts yet.</p>
+        )}
+
+        {snapshots.length > 0 ? (
+          <div className="space-y-2 border-t border-gray-100 pt-3">
+            <p className="text-sm font-medium text-gray-800">Compare</p>
+            <div className="flex flex-wrap gap-3 text-sm">
+              <label className="flex items-center gap-2">
+                <span className="text-gray-600">A</span>
+                <select
+                  className="rounded border border-gray-300 px-2 py-1"
+                  value={compareA}
+                  onChange={(e) => setCompareA(e.target.value)}
+                >
+                  <option value="workspace">Current workspace</option>
+                  {snapshots.map((s) => (
+                    <option key={s.id} value={s.id}>
+                      {s.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex items-center gap-2">
+                <span className="text-gray-600">B</span>
+                <select
+                  className="rounded border border-gray-300 px-2 py-1"
+                  value={compareB}
+                  onChange={(e) => setCompareB(e.target.value)}
+                >
+                  <option value="">Select snapshot…</option>
+                  {snapshots.map((s) => (
+                    <option key={s.id} value={s.id}>
+                      {s.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+            {compareSummary ? (
+              <div className="grid gap-3 md:grid-cols-2 text-xs">
+                {[
+                  {
+                    label: compareSummary.aLabel,
+                    summary: compareSummary.a,
+                  },
+                  {
+                    label: compareSummary.bLabel,
+                    summary: compareSummary.b,
+                  },
+                ].map((side) => (
+                  <div
+                    key={side.label}
+                    className="rounded border border-gray-200 bg-gray-50 px-3 py-2"
+                  >
+                    <div className="font-semibold text-gray-900">{side.label}</div>
+                    <div className="mt-1 text-amber-800">
+                      Unassigned {side.summary.unassigned}
+                    </div>
+                    <ul className="mt-2 space-y-1 text-gray-700">
+                      {side.summary.teams.map((t) => (
+                        <li key={t.team}>
+                          Team {t.team}: {t.size} · score {t.skillTotal}
+                          {t.size > 0 ? ` (avg ${t.skillAvg.toFixed(1)})` : ''} ·
+                          W/NB/O {t.gender.wNbO} · M {t.gender.men}
+                          {t.gender.unset ? ` · — ${t.gender.unset}` : ''}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+
       <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-gray-700 border border-gray-200 rounded bg-white px-3 py-2">
         <span className="font-medium text-gray-600">Copy roster options</span>
         <label className="flex items-center gap-1.5 cursor-pointer">
@@ -482,8 +766,9 @@ export function EventDraftBoard(props: Props) {
           <TeamColumn
             team={null}
             label="Unassigned"
-            players={byColumn.get(columnId(null)) ?? []}
+            players={unassignedPlayers}
             sort={playerSort}
+            emphasizeUnassigned
           />
           {Array.from({ length: teamCount }, (_, i) => i + 1).map((t) => {
             const teamPlayers = byColumn.get(columnId(t)) ?? []

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -128,6 +128,8 @@ export const eventRegistrations = pgTable(
     /** Positive int draft bucket; null = unassigned */
     draftGroup: integer('draft_group'),
     isCaptain: boolean('is_captain').notNull().default(false),
+    /** Shared UUID links two registrations as a pair; null = unpaired */
+    pairId: uuid('pair_id'),
     importBatchId: uuid('import_batch_id').references(() => importBatches.id, {
       onDelete: 'set null',
     }),
@@ -138,5 +140,25 @@ export const eventRegistrations = pgTable(
     uniqueIndex('event_registrations_event_player_uidx').on(table.eventId, table.playerId),
     index('event_registrations_event_id_idx').on(table.eventId),
     index('event_registrations_player_id_idx').on(table.playerId),
+    index('event_registrations_event_pair_id_idx').on(table.eventId, table.pairId),
   ]
+)
+
+export const eventDraftSnapshots = pgTable(
+  'event_draft_snapshots',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    eventId: uuid('event_id')
+      .notNull()
+      .references(() => events.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    /** Map of registrationId → draftGroup (number) or null */
+    assignments: jsonb('assignments')
+      .$type<Record<string, number | null>>()
+      .notNull()
+      .default({}),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index('event_draft_snapshots_event_id_idx').on(table.eventId)]
 )

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -20,7 +20,10 @@ import {
   emptySeedDraftGroups,
   playersPerTeamLabel,
 } from '@/app/lib/events/draft-seed'
-import type { EventRegistrationListItem } from '@/app/lib/events/types'
+import type {
+  EventDraftSnapshotListItem,
+  EventRegistrationListItem,
+} from '@/app/lib/events/types'
 import { genderGroup } from '@/app/lib/players/gender'
 import {
   SKILL_LEVELS,
@@ -155,22 +158,29 @@ function EventTrackerPageContent() {
   )
   const [draftApplying, setDraftApplying] = useState(false)
   const [draftError, setDraftError] = useState<string | null>(null)
+  const [snapshots, setSnapshots] = useState<EventDraftSnapshotListItem[]>([])
+  const [snapshotsBusy, setSnapshotsBusy] = useState(false)
 
   const load = useCallback(async () => {
     if (!eventId) return
     setLoading(true)
     setError(null)
     try {
-      const [eventRes, regRes] = await Promise.all([
+      const [eventRes, regRes, snapRes] = await Promise.all([
         fetch(`/api/events/${eventId}`),
         fetch(`/api/events/${eventId}/registrations`),
+        fetch(`/api/events/${eventId}/draft-snapshots`),
       ])
       const eventData = await eventRes.json()
       const regData = await regRes.json()
+      const snapData = await snapRes.json()
       if (!eventRes.ok) throw new Error(eventData.error || 'Failed to load event')
       if (!regRes.ok) throw new Error(regData.error || 'Failed to load roster')
       setEvent(eventData.event)
       setRegistrations(regData.registrations)
+      if (snapRes.ok) {
+        setSnapshots(snapData.snapshots ?? [])
+      }
       const groups = (regData.registrations as EventRegistrationListItem[])
         .map((r) => r.draftGroup)
         .filter((g): g is number => g != null)
@@ -322,45 +332,60 @@ function EventTrackerPageContent() {
     }
   }
 
-  async function removeRegistration(registrationId: string, label: string) {
-    if (!window.confirm(`Remove ${label} from this event?`)) return
-    setRemovingId(registrationId)
+  async function pairWith(registrationId: string, partnerRegistrationId: string) {
+    setSavingId(registrationId)
     setFormError(null)
     try {
       const res = await fetch(
         `/api/events/${eventId}/registrations/${registrationId}`,
-        { method: 'DELETE' }
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ pairWithRegistrationId: partnerRegistrationId }),
+        }
       )
       const data = await res.json()
-      if (!res.ok) throw new Error(data.error || 'Failed to remove player')
-      setRegistrations((prev) => prev.filter((r) => r.id !== registrationId))
-      setMessage(`Removed ${label} from event`)
+      if (!res.ok) throw new Error(data.error || 'Failed to pair players')
+      await load()
+      setMessage('Players paired')
     } catch (err) {
-      setFormError(err instanceof Error ? err.message : 'Failed to remove player')
+      setFormError(err instanceof Error ? err.message : 'Failed to pair players')
     } finally {
-      setRemovingId(null)
+      setSavingId(null)
     }
   }
 
-  async function deleteEvent() {
-    if (
-      !window.confirm(
-        `Delete “${event?.name}”? This removes the event and all its registrations.`
-      )
-    ) {
-      return
-    }
-    setDeletingEvent(true)
+  async function unpair(registrationId: string) {
+    setSavingId(registrationId)
     setFormError(null)
     try {
-      const res = await fetch(`/api/events/${eventId}`, { method: 'DELETE' })
+      const res = await fetch(
+        `/api/events/${eventId}/registrations/${registrationId}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ unpair: true }),
+        }
+      )
       const data = await res.json()
-      if (!res.ok) throw new Error(data.error || 'Failed to delete event')
-      router.push(withDevMode('/events', devMode))
+      if (!res.ok) throw new Error(data.error || 'Failed to unpair')
+      await load()
+      setMessage('Pair cleared')
     } catch (err) {
-      setFormError(err instanceof Error ? err.message : 'Failed to delete event')
-      setDeletingEvent(false)
+      setFormError(err instanceof Error ? err.message : 'Failed to unpair')
+    } finally {
+      setSavingId(null)
     }
+  }
+
+  function seedPlayersFromRegistrations() {
+    return registrations.map((r) => ({
+      id: r.id,
+      skillLevel: r.skillLevel,
+      gender: r.gender,
+      pairId: r.pairId,
+      draftGroup: r.draftGroup,
+    }))
   }
 
   function openDraftSetup() {
@@ -371,12 +396,7 @@ function EventTrackerPageContent() {
   }
 
   function startDraftBoard() {
-    const seeds = registrations.map((r) => ({
-      id: r.id,
-      skillLevel: r.skillLevel,
-      gender: r.gender,
-      draftGroup: r.draftGroup,
-    }))
+    const seeds = seedPlayersFromRegistrations()
     const n = Math.max(1, Math.floor(draftTeamCount))
     let next: Map<string, number | null>
     if (draftSeedMode === 'auto') {
@@ -397,11 +417,7 @@ function EventTrackerPageContent() {
   }
 
   function reshuffleDraft() {
-    const seeds = registrations.map((r) => ({
-      id: r.id,
-      skillLevel: r.skillLevel,
-      gender: r.gender,
-    }))
+    const seeds = seedPlayersFromRegistrations()
     const n = Math.max(1, Math.floor(draftTeamCount))
     const seeded = autoSeedDraftGroups(seeds, n, { shuffle: true })
     const next = new Map<string, number | null>()
@@ -450,6 +466,162 @@ function EventTrackerPageContent() {
       setDraftError(err instanceof Error ? err.message : 'Failed to apply draft')
     } finally {
       setDraftApplying(false)
+    }
+  }
+
+  function assignmentsObjectFromMap(
+    map: Map<string, number | null>
+  ): Record<string, number | null> {
+    const obj: Record<string, number | null> = {}
+    for (const r of registrations) {
+      obj[r.id] = map.get(r.id) ?? null
+    }
+    return obj
+  }
+
+  async function saveSnapshot(name: string) {
+    setSnapshotsBusy(true)
+    setDraftError(null)
+    try {
+      const res = await fetch(`/api/events/${eventId}/draft-snapshots`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name,
+          assignments: assignmentsObjectFromMap(draftAssignments),
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to save snapshot')
+      setSnapshots((prev) => [...prev, data.snapshot])
+      setMessage(`Saved draft “${data.snapshot.name}”`)
+    } catch (err) {
+      setDraftError(err instanceof Error ? err.message : 'Failed to save snapshot')
+    } finally {
+      setSnapshotsBusy(false)
+    }
+  }
+
+  function loadSnapshot(snapshotId: string) {
+    const snap = snapshots.find((s) => s.id === snapshotId)
+    if (!snap) return
+    const next = new Map<string, number | null>()
+    for (const r of registrations) {
+      next.set(r.id, snap.assignments[r.id] ?? null)
+    }
+    const maxAssigned = Math.max(
+      0,
+      ...Object.values(snap.assignments).filter((g): g is number => g != null)
+    )
+    if (maxAssigned > 0) {
+      setDraftTeamCount((prev) => Math.max(prev, maxAssigned))
+      setMaxGroup((prev) => Math.max(prev, maxAssigned))
+    }
+    setDraftAssignments(next)
+    setMessage(`Loaded draft “${snap.name}” into workspace`)
+  }
+
+  async function renameSnapshot(snapshotId: string, name: string) {
+    setSnapshotsBusy(true)
+    setDraftError(null)
+    try {
+      const res = await fetch(
+        `/api/events/${eventId}/draft-snapshots/${snapshotId}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name }),
+        }
+      )
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to rename snapshot')
+      setSnapshots((prev) =>
+        prev.map((s) => (s.id === snapshotId ? data.snapshot : s))
+      )
+    } catch (err) {
+      setDraftError(err instanceof Error ? err.message : 'Failed to rename snapshot')
+    } finally {
+      setSnapshotsBusy(false)
+    }
+  }
+
+  async function deleteSnapshot(snapshotId: string) {
+    setSnapshotsBusy(true)
+    setDraftError(null)
+    try {
+      const res = await fetch(
+        `/api/events/${eventId}/draft-snapshots/${snapshotId}`,
+        { method: 'DELETE' }
+      )
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to delete snapshot')
+      setSnapshots((prev) => prev.filter((s) => s.id !== snapshotId))
+    } catch (err) {
+      setDraftError(err instanceof Error ? err.message : 'Failed to delete snapshot')
+    } finally {
+      setSnapshotsBusy(false)
+    }
+  }
+
+  async function promoteSnapshot(snapshotId: string) {
+    setSnapshotsBusy(true)
+    setDraftError(null)
+    try {
+      const res = await fetch(
+        `/api/events/${eventId}/draft-snapshots/${snapshotId}/promote`,
+        { method: 'POST' }
+      )
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to promote snapshot')
+      await load()
+      setDraftPhase('off')
+      setDraftAssignments(new Map())
+      setMessage('Snapshot promoted to live roster')
+    } catch (err) {
+      setDraftError(err instanceof Error ? err.message : 'Failed to promote snapshot')
+    } finally {
+      setSnapshotsBusy(false)
+    }
+  }
+
+  async function removeRegistration(registrationId: string, label: string) {
+    if (!window.confirm(`Remove ${label} from this event?`)) return
+    setRemovingId(registrationId)
+    setFormError(null)
+    try {
+      const res = await fetch(
+        `/api/events/${eventId}/registrations/${registrationId}`,
+        { method: 'DELETE' }
+      )
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to remove player')
+      setRegistrations((prev) => prev.filter((r) => r.id !== registrationId))
+      setMessage(`Removed ${label} from event`)
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Failed to remove player')
+    } finally {
+      setRemovingId(null)
+    }
+  }
+
+  async function deleteEvent() {
+    if (
+      !window.confirm(
+        `Delete “${event?.name}”? This removes the event and all its registrations.`
+      )
+    ) {
+      return
+    }
+    setDeletingEvent(true)
+    setFormError(null)
+    try {
+      const res = await fetch(`/api/events/${eventId}`, { method: 'DELETE' })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to delete event')
+      router.push(withDevMode('/events', devMode))
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Failed to delete event')
+      setDeletingEvent(false)
     }
   }
 
@@ -592,6 +764,27 @@ function EventTrackerPageContent() {
         <p className="text-sm text-red-600">{formError}</p>
       ) : null}
 
+      {draftPhase !== 'board' && counts.unassigned > 0 ? (
+        <div
+          className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-950"
+          role="status"
+        >
+          <p className="font-medium">
+            {counts.unassigned} registered{' '}
+            {counts.unassigned === 1 ? 'player is' : 'players are'} not on a team
+          </p>
+          {draftPhase === 'off' ? (
+            <button
+              type="button"
+              className="rounded border border-amber-400 bg-white px-3 py-1.5 text-sm font-medium text-amber-900 hover:bg-amber-100"
+              onClick={() => setDraftFilter('unassigned')}
+            >
+              Show unassigned
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+
       {draftPhase === 'setup' ? (
         <div className="rounded-lg border border-blue-200 bg-blue-50/30 p-4 space-y-4">
           <div>
@@ -680,6 +873,13 @@ function EventTrackerPageContent() {
           onDiscard={discardDraft}
           applying={draftApplying}
           error={draftError}
+          snapshots={snapshots}
+          snapshotsBusy={snapshotsBusy}
+          onSaveSnapshot={saveSnapshot}
+          onLoadSnapshot={loadSnapshot}
+          onRenameSnapshot={renameSnapshot}
+          onDeleteSnapshot={deleteSnapshot}
+          onPromoteSnapshot={promoteSnapshot}
         />
       ) : null}
 
@@ -688,10 +888,24 @@ function EventTrackerPageContent() {
           <div className="text-gray-500">Total</div>
           <div className="text-xl font-semibold">{counts.total}</div>
         </div>
-        <div className="rounded border border-gray-200 px-3 py-2">
+        <div
+          className={`rounded border px-3 py-2 ${
+            counts.unassigned > 0
+              ? 'border-amber-300 bg-amber-50/60'
+              : 'border-gray-200'
+          }`}
+        >
           <div className="text-gray-500">Draft buckets</div>
           <div>
-            Unassigned {counts.unassigned} · Assigned {counts.assigned}
+            <span
+              className={
+                counts.unassigned > 0 ? 'font-semibold text-amber-800' : undefined
+              }
+            >
+              Unassigned {counts.unassigned}
+            </span>
+            {' · '}
+            Assigned {counts.assigned}
           </div>
           {groupOptions.length > 0 ? (
             <div className="text-xs mt-1 text-gray-600">
@@ -796,13 +1010,14 @@ function EventTrackerPageContent() {
                   <th className="px-3 py-2 font-medium">Email</th>
                   <th className="px-3 py-2 font-medium">Draft group</th>
                   <th className="px-3 py-2 font-medium">Captain</th>
+                  <th className="px-3 py-2 font-medium">Pair</th>
                   <th className="px-3 py-2 font-medium"> </th>
                 </tr>
               </thead>
               <tbody>
                 {filtered.length === 0 ? (
                   <tr>
-                    <td colSpan={7} className="px-3 py-6 text-center text-gray-500">
+                    <td colSpan={8} className="px-3 py-6 text-center text-gray-500">
                       {registrations.length === 0
                         ? 'No registrations yet. Import a TeamLinkt CSV for this event.'
                         : 'No players match this filter.'}
@@ -812,6 +1027,12 @@ function EventTrackerPageContent() {
                   filtered.map((r) => {
                     const label =
                       r.nickname || `${r.firstName} ${r.lastName}`
+                    const unpairedOptions = registrations.filter(
+                      (other) =>
+                        other.id !== r.id &&
+                        other.pairId == null &&
+                        r.pairId == null
+                    )
                     return (
                       <tr
                         key={r.id}
@@ -823,6 +1044,11 @@ function EventTrackerPageContent() {
                           </SkillStyledText>
                           {r.isCaptain ? (
                             <span className="ml-1 text-xs font-medium text-blue-700">(C)</span>
+                          ) : null}
+                          {r.partnerNickname ? (
+                            <div className="text-xs text-violet-700">
+                              Paired with {r.partnerNickname}
+                            </div>
                           ) : null}
                           <div className="text-xs text-gray-500">
                             {r.firstName} {r.lastName}
@@ -864,6 +1090,40 @@ function EventTrackerPageContent() {
                           >
                             {r.isCaptain ? '(C) Remove' : 'Set (C)'}
                           </button>
+                        </td>
+                        <td className="px-3 py-2">
+                          {r.pairId ? (
+                            <button
+                              type="button"
+                              className="text-xs text-violet-700 hover:underline disabled:opacity-40"
+                              disabled={savingId === r.id}
+                              onClick={() => void unpair(r.id)}
+                            >
+                              Unpair
+                            </button>
+                          ) : unpairedOptions.length > 0 ? (
+                            <select
+                              className="max-w-[10rem] rounded border border-gray-300 px-2 py-1 text-xs disabled:opacity-40"
+                              disabled={savingId === r.id}
+                              defaultValue=""
+                              onChange={(e) => {
+                                const partnerId = e.target.value
+                                e.target.value = ''
+                                if (!partnerId) return
+                                void pairWith(r.id, partnerId)
+                              }}
+                            >
+                              <option value="">Pair with…</option>
+                              {unpairedOptions.map((other) => (
+                                <option key={other.id} value={other.id}>
+                                  {other.nickname ||
+                                    `${other.firstName} ${other.lastName}`}
+                                </option>
+                              ))}
+                            </select>
+                          ) : (
+                            <span className="text-xs text-gray-400">—</span>
+                          )}
                         </td>
                         <td className="px-3 py-2">
                           <button

--- a/app/lib/events/draft-seed.ts
+++ b/app/lib/events/draft-seed.ts
@@ -4,6 +4,8 @@ export type DraftSeedPlayer = {
   id: string
   skillLevel: number | null
   gender: string | null
+  /** Shared id links two players as a pair that must stay together. */
+  pairId?: string | null
 }
 
 export type AutoSeedOptions = {
@@ -11,6 +13,14 @@ export type AutoSeedOptions = {
   shuffle?: boolean
   /** RNG in [0, 1). Defaults to Math.random. Inject for tests. */
   random?: () => number
+}
+
+type DraftUnit = {
+  id: string
+  members: DraftSeedPlayer[]
+  skillTotal: number
+  preferGender: 'w_nb_o' | 'men' | null
+  poolGender: GenderGroup
 }
 
 /**
@@ -69,9 +79,62 @@ function skillScore(skillLevel: number | null): number {
   return skillLevel ?? 0
 }
 
-function sortBySkillDesc(players: DraftSeedPlayer[]): DraftSeedPlayer[] {
-  return [...players].sort((a, b) => {
-    const skillDiff = skillScore(b.skillLevel) - skillScore(a.skillLevel)
+function unitPreferGender(members: DraftSeedPlayer[]): 'w_nb_o' | 'men' | null {
+  const groups = members.map((m) => genderGroup(m.gender))
+  if (groups.some((g) => g === 'w_nb_o')) return 'w_nb_o'
+  if (groups.some((g) => g === 'men')) return 'men'
+  return null
+}
+
+function unitPoolGender(members: DraftSeedPlayer[]): GenderGroup {
+  const prefer = unitPreferGender(members)
+  if (prefer === 'w_nb_o') return 'w_nb_o'
+  if (prefer === 'men') return 'men'
+  return 'unset'
+}
+
+function buildDraftUnits(players: DraftSeedPlayer[]): DraftUnit[] {
+  const units: DraftUnit[] = []
+  const seenPairIds = new Set<string>()
+  const byPairId = new Map<string, DraftSeedPlayer[]>()
+
+  for (const p of players) {
+    if (p.pairId) {
+      const list = byPairId.get(p.pairId) ?? []
+      list.push(p)
+      byPairId.set(p.pairId, list)
+    }
+  }
+
+  for (const p of players) {
+    if (p.pairId) {
+      if (seenPairIds.has(p.pairId)) continue
+      seenPairIds.add(p.pairId)
+      const members = byPairId.get(p.pairId) ?? [p]
+      units.push({
+        id: `pair:${p.pairId}`,
+        members,
+        skillTotal: members.reduce((sum, m) => sum + skillScore(m.skillLevel), 0),
+        preferGender: unitPreferGender(members),
+        poolGender: unitPoolGender(members),
+      })
+      continue
+    }
+    units.push({
+      id: `solo:${p.id}`,
+      members: [p],
+      skillTotal: skillScore(p.skillLevel),
+      preferGender: unitPreferGender([p]),
+      poolGender: unitPoolGender([p]),
+    })
+  }
+
+  return units
+}
+
+function sortUnitsBySkillDesc(units: DraftUnit[]): DraftUnit[] {
+  return [...units].sort((a, b) => {
+    const skillDiff = b.skillTotal - a.skillTotal
     if (skillDiff !== 0) return skillDiff
     return a.id.localeCompare(b.id)
   })
@@ -79,15 +142,15 @@ function sortBySkillDesc(players: DraftSeedPlayer[]): DraftSeedPlayer[] {
 
 /** Fisher–Yates shuffle within equal-skill bands (list already skill-sorted). */
 function shuffleEqualSkillBands(
-  players: DraftSeedPlayer[],
+  units: DraftUnit[],
   random: () => number
-): DraftSeedPlayer[] {
-  const result = [...players]
+): DraftUnit[] {
+  const result = [...units]
   let i = 0
   while (i < result.length) {
     let j = i + 1
-    const skill = skillScore(result[i].skillLevel)
-    while (j < result.length && skillScore(result[j].skillLevel) === skill) {
+    const skill = result[i].skillTotal
+    while (j < result.length && result[j].skillTotal === skill) {
       j++
     }
     for (let k = j - 1; k > i; k--) {
@@ -119,6 +182,7 @@ function teamTieBreakRanks(n: number, random: () => number): number[] {
 
 /**
  * Auto-seed teams: gender-balanced (W/NB/O vs men), skill-aware snake draft.
+ * Paired players (shared pairId) are placed on the same team as one unit.
  * Returns map of player id → team number (1..teamCount). Unset gender players
  * are placed last into the currently smallest / lowest-score teams.
  */
@@ -134,16 +198,17 @@ export function autoSeedDraftGroups(
 
   if (players.length === 0) return assignments
 
-  const pools: Record<GenderGroup, DraftSeedPlayer[]> = {
+  const units = buildDraftUnits(players)
+  const pools: Record<GenderGroup, DraftUnit[]> = {
     w_nb_o: [],
     men: [],
     unset: [],
   }
-  for (const p of players) {
-    pools[genderGroup(p.gender)].push(p)
+  for (const unit of units) {
+    pools[unit.poolGender].push(unit)
   }
   for (const key of Object.keys(pools) as GenderGroup[]) {
-    const sorted = sortBySkillDesc(pools[key])
+    const sorted = sortUnitsBySkillDesc(pools[key])
     pools[key] = shuffle ? shuffleEqualSkillBands(sorted, random) : sorted
   }
 
@@ -190,14 +255,16 @@ export function autoSeedDraftGroups(
     return best
   }
 
-  function assign(player: DraftSeedPlayer, teamIndex: number) {
+  function assignUnit(unit: DraftUnit, teamIndex: number) {
     const team = teamIndex + 1
-    assignments.set(player.id, team)
-    teamSizes[teamIndex]++
-    teamScores[teamIndex] += skillScore(player.skillLevel)
-    const g = genderGroup(player.gender)
-    if (g === 'w_nb_o') teamGender[teamIndex].w_nb_o++
-    else if (g === 'men') teamGender[teamIndex].men++
+    for (const member of unit.members) {
+      assignments.set(member.id, team)
+      const g = genderGroup(member.gender)
+      if (g === 'w_nb_o') teamGender[teamIndex].w_nb_o++
+      else if (g === 'men') teamGender[teamIndex].men++
+    }
+    teamSizes[teamIndex] += unit.members.length
+    teamScores[teamIndex] += unit.skillTotal
   }
 
   // Interleave W/NB/O and men by skill (snake-style via pickTeam heuristics).
@@ -209,19 +276,19 @@ export function autoSeedDraftGroups(
 
   while (i < primary.length || j < secondary.length) {
     if (takePrimary && i < primary.length) {
-      assign(primary[i++], pickTeam('w_nb_o'))
+      assignUnit(primary[i++], pickTeam('w_nb_o'))
     } else if (!takePrimary && j < secondary.length) {
-      assign(secondary[j++], pickTeam('men'))
+      assignUnit(secondary[j++], pickTeam('men'))
     } else if (i < primary.length) {
-      assign(primary[i++], pickTeam('w_nb_o'))
+      assignUnit(primary[i++], pickTeam('w_nb_o'))
     } else if (j < secondary.length) {
-      assign(secondary[j++], pickTeam('men'))
+      assignUnit(secondary[j++], pickTeam('men'))
     }
     takePrimary = !takePrimary
   }
 
-  for (const player of pools.unset) {
-    assign(player, pickTeam(null))
+  for (const unit of pools.unset) {
+    assignUnit(unit, pickTeam(null))
   }
 
   return assignments
@@ -270,4 +337,60 @@ export function teamGenderCounts(players: Array<{ gender: string | null }>): {
     else unset++
   }
   return { wNbO, men, unset }
+}
+
+/** Build assignment map stats for snapshot compare UI. */
+export function summarizeDraftAssignments(
+  registrations: Array<{
+    id: string
+    skillLevel: number | null
+    gender: string | null
+  }>,
+  assignments: Map<string, number | null> | Record<string, number | null>,
+  teamCount: number
+): {
+  unassigned: number
+  teams: Array<{
+    team: number
+    size: number
+    skillTotal: number
+    skillAvg: number
+    gender: { wNbO: number; men: number; unset: number }
+  }>
+} {
+  const get =
+    assignments instanceof Map
+      ? (id: string) => assignments.get(id) ?? null
+      : (id: string) => assignments[id] ?? null
+
+  const byTeam = new Map<number | null, typeof registrations>()
+  byTeam.set(null, [])
+  for (let t = 1; t <= teamCount; t++) byTeam.set(t, [])
+
+  for (const r of registrations) {
+    const team = get(r.id)
+    const key =
+      team != null && team >= 1 && team <= teamCount ? team : null
+    const list = byTeam.get(key) ?? []
+    list.push(r)
+    byTeam.set(key, list)
+  }
+
+  const teams = Array.from({ length: teamCount }, (_, i) => {
+    const team = i + 1
+    const players = byTeam.get(team) ?? []
+    const skillTotal = teamSkillTotal(players)
+    return {
+      team,
+      size: players.length,
+      skillTotal,
+      skillAvg: players.length > 0 ? skillTotal / players.length : 0,
+      gender: teamGenderCounts(players),
+    }
+  })
+
+  return {
+    unassigned: (byTeam.get(null) ?? []).length,
+    teams,
+  }
 }

--- a/app/lib/events/mutations.ts
+++ b/app/lib/events/mutations.ts
@@ -1,9 +1,15 @@
-import { and, eq, inArray } from 'drizzle-orm'
+import { and, asc, eq, inArray } from 'drizzle-orm'
+import { randomUUID } from 'crypto'
 import { getDb } from '@/app/lib/db'
-import { eventRegistrations, events } from '@/app/db/schema'
+import {
+  eventDraftSnapshots,
+  eventRegistrations,
+  events,
+} from '@/app/db/schema'
 import {
   isValidEventType,
   parseDraftGroup,
+  type EventDraftSnapshotListItem,
   type EventRecord,
   type EventType,
 } from '@/app/lib/events/types'
@@ -206,6 +212,256 @@ export async function updateRegistrationCaptain(
 
   if (!updated) throw new Error('Registration not found')
   return updated
+}
+
+export async function pairRegistrations(
+  eventId: string,
+  registrationIdA: string,
+  registrationIdB: string
+): Promise<{ pairId: string; registrationIds: [string, string] }> {
+  if (registrationIdA === registrationIdB) {
+    throw new Error('Cannot pair a registration with itself')
+  }
+
+  const db = getDb()
+  const rows = await db
+    .select({
+      id: eventRegistrations.id,
+      pairId: eventRegistrations.pairId,
+    })
+    .from(eventRegistrations)
+    .where(
+      and(
+        eq(eventRegistrations.eventId, eventId),
+        inArray(eventRegistrations.id, [registrationIdA, registrationIdB])
+      )
+    )
+
+  if (rows.length !== 2) throw new Error('Registration not found')
+  for (const row of rows) {
+    if (row.pairId != null) {
+      throw new Error('Registration is already paired')
+    }
+  }
+
+  const pairId = randomUUID()
+  const now = new Date()
+  await db
+    .update(eventRegistrations)
+    .set({ pairId, updatedAt: now })
+    .where(
+      and(
+        eq(eventRegistrations.eventId, eventId),
+        inArray(eventRegistrations.id, [registrationIdA, registrationIdB])
+      )
+    )
+
+  return { pairId, registrationIds: [registrationIdA, registrationIdB] }
+}
+
+export async function unpairRegistration(
+  eventId: string,
+  registrationId: string
+): Promise<{ clearedPairId: string | null; registrationIds: string[] }> {
+  const db = getDb()
+  const [row] = await db
+    .select({
+      id: eventRegistrations.id,
+      pairId: eventRegistrations.pairId,
+    })
+    .from(eventRegistrations)
+    .where(
+      and(
+        eq(eventRegistrations.id, registrationId),
+        eq(eventRegistrations.eventId, eventId)
+      )
+    )
+    .limit(1)
+
+  if (!row) throw new Error('Registration not found')
+  if (row.pairId == null) {
+    return { clearedPairId: null, registrationIds: [row.id] }
+  }
+
+  const members = await db
+    .select({ id: eventRegistrations.id })
+    .from(eventRegistrations)
+    .where(
+      and(
+        eq(eventRegistrations.eventId, eventId),
+        eq(eventRegistrations.pairId, row.pairId)
+      )
+    )
+
+  const ids = members.map((m) => m.id)
+  await db
+    .update(eventRegistrations)
+    .set({ pairId: null, updatedAt: new Date() })
+    .where(
+      and(
+        eq(eventRegistrations.eventId, eventId),
+        inArray(eventRegistrations.id, ids)
+      )
+    )
+
+  return { clearedPairId: row.pairId, registrationIds: ids }
+}
+
+function parseSnapshotAssignments(
+  value: unknown
+): Record<string, number | null> {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('assignments must be an object')
+  }
+  const result: Record<string, number | null> = {}
+  for (const [registrationId, draftGroup] of Object.entries(
+    value as Record<string, unknown>
+  )) {
+    if (!registrationId) throw new Error('registrationId is required')
+    const parsed = parseDraftGroup(draftGroup)
+    if (parsed === undefined) {
+      throw new Error('draftGroup is required for each assignment')
+    }
+    result[registrationId] = parsed
+  }
+  return result
+}
+
+export async function listEventDraftSnapshots(
+  eventId: string
+): Promise<EventDraftSnapshotListItem[]> {
+  const db = getDb()
+  const rows = await db
+    .select()
+    .from(eventDraftSnapshots)
+    .where(eq(eventDraftSnapshots.eventId, eventId))
+    .orderBy(asc(eventDraftSnapshots.createdAt))
+
+  return rows.map((r) => ({
+    id: r.id,
+    eventId: r.eventId,
+    name: r.name,
+    assignments: r.assignments ?? {},
+    createdAt: r.createdAt,
+    updatedAt: r.updatedAt,
+  }))
+}
+
+export async function createEventDraftSnapshot(input: {
+  eventId: string
+  name: string
+  assignments: unknown
+}): Promise<EventDraftSnapshotListItem> {
+  const name = input.name.trim()
+  if (!name) throw new Error('name is required')
+  const assignments = parseSnapshotAssignments(input.assignments)
+
+  const db = getDb()
+  const [created] = await db
+    .insert(eventDraftSnapshots)
+    .values({
+      eventId: input.eventId,
+      name,
+      assignments,
+    })
+    .returning()
+
+  return {
+    id: created.id,
+    eventId: created.eventId,
+    name: created.name,
+    assignments: created.assignments ?? {},
+    createdAt: created.createdAt,
+    updatedAt: created.updatedAt,
+  }
+}
+
+export async function renameEventDraftSnapshot(
+  eventId: string,
+  snapshotId: string,
+  nameInput: string
+): Promise<EventDraftSnapshotListItem> {
+  const name = nameInput.trim()
+  if (!name) throw new Error('name is required')
+
+  const db = getDb()
+  const [updated] = await db
+    .update(eventDraftSnapshots)
+    .set({ name, updatedAt: new Date() })
+    .where(
+      and(
+        eq(eventDraftSnapshots.id, snapshotId),
+        eq(eventDraftSnapshots.eventId, eventId)
+      )
+    )
+    .returning()
+
+  if (!updated) throw new Error('Snapshot not found')
+  return {
+    id: updated.id,
+    eventId: updated.eventId,
+    name: updated.name,
+    assignments: updated.assignments ?? {},
+    createdAt: updated.createdAt,
+    updatedAt: updated.updatedAt,
+  }
+}
+
+export async function deleteEventDraftSnapshot(
+  eventId: string,
+  snapshotId: string
+): Promise<void> {
+  const db = getDb()
+  const deleted = await db
+    .delete(eventDraftSnapshots)
+    .where(
+      and(
+        eq(eventDraftSnapshots.id, snapshotId),
+        eq(eventDraftSnapshots.eventId, eventId)
+      )
+    )
+    .returning({ id: eventDraftSnapshots.id })
+
+  if (deleted.length === 0) throw new Error('Snapshot not found')
+}
+
+export async function getEventDraftSnapshot(
+  eventId: string,
+  snapshotId: string
+): Promise<EventDraftSnapshotListItem | null> {
+  const db = getDb()
+  const [row] = await db
+    .select()
+    .from(eventDraftSnapshots)
+    .where(
+      and(
+        eq(eventDraftSnapshots.id, snapshotId),
+        eq(eventDraftSnapshots.eventId, eventId)
+      )
+    )
+    .limit(1)
+  if (!row) return null
+  return {
+    id: row.id,
+    eventId: row.eventId,
+    name: row.name,
+    assignments: row.assignments ?? {},
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  }
+}
+
+export async function promoteEventDraftSnapshot(
+  eventId: string,
+  snapshotId: string
+): Promise<Array<{ id: string; draftGroup: number | null }>> {
+  const snapshot = await getEventDraftSnapshot(eventId, snapshotId)
+  if (!snapshot) throw new Error('Snapshot not found')
+
+  const assignments = Object.entries(snapshot.assignments).map(
+    ([registrationId, draftGroup]) => ({ registrationId, draftGroup })
+  )
+  return bulkUpdateRegistrationDraftGroups(eventId, assignments)
 }
 
 export async function deleteEventRegistration(

--- a/app/lib/events/queries.ts
+++ b/app/lib/events/queries.ts
@@ -63,6 +63,7 @@ export async function listEventRegistrations(
       status: eventRegistrations.status,
       draftGroup: eventRegistrations.draftGroup,
       isCaptain: eventRegistrations.isCaptain,
+      pairId: eventRegistrations.pairId,
       registeredAt: eventRegistrations.registeredAt,
       updatedAt: eventRegistrations.updatedAt,
       firstName: players.firstName,
@@ -107,29 +108,57 @@ export async function listEventRegistrations(
     }
   }
 
-  return rows.map((r) => ({
-    id: r.id,
-    eventId: r.eventId,
-    playerId: r.playerId,
-    status: r.status,
-    draftGroup: r.draftGroup,
-    isCaptain: r.isCaptain,
-    registeredAt: r.registeredAt,
-    updatedAt: r.updatedAt,
-    firstName: r.firstName,
-    lastName: r.lastName,
-    rosterName: r.rosterName,
-    nickname: resolveNickname(r.nickname, r.firstName, r.lastName),
-    jerseyNumber: r.jerseyNumber,
-    skillLevel: r.skillLevel,
-    skillLabel: skillLevelLabel(r.skillLevel),
-    gender: r.gender,
-    genderLabel: genderLabel(r.gender),
-    genderGroupLabel: genderGroupLabel(r.gender),
-    primaryEmail: primaryByPlayer.get(r.playerId) ?? null,
-    hasStrongPersonality: r.hasStrongPersonality,
-    strongPersonalityNotes: r.strongPersonalityNotes,
-  }))
+  const nicknameById = new Map(
+    rows.map((r) => [
+      r.id,
+      resolveNickname(r.nickname, r.firstName, r.lastName),
+    ])
+  )
+  const partnerByRegistrationId = new Map<string, string>()
+  const byPairId = new Map<string, string[]>()
+  for (const r of rows) {
+    if (!r.pairId) continue
+    const list = byPairId.get(r.pairId) ?? []
+    list.push(r.id)
+    byPairId.set(r.pairId, list)
+  }
+  for (const members of byPairId.values()) {
+    if (members.length !== 2) continue
+    partnerByRegistrationId.set(members[0], members[1])
+    partnerByRegistrationId.set(members[1], members[0])
+  }
+
+  return rows.map((r) => {
+    const partnerRegistrationId = partnerByRegistrationId.get(r.id) ?? null
+    return {
+      id: r.id,
+      eventId: r.eventId,
+      playerId: r.playerId,
+      status: r.status,
+      draftGroup: r.draftGroup,
+      isCaptain: r.isCaptain,
+      pairId: r.pairId,
+      partnerRegistrationId,
+      partnerNickname: partnerRegistrationId
+        ? (nicknameById.get(partnerRegistrationId) ?? null)
+        : null,
+      registeredAt: r.registeredAt,
+      updatedAt: r.updatedAt,
+      firstName: r.firstName,
+      lastName: r.lastName,
+      rosterName: r.rosterName,
+      nickname: nicknameById.get(r.id)!,
+      jerseyNumber: r.jerseyNumber,
+      skillLevel: r.skillLevel,
+      skillLabel: skillLevelLabel(r.skillLevel),
+      gender: r.gender,
+      genderLabel: genderLabel(r.gender),
+      genderGroupLabel: genderGroupLabel(r.gender),
+      primaryEmail: primaryByPlayer.get(r.playerId) ?? null,
+      hasStrongPersonality: r.hasStrongPersonality,
+      strongPersonalityNotes: r.strongPersonalityNotes,
+    }
+  })
 }
 
 export async function getRegisteredPlayerIds(eventId: string): Promise<Set<string>> {

--- a/app/lib/events/types.ts
+++ b/app/lib/events/types.ts
@@ -39,6 +39,9 @@ export type EventRegistrationListItem = {
   status: string
   draftGroup: number | null
   isCaptain: boolean
+  pairId: string | null
+  partnerRegistrationId: string | null
+  partnerNickname: string | null
   registeredAt: Date
   updatedAt: Date
   firstName: string
@@ -54,6 +57,15 @@ export type EventRegistrationListItem = {
   primaryEmail: string | null
   hasStrongPersonality: boolean
   strongPersonalityNotes: string | null
+}
+
+export type EventDraftSnapshotListItem = {
+  id: string
+  eventId: string
+  name: string
+  assignments: Record<string, number | null>
+  createdAt: Date
+  updatedAt: Date
 }
 
 export function isValidEventType(value: unknown): value is EventType {

--- a/drizzle/0007_event_registration_pairs.sql
+++ b/drizzle/0007_event_registration_pairs.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "event_registrations" ADD COLUMN IF NOT EXISTS "pair_id" uuid;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "event_registrations_event_pair_id_idx" ON "event_registrations" USING btree ("event_id","pair_id");

--- a/drizzle/0008_event_draft_snapshots.sql
+++ b/drizzle/0008_event_draft_snapshots.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS "event_draft_snapshots" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"event_id" uuid NOT NULL,
+	"name" text NOT NULL,
+	"assignments" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "event_draft_snapshots" ADD CONSTRAINT "event_draft_snapshots_event_id_events_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."events"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "event_draft_snapshots_event_id_idx" ON "event_draft_snapshots" USING btree ("event_id");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,20 @@
       "when": 1753228276000,
       "tag": "0006_event_registration_captain",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1753230000000,
+      "tag": "0007_event_registration_pairs",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1753231000000,
+      "tag": "0008_event_draft_snapshots",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses the three open event-draft issues.

### #83 — Unassigned players visible
- Amber banner when registered players are not on a team, with “Show unassigned” on the roster
- Stronger Unassigned count on draft buckets summary and draft board toolbar/column

### #85 — Manual pair signups
- `pair_id` on `event_registrations` (migration `0007`)
- Pair / Unpair from the roster table
- Auto-seed and draft-board DnD keep pairs on the same team
- Pair badge on draft cards

### #82 — Named draft snapshots
- `event_draft_snapshots` table (migration `0008`)
- Save / load / rename / delete / promote from draft mode
- Side-by-side compare (workspace vs snapshot or two snapshots)

### Ops
After merge (or before testing against a live DB), run:

```bash
npm run db:migrate
```

Fixes #83  
Fixes #85  
Fixes #82

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae9de0ab-513e-41c6-9f9d-2b755f072f69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae9de0ab-513e-41c6-9f9d-2b755f072f69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

