### PR TITLE
Auto-run DB migrations on Vercel deploy

### DIFF
--- a/.cursor/players-and-auth-runbook.md
+++ b/.cursor/players-and-auth-runbook.md
@@ -39,14 +39,18 @@ Auth env for the stable preview host is scoped to the **`preview`** Git branch i
 
 ## Database setup
 
-1. Provision Neon (Vercel Marketplace → Neon) and set `DATABASE_URL`.
-2. Apply schema:
+1. Provision Neon (Vercel Marketplace → Neon) and set `DATABASE_URL` for
+   **Production** and **Preview** (available at build time).
+2. Schema changes ship as SQL under [`drizzle/`](../drizzle/). Deploys apply
+   them automatically: `npm run build` runs `db:migrate:deploy` before
+   `next build` whenever `DATABASE_URL` is set.
+3. Locally (or if you need to migrate without a full build):
 
 ```bash
-npm run db:push
-# or, with migrations:
 npm run db:migrate
 ```
+
+`db:migrate:deploy` skips cleanly when `DATABASE_URL` is unset (CI builds).
 
 SQL migration source: [`drizzle/0000_players.sql`](../drizzle/0000_players.sql).
 

--- a/app/__tests__/migrate-on-deploy.test.ts
+++ b/app/__tests__/migrate-on-deploy.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+describe('migrate-on-deploy', () => {
+  it('is wired into the production build script', () => {
+    const pkg = JSON.parse(
+      readFileSync(resolve(process.cwd(), 'package.json'), 'utf8')
+    )
+    expect(pkg.scripts.build).toContain('db:migrate:deploy')
+    expect(pkg.scripts['db:migrate:deploy']).toBe(
+      'node scripts/migrate-on-deploy.mjs'
+    )
+  })
+
+  it('skips when DATABASE_URL is unset and migrates when set', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), 'scripts/migrate-on-deploy.mjs'),
+      'utf8'
+    )
+    expect(source).toContain('DATABASE_URL')
+    expect(source).toContain('Skipping migrations')
+    expect(source).toContain('drizzle-kit')
+    expect(source).toContain('migrate')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build",
+    "build": "npm run db:migrate:deploy && next build",
     "start": "next start",
     "lint": "next lint",
     "test": "vitest",
@@ -13,6 +13,7 @@
     "test:league": "node test-create-league.js",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
+    "db:migrate:deploy": "node scripts/migrate-on-deploy.mjs",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio"
   },

--- a/scripts/migrate-on-deploy.mjs
+++ b/scripts/migrate-on-deploy.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/**
+ * Run Drizzle migrations when DATABASE_URL is available (Vercel builds).
+ * Skip cleanly otherwise so CI / local builds without a DB still succeed.
+ */
+import { spawnSync } from 'node:child_process'
+
+const databaseUrl = process.env.DATABASE_URL?.trim()
+
+if (!databaseUrl) {
+  console.log(
+    '[db:migrate:deploy] Skipping migrations (DATABASE_URL is not set).'
+  )
+  process.exit(0)
+}
+
+console.log('[db:migrate:deploy] Applying pending Drizzle migrations…')
+const result = spawnSync('npx', ['drizzle-kit', 'migrate'], {
+  stdio: 'inherit',
+  env: process.env,
+  shell: process.platform === 'win32',
+})
+
+if (result.error) {
+  console.error('[db:migrate:deploy] Failed to start drizzle-kit:', result.error)
+  process.exit(1)
+}
+
+process.exit(result.status ?? 1)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Vercel deploys will apply pending Drizzle migrations before `next build`.

### Behavior
- `npm run build` → `db:migrate:deploy` → `next build`
- When `DATABASE_URL` is set (Production / Preview builds): runs `drizzle-kit migrate`
- When unset (GitHub Actions CI): skips and continues the build

### Files
- [`scripts/migrate-on-deploy.mjs`](scripts/migrate-on-deploy.mjs)
- [`package.json`](package.json) build script
- Runbook note in [`.cursor/players-and-auth-runbook.md`](.cursor/players-and-auth-runbook.md)

### Requirement
Ensure `DATABASE_URL` is available at **build time** for Production and Preview in Vercel (Neon integration usually does this already).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae9de0ab-513e-41c6-9f9d-2b755f072f69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae9de0ab-513e-41c6-9f9d-2b755f072f69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

