### PR TITLE
Add bulk edit mode for players

### DIFF
--- a/app/__tests__/players-bulk.test.ts
+++ b/app/__tests__/players-bulk.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import {
+  bulkPatchHasCoreFields,
+  parseBulkPlayerRequest,
+  type BulkPlayerPatch,
+} from '@/app/lib/players/bulk'
+
+describe('parseBulkPlayerRequest', () => {
+  it('accepts a gender-only patch and dedupes player ids', () => {
+    const parsed = parseBulkPlayerRequest({
+      playerIds: ['a', 'b', 'a'],
+      patch: { gender: 'woman' },
+    })
+    expect(parsed.playerIds).toEqual(['a', 'b'])
+    expect(parsed.patch).toEqual({ gender: 'woman' })
+  })
+
+  it('accepts clearing gender and skill to null', () => {
+    const parsed = parseBulkPlayerRequest({
+      playerIds: ['p1'],
+      patch: { gender: null, skillLevel: null },
+    })
+    expect(parsed.patch).toEqual({ gender: null, skillLevel: null })
+  })
+
+  it('accepts home-league add and remove by code', () => {
+    const parsed = parseBulkPlayerRequest({
+      playerIds: ['p1'],
+      patch: {
+        addHomeLeague: 'boston_dodgeball_league',
+        removeHomeLeague: 'nutmeg_dodgeball',
+      },
+    })
+    expect(parsed.patch.addHomeLeague).toBe('boston_dodgeball_league')
+    expect(parsed.patch.removeHomeLeague).toBe('nutmeg_dodgeball')
+  })
+
+  it('requires notes when enabling strong personality', () => {
+    expect(() =>
+      parseBulkPlayerRequest({
+        playerIds: ['p1'],
+        patch: { hasStrongPersonality: true },
+      })
+    ).toThrow(/strongPersonalityNotes are required/)
+
+    expect(() =>
+      parseBulkPlayerRequest({
+        playerIds: ['p1'],
+        patch: { hasStrongPersonality: true, strongPersonalityNotes: '   ' },
+      })
+    ).toThrow(/strongPersonalityNotes are required/)
+
+    const ok = parseBulkPlayerRequest({
+      playerIds: ['p1'],
+      patch: {
+        hasStrongPersonality: true,
+        strongPersonalityNotes: ' Needs clear communication ',
+      },
+    })
+    expect(ok.patch.strongPersonalityNotes).toBe('Needs clear communication')
+  })
+
+  it('rejects empty playerIds, empty patch, and invalid enums', () => {
+    expect(() => parseBulkPlayerRequest({ playerIds: [], patch: { gender: 'woman' } })).toThrow(
+      /playerIds must be a non-empty array/
+    )
+    expect(() => parseBulkPlayerRequest({ playerIds: ['p1'], patch: {} })).toThrow(
+      /at least one field/
+    )
+    expect(() =>
+      parseBulkPlayerRequest({ playerIds: ['p1'], patch: { gender: 'alien' } })
+    ).toThrow(/Invalid gender/)
+    expect(() =>
+      parseBulkPlayerRequest({ playerIds: ['p1'], patch: { skillLevel: 9 } })
+    ).toThrow(/Invalid skill level/)
+    expect(() =>
+      parseBulkPlayerRequest({
+        playerIds: ['p1'],
+        patch: { addHomeLeague: 'Boston Dodgeball League' },
+      })
+    ).toThrow(/Invalid addHomeLeague/)
+    expect(() =>
+      parseBulkPlayerRequest({
+        playerIds: ['p1'],
+        patch: { removeHomeLeague: 'not-a-league' },
+      })
+    ).toThrow(/Invalid removeHomeLeague/)
+  })
+})
+
+describe('bulkPatchHasCoreFields', () => {
+  it('detects scalar fields vs home-league-only patches', () => {
+    expect(bulkPatchHasCoreFields({ gender: 'man' })).toBe(true)
+    expect(bulkPatchHasCoreFields({ addHomeLeague: 'boston_dodgeball_league' })).toBe(false)
+    const empty: BulkPlayerPatch = {}
+    expect(bulkPatchHasCoreFields(empty)).toBe(false)
+  })
+})

--- a/app/api/players/bulk/route.ts
+++ b/app/api/players/bulk/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import { parseBulkPlayerRequest } from '@/app/lib/players/bulk'
+import { bulkUpdatePlayers } from '@/app/lib/players/mutations'
+
+export async function PATCH(request: NextRequest) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    let body: unknown
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+    }
+
+    const { playerIds, patch } = parseBulkPlayerRequest(body)
+    const result = await bulkUpdatePlayers(playerIds, patch, {
+      actor: session.email,
+    })
+
+    return NextResponse.json(result)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to bulk update players'
+    const status =
+      message.startsWith('Player not found')
+        ? 404
+        : message.startsWith('Cannot edit a merged player')
+          ? 400
+          : message.includes('must') ||
+              message.startsWith('Invalid') ||
+              message.includes('required') ||
+              message.includes('non-empty')
+            ? 400
+            : 500
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/lib/players/bulk.ts
+++ b/app/lib/players/bulk.ts
@@ -1,0 +1,131 @@
+import { isValidGender } from '@/app/lib/players/gender'
+import { isValidHomeLeague } from '@/app/lib/players/home-league'
+import { isValidSkillLevel } from '@/app/lib/players/skill'
+import { shouldPromptForStrongPersonalityNotes } from '@/app/lib/players/strong-personality'
+
+export type BulkPlayerPatch = {
+  gender?: string | null
+  skillLevel?: number | null
+  hasStrongPersonality?: boolean
+  strongPersonalityNotes?: string | null
+  addHomeLeague?: string
+  removeHomeLeague?: string
+}
+
+export type ParsedBulkPlayerRequest = {
+  playerIds: string[]
+  patch: BulkPlayerPatch
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/** Parse and validate a bulk players PATCH body. Throws Error with a user-facing message. */
+export function parseBulkPlayerRequest(body: unknown): ParsedBulkPlayerRequest {
+  if (!isPlainObject(body)) {
+    throw new Error('Request body must be an object')
+  }
+
+  if (!Array.isArray(body.playerIds) || body.playerIds.length === 0) {
+    throw new Error('playerIds must be a non-empty array')
+  }
+
+  const playerIds: string[] = []
+  const seen = new Set<string>()
+  for (const id of body.playerIds) {
+    if (typeof id !== 'string' || !id.trim()) {
+      throw new Error('Each playerId must be a non-empty string')
+    }
+    if (seen.has(id)) continue
+    seen.add(id)
+    playerIds.push(id)
+  }
+
+  if (!isPlainObject(body.patch)) {
+    throw new Error('patch must be an object')
+  }
+
+  const raw = body.patch
+  const patch: BulkPlayerPatch = {}
+
+  if ('gender' in raw) {
+    if (raw.gender === null) {
+      patch.gender = null
+    } else if (typeof raw.gender === 'string' && isValidGender(raw.gender)) {
+      patch.gender = raw.gender
+    } else {
+      throw new Error('Invalid gender')
+    }
+  }
+
+  if ('skillLevel' in raw) {
+    if (raw.skillLevel === null) {
+      patch.skillLevel = null
+    } else if (isValidSkillLevel(raw.skillLevel)) {
+      patch.skillLevel = raw.skillLevel
+    } else {
+      throw new Error('Invalid skill level')
+    }
+  }
+
+  if ('hasStrongPersonality' in raw) {
+    if (typeof raw.hasStrongPersonality !== 'boolean') {
+      throw new Error('hasStrongPersonality must be a boolean')
+    }
+    patch.hasStrongPersonality = raw.hasStrongPersonality
+  }
+
+  if ('strongPersonalityNotes' in raw) {
+    if (raw.strongPersonalityNotes === null) {
+      patch.strongPersonalityNotes = null
+    } else if (typeof raw.strongPersonalityNotes === 'string') {
+      patch.strongPersonalityNotes = raw.strongPersonalityNotes.trim() || null
+    } else {
+      throw new Error('strongPersonalityNotes must be a string or null')
+    }
+  }
+
+  if ('addHomeLeague' in raw) {
+    if (typeof raw.addHomeLeague !== 'string' || !isValidHomeLeague(raw.addHomeLeague)) {
+      throw new Error('Invalid addHomeLeague')
+    }
+    patch.addHomeLeague = raw.addHomeLeague
+  }
+
+  if ('removeHomeLeague' in raw) {
+    if (typeof raw.removeHomeLeague !== 'string' || !isValidHomeLeague(raw.removeHomeLeague)) {
+      throw new Error('Invalid removeHomeLeague')
+    }
+    patch.removeHomeLeague = raw.removeHomeLeague
+  }
+
+  if (
+    patch.gender === undefined &&
+    patch.skillLevel === undefined &&
+    patch.hasStrongPersonality === undefined &&
+    patch.strongPersonalityNotes === undefined &&
+    patch.addHomeLeague === undefined &&
+    patch.removeHomeLeague === undefined
+  ) {
+    throw new Error('patch must include at least one field to update')
+  }
+
+  if (patch.hasStrongPersonality === true) {
+    const notes = patch.strongPersonalityNotes ?? ''
+    if (shouldPromptForStrongPersonalityNotes(true, notes)) {
+      throw new Error('strongPersonalityNotes are required when enabling strong personality')
+    }
+  }
+
+  return { playerIds, patch }
+}
+
+export function bulkPatchHasCoreFields(patch: BulkPlayerPatch): boolean {
+  return (
+    patch.gender !== undefined ||
+    patch.skillLevel !== undefined ||
+    patch.hasStrongPersonality !== undefined ||
+    patch.strongPersonalityNotes !== undefined
+  )
+}

--- a/app/lib/players/mutations.ts
+++ b/app/lib/players/mutations.ts
@@ -3,6 +3,10 @@ import { getDb } from '@/app/lib/db'
 import { playerAliases, playerEmails, playerHomeLeagues, players } from '@/app/db/schema'
 import { writePlayerChange } from '@/app/lib/players/audit'
 import {
+  bulkPatchHasCoreFields,
+  type BulkPlayerPatch,
+} from '@/app/lib/players/bulk'
+import {
   defaultRosterName,
   isValidSkillLevel,
   normalizeStoredJerseyName,
@@ -15,7 +19,7 @@ import {
   snapshotToJson,
 } from '@/app/lib/players/queries'
 import { normalizeAlias, normalizeEmail, normalizeNamePart } from '@/app/lib/players/normalize'
-import type { ChangeSource } from '@/app/lib/players/types'
+import type { ChangeSource, PlayerSnapshot } from '@/app/lib/players/types'
 
 export async function createPlayer(input: {
   firstName: string
@@ -544,4 +548,78 @@ export async function ensurePlayerAlias(
     source: 'import',
     importBatchId: opts.importBatchId,
   })
+}
+
+/**
+ * Apply the same patch to many players. Home-league add is idempotent;
+ * remove-by-code is a no-op when the league is not on the player.
+ */
+export async function bulkUpdatePlayers(
+  playerIds: string[],
+  patch: BulkPlayerPatch,
+  opts: { actor: string }
+): Promise<{ updated: number; players: PlayerSnapshot[] }> {
+  if (playerIds.length === 0) {
+    throw new Error('playerIds must be a non-empty array')
+  }
+  if (
+    !bulkPatchHasCoreFields(patch) &&
+    patch.addHomeLeague === undefined &&
+    patch.removeHomeLeague === undefined
+  ) {
+    throw new Error('patch must include at least one field to update')
+  }
+
+  const results: PlayerSnapshot[] = []
+
+  for (const playerId of playerIds) {
+    let snapshot = await getPlayerSnapshot(playerId)
+    if (!snapshot) {
+      throw new Error(`Player not found: ${playerId}`)
+    }
+    if (snapshot.isMerged) {
+      throw new Error(`Cannot edit a merged player: ${playerId}`)
+    }
+
+    if (bulkPatchHasCoreFields(patch)) {
+      const next = await updatePlayer(
+        playerId,
+        {
+          gender: patch.gender,
+          skillLevel: patch.skillLevel,
+          hasStrongPersonality: patch.hasStrongPersonality,
+          strongPersonalityNotes: patch.strongPersonalityNotes,
+        },
+        { actor: opts.actor, source: 'admin' }
+      )
+      if (!next) throw new Error(`Player not found: ${playerId}`)
+      snapshot = next
+    }
+
+    if (patch.addHomeLeague) {
+      const already = snapshot.homeLeagues.some((h) => h.homeLeague === patch.addHomeLeague)
+      if (!already) {
+        const next = await addPlayerHomeLeague(playerId, patch.addHomeLeague, {
+          actor: opts.actor,
+        })
+        if (!next) throw new Error(`Player not found: ${playerId}`)
+        snapshot = next
+      }
+    }
+
+    if (patch.removeHomeLeague) {
+      const match = snapshot.homeLeagues.find((h) => h.homeLeague === patch.removeHomeLeague)
+      if (match) {
+        const next = await removePlayerHomeLeague(playerId, match.id, {
+          actor: opts.actor,
+        })
+        if (!next) throw new Error(`Player not found: ${playerId}`)
+        snapshot = next
+      }
+    }
+
+    results.push(snapshot)
+  }
+
+  return { updated: results.length, players: results }
 }

--- a/app/players/__tests__/page.test.tsx
+++ b/app/players/__tests__/page.test.tsx
@@ -251,6 +251,141 @@ describe('PlayersPage quick fill mode', () => {
   })
 })
 
+describe('PlayersPage bulk edit mode', () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock)
+    window.localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('selects all visible filtered players and applies a bulk gender update', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          players: [
+            player({
+              id: 'w1',
+              firstName: 'Ada',
+              lastName: 'Woman',
+              rosterName: 'Ada Woman',
+              gender: 'woman',
+            }),
+            player({
+              id: 'w2',
+              firstName: 'Bea',
+              lastName: 'Woman',
+              rosterName: 'Bea Woman',
+              gender: 'woman',
+            }),
+            player({
+              id: 'm1',
+              firstName: 'Cal',
+              lastName: 'Man',
+              rosterName: 'Cal Man',
+              gender: 'man',
+              genderLabel: 'Man',
+              genderGroupLabel: 'M',
+            }),
+          ],
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse({ updated: 2, players: [] }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          players: [
+            player({
+              id: 'w1',
+              firstName: 'Ada',
+              lastName: 'Woman',
+              rosterName: 'Ada Woman',
+              skillLevel: 3,
+              skillLabel: 'Advanced',
+              gender: 'woman',
+            }),
+            player({
+              id: 'w2',
+              firstName: 'Bea',
+              lastName: 'Woman',
+              rosterName: 'Bea Woman',
+              skillLevel: 3,
+              skillLabel: 'Advanced',
+              gender: 'woman',
+            }),
+            player({
+              id: 'm1',
+              firstName: 'Cal',
+              lastName: 'Man',
+              rosterName: 'Cal Man',
+              gender: 'man',
+              genderLabel: 'Man',
+              genderGroupLabel: 'M',
+            }),
+          ],
+        })
+      )
+
+    render(<PlayersPage />)
+
+    await screen.findByText('3 players')
+    expect(screen.queryByLabelText('Select Ada Woman')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Bulk edit' }))
+    expect(screen.getByText(/Bulk edit mode:/)).toBeInTheDocument()
+
+    await userEvent.selectOptions(screen.getByLabelText('Filter by gender'), 'w_nb_o')
+    expect(screen.getByText('2 players')).toBeInTheDocument()
+    expect(screen.queryByText('Cal')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /Select all visible \(2\)/ }))
+    expect(screen.getByLabelText('Select Ada Woman')).toBeChecked()
+    expect(screen.getByLabelText('Select Bea Woman')).toBeChecked()
+
+    await userEvent.selectOptions(screen.getByLabelText('Bulk set skill'), '3')
+    await userEvent.click(screen.getByRole('button', { name: 'Apply to 2 players' }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+    expect(fetchMock.mock.calls[1]?.[0]).toBe('/api/players/bulk')
+    expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({
+      method: 'PATCH',
+      body: JSON.stringify({
+        playerIds: ['w1', 'w2'],
+        patch: { skillLevel: 3 },
+      }),
+    })
+    expect(await screen.findByText('Updated 2 players')).toBeInTheDocument()
+  })
+
+  it('exits quick fill when entering bulk edit', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        players: [
+          player({
+            id: 'missing-gender',
+            gender: null,
+            genderLabel: '—',
+            genderGroupLabel: '—',
+          }),
+        ],
+      })
+    )
+
+    render(<PlayersPage />)
+    await screen.findByText('1 player')
+    await userEvent.click(screen.getByRole('button', { name: 'Quick fill missing info (1)' }))
+    expect(screen.getByText(/Quick fill mode:/)).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Bulk edit' }))
+    expect(screen.queryByText(/Quick fill mode:/)).not.toBeInTheDocument()
+    expect(screen.getByText(/Bulk edit mode:/)).toBeInTheDocument()
+  })
+})
+
 describe('PlayersPage home leagues', () => {
   const fetchMock = vi.fn()
 

--- a/app/players/page.tsx
+++ b/app/players/page.tsx
@@ -52,6 +52,49 @@ type QuickFillDraft = {
   gender: string
 }
 
+/** Empty string = leave field unchanged on apply. */
+type BulkEditDraft = {
+  gender: string
+  skillLevel: string
+  strongPersonality: '' | 'on' | 'off'
+  strongPersonalityNotes: string
+  addHomeLeague: string
+  removeHomeLeague: string
+}
+
+const EMPTY_BULK_EDIT_DRAFT: BulkEditDraft = {
+  gender: '',
+  skillLevel: '',
+  strongPersonality: '',
+  strongPersonalityNotes: '',
+  addHomeLeague: '',
+  removeHomeLeague: '',
+}
+
+function buildBulkEditPatch(draft: BulkEditDraft): Record<string, unknown> | null {
+  const patch: Record<string, unknown> = {}
+  if (draft.gender !== '') {
+    patch.gender = draft.gender === '__clear__' ? null : draft.gender
+  }
+  if (draft.skillLevel !== '') {
+    patch.skillLevel = draft.skillLevel === '__clear__' ? null : Number(draft.skillLevel)
+  }
+  if (draft.strongPersonality === 'on') {
+    patch.hasStrongPersonality = true
+    patch.strongPersonalityNotes = draft.strongPersonalityNotes.trim() || null
+  } else if (draft.strongPersonality === 'off') {
+    patch.hasStrongPersonality = false
+    if (draft.strongPersonalityNotes.trim()) {
+      patch.strongPersonalityNotes = draft.strongPersonalityNotes.trim()
+    }
+  } else if (draft.strongPersonalityNotes.trim()) {
+    patch.strongPersonalityNotes = draft.strongPersonalityNotes.trim()
+  }
+  if (draft.addHomeLeague) patch.addHomeLeague = draft.addHomeLeague
+  if (draft.removeHomeLeague) patch.removeHomeLeague = draft.removeHomeLeague
+  return Object.keys(patch).length > 0 ? patch : null
+}
+
 function parseJerseyNumber(value: string): number | null {
   if (!value.trim()) return null
   const n = Number.parseInt(value, 10)
@@ -305,6 +348,10 @@ export default function PlayersPage() {
   const [quickFillMode, setQuickFillMode] = useState(false)
   const [quickFillDrafts, setQuickFillDrafts] = useState<Record<string, QuickFillDraft>>({})
   const [quickFillSavingId, setQuickFillSavingId] = useState<string | null>(null)
+  const [bulkEditMode, setBulkEditMode] = useState(false)
+  const [bulkEditDraft, setBulkEditDraft] = useState<BulkEditDraft>(EMPTY_BULK_EDIT_DRAFT)
+  const [bulkEditBusy, setBulkEditBusy] = useState(false)
+  const [bulkEditMessage, setBulkEditMessage] = useState<string | null>(null)
 
   useEffect(() => {
     setVisibleColumns(loadVisibleColumns())
@@ -333,15 +380,18 @@ export default function PlayersPage() {
 
   const showGenderColumn = visibleColumns.gender || quickFillMode
   const showSkillColumn = visibleColumns.skill || quickFillMode
+  const showHomeLeaguesColumn = visibleColumns.homeLeagues || bulkEditMode
 
   const visibleColumnCount =
     2 + // first + last always shown
     COLUMN_OPTIONS.filter((c) => {
       if (c.key === 'gender') return showGenderColumn
       if (c.key === 'skill') return showSkillColumn
+      if (c.key === 'homeLeagues') return showHomeLeaguesColumn
       return visibleColumns[c.key]
     }).length +
-    2 // checkbox + actions
+    (bulkEditMode ? 1 : 0) + // checkbox
+    1 // actions
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [editing, setEditing] = useState<PlayerSnapshot | null>(null)
@@ -434,6 +484,18 @@ export default function PlayersPage() {
     [displayedPlayers, selectedIds]
   )
 
+  const selectableVisibleIds = useMemo(
+    () => displayedPlayers.filter((p) => !p.isMerged).map((p) => p.id),
+    [displayedPlayers]
+  )
+
+  const allVisibleSelected =
+    selectableVisibleIds.length > 0 &&
+    selectableVisibleIds.every((id) => selectedIds.has(id))
+
+  const someVisibleSelected =
+    selectableVisibleIds.some((id) => selectedIds.has(id)) && !allVisibleSelected
+
   function toggleSelect(id: string) {
     setSelectedIds((prev) => {
       const next = new Set(prev)
@@ -441,6 +503,73 @@ export default function PlayersPage() {
       else next.add(id)
       return next
     })
+  }
+
+  function toggleSelectAllVisible() {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (allVisibleSelected) {
+        for (const id of selectableVisibleIds) next.delete(id)
+      } else {
+        for (const id of selectableVisibleIds) next.add(id)
+      }
+      return next
+    })
+  }
+
+  function enterBulkEditMode() {
+    setQuickFillMode(false)
+    setBulkEditMode(true)
+    setBulkEditMessage(null)
+    setFormError(null)
+  }
+
+  function exitBulkEditMode() {
+    setBulkEditMode(false)
+    setSelectedIds(new Set())
+    setBulkEditDraft(EMPTY_BULK_EDIT_DRAFT)
+    setBulkEditMessage(null)
+    setFormError(null)
+  }
+
+  async function applyBulkEdit() {
+    if (selectedIds.size === 0 || bulkEditBusy) return
+    const patch = buildBulkEditPatch(bulkEditDraft)
+    if (!patch) {
+      setFormError('Choose at least one field to update')
+      return
+    }
+    if (
+      bulkEditDraft.strongPersonality === 'on' &&
+      shouldPromptForStrongPersonalityNotes(true, bulkEditDraft.strongPersonalityNotes)
+    ) {
+      setFormError('Add strong personality notes when enabling the flag')
+      return
+    }
+
+    setBulkEditBusy(true)
+    setFormError(null)
+    setBulkEditMessage(null)
+    try {
+      const res = await fetch('/api/players/bulk', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          playerIds: [...selectedIds],
+          patch,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Bulk update failed')
+      const updated = typeof data.updated === 'number' ? data.updated : selectedIds.size
+      setBulkEditMessage(`Updated ${updated} player${updated === 1 ? '' : 's'}`)
+      setBulkEditDraft(EMPTY_BULK_EDIT_DRAFT)
+      await loadPlayers()
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Bulk update failed')
+    } finally {
+      setBulkEditBusy(false)
+    }
   }
 
   async function openEdit(id: string) {
@@ -729,6 +858,11 @@ export default function PlayersPage() {
             type="button"
             onClick={() => {
               if (!quickFillMode) {
+                // Entering quick fill — leave bulk edit
+                setBulkEditMode(false)
+                setSelectedIds(new Set())
+                setBulkEditDraft(EMPTY_BULK_EDIT_DRAFT)
+                setBulkEditMessage(null)
                 setSkillFilter('')
                 setHomeLeagueFilter('')
                 setGenderFilter('')
@@ -746,6 +880,23 @@ export default function PlayersPage() {
           <button
             type="button"
             onClick={() => {
+              if (bulkEditMode) {
+                exitBulkEditMode()
+              } else {
+                enterBulkEditMode()
+              }
+            }}
+            className={`rounded px-3 py-2 text-sm ${
+              bulkEditMode
+                ? 'bg-violet-100 text-violet-900 hover:bg-violet-200'
+                : 'border border-violet-300 bg-white text-violet-900 hover:bg-violet-50'
+            }`}
+          >
+            {bulkEditMode ? 'Exit bulk edit' : 'Bulk edit'}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
               setImportOpen(true)
               setImportPreview(null)
               setImportProfileFields('skip')
@@ -755,18 +906,20 @@ export default function PlayersPage() {
           >
             Import TeamLinkt CSV
           </button>
-          <button
-            type="button"
-            disabled={selectedIds.size < 2}
-            onClick={() => {
-              setMergeOpen(true)
-              setSurvivorId([...selectedIds][0] ?? '')
-              setFormError(null)
-            }}
-            className="rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800 hover:bg-gray-50 disabled:opacity-40"
-          >
-            Merge selected ({selectedIds.size})
-          </button>
+          {bulkEditMode ? (
+            <button
+              type="button"
+              disabled={selectedIds.size < 2}
+              onClick={() => {
+                setMergeOpen(true)
+                setSurvivorId([...selectedIds][0] ?? '')
+                setFormError(null)
+              }}
+              className="rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800 hover:bg-gray-50 disabled:opacity-40"
+            >
+              Merge selected ({selectedIds.size})
+            </button>
+          ) : null}
         </div>
       </div>
 
@@ -862,6 +1015,181 @@ export default function PlayersPage() {
         </p>
       ) : null}
 
+      {bulkEditMode ? (
+        <div className="rounded border border-violet-200 bg-violet-50 px-3 py-3 space-y-3 text-violet-950">
+          <p className="text-sm">
+            Bulk edit mode: filter the list (gender, skill, home league, search), select
+            players, then apply shared updates. Leave a field blank to leave it unchanged.
+          </p>
+          <div className="flex flex-wrap items-center gap-2 text-sm">
+            <button
+              type="button"
+              onClick={toggleSelectAllVisible}
+              disabled={selectableVisibleIds.length === 0}
+              className="rounded border border-violet-300 bg-white px-2.5 py-1.5 text-violet-900 hover:bg-violet-100 disabled:opacity-40"
+            >
+              {allVisibleSelected ? 'Deselect all visible' : 'Select all visible'}
+              {selectableVisibleIds.length > 0
+                ? ` (${selectableVisibleIds.length})`
+                : ''}
+            </button>
+            <button
+              type="button"
+              onClick={() => setSelectedIds(new Set())}
+              disabled={selectedIds.size === 0}
+              className="rounded border border-violet-300 bg-white px-2.5 py-1.5 text-violet-900 hover:bg-violet-100 disabled:opacity-40"
+            >
+              Clear selection
+            </button>
+            <span className="text-violet-800">
+              {selectedIds.size} selected
+            </span>
+          </div>
+
+          {selectedIds.size > 0 ? (
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 rounded border border-violet-200 bg-white p-3 text-gray-900">
+              <label className="text-sm">
+                <span className="block text-gray-600 mb-1">Gender</span>
+                <select
+                  aria-label="Bulk set gender"
+                  value={bulkEditDraft.gender}
+                  onChange={(e) =>
+                    setBulkEditDraft((d) => ({ ...d, gender: e.target.value }))
+                  }
+                  className="w-full rounded border border-gray-300 bg-white px-2 py-1.5 text-sm"
+                >
+                  <option value="">No change</option>
+                  {Object.entries(GENDERS).map(([value, label]) => (
+                    <option key={value} value={value}>
+                      {label}
+                    </option>
+                  ))}
+                  <option value="__clear__">Clear</option>
+                </select>
+              </label>
+              <label className="text-sm">
+                <span className="block text-gray-600 mb-1">Skill</span>
+                <select
+                  aria-label="Bulk set skill"
+                  value={bulkEditDraft.skillLevel}
+                  onChange={(e) =>
+                    setBulkEditDraft((d) => ({ ...d, skillLevel: e.target.value }))
+                  }
+                  className="w-full rounded border border-gray-300 bg-white px-2 py-1.5 text-sm"
+                >
+                  <option value="">No change</option>
+                  {Object.entries(SKILL_LEVELS).map(([value, label]) => (
+                    <option key={value} value={value}>
+                      {value}: {label}
+                    </option>
+                  ))}
+                  <option value="__clear__">Clear</option>
+                </select>
+              </label>
+              <label className="text-sm">
+                <span className="block text-gray-600 mb-1">Strong personality</span>
+                <select
+                  aria-label="Bulk set strong personality"
+                  value={bulkEditDraft.strongPersonality}
+                  onChange={(e) =>
+                    setBulkEditDraft((d) => ({
+                      ...d,
+                      strongPersonality: e.target.value as BulkEditDraft['strongPersonality'],
+                    }))
+                  }
+                  className="w-full rounded border border-gray-300 bg-white px-2 py-1.5 text-sm"
+                >
+                  <option value="">No change</option>
+                  <option value="on">Turn on</option>
+                  <option value="off">Turn off</option>
+                </select>
+              </label>
+              {bulkEditDraft.strongPersonality === 'on' ||
+              bulkEditDraft.strongPersonalityNotes ? (
+                <label className="text-sm sm:col-span-2 lg:col-span-1">
+                  <span className="block text-gray-600 mb-1">Strong personality notes</span>
+                  <input
+                    aria-label="Bulk strong personality notes"
+                    value={bulkEditDraft.strongPersonalityNotes}
+                    onChange={(e) =>
+                      setBulkEditDraft((d) => ({
+                        ...d,
+                        strongPersonalityNotes: e.target.value,
+                      }))
+                    }
+                    placeholder={
+                      bulkEditDraft.strongPersonality === 'on'
+                        ? 'Required when turning on'
+                        : 'Optional'
+                    }
+                    className="w-full rounded border border-gray-300 bg-white px-2 py-1.5 text-sm"
+                  />
+                </label>
+              ) : null}
+              <label className="text-sm">
+                <span className="block text-gray-600 mb-1">Add home league</span>
+                <select
+                  aria-label="Bulk add home league"
+                  value={bulkEditDraft.addHomeLeague}
+                  onChange={(e) =>
+                    setBulkEditDraft((d) => ({ ...d, addHomeLeague: e.target.value }))
+                  }
+                  className="w-full rounded border border-gray-300 bg-white px-2 py-1.5 text-sm"
+                >
+                  <option value="">No change</option>
+                  {Object.entries(HOME_LEAGUES).map(([value, label]) => (
+                    <option key={value} value={value}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="text-sm">
+                <span className="block text-gray-600 mb-1">Remove home league</span>
+                <select
+                  aria-label="Bulk remove home league"
+                  value={bulkEditDraft.removeHomeLeague}
+                  onChange={(e) =>
+                    setBulkEditDraft((d) => ({ ...d, removeHomeLeague: e.target.value }))
+                  }
+                  className="w-full rounded border border-gray-300 bg-white px-2 py-1.5 text-sm"
+                >
+                  <option value="">No change</option>
+                  {Object.entries(HOME_LEAGUES).map(([value, label]) => (
+                    <option key={value} value={value}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <div className="flex items-end sm:col-span-2 lg:col-span-3 xl:col-span-4">
+                <button
+                  type="button"
+                  disabled={bulkEditBusy || !buildBulkEditPatch(bulkEditDraft)}
+                  onClick={() => void applyBulkEdit()}
+                  className="rounded bg-violet-700 px-3 py-2 text-sm text-white hover:bg-violet-800 disabled:opacity-40"
+                >
+                  {bulkEditBusy
+                    ? 'Applying…'
+                    : `Apply to ${selectedIds.size} player${selectedIds.size === 1 ? '' : 's'}`}
+                </button>
+              </div>
+            </div>
+          ) : null}
+
+          {bulkEditMessage ? (
+            <p className="text-sm text-violet-900" role="status">
+              {bulkEditMessage}
+            </p>
+          ) : null}
+          {formError && bulkEditMode ? (
+            <p className="text-sm text-red-700" role="alert">
+              {formError}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
       {error ? <p className="text-sm text-red-600">{error}</p> : null}
       {loading ? <p className="text-sm text-gray-600">Loading players…</p> : null}
 
@@ -876,7 +1204,20 @@ export default function PlayersPage() {
           <table className="min-w-full text-sm text-gray-900">
             <thead className="bg-gray-50 text-left text-gray-700">
               <tr>
-                <th className="px-3 py-2 w-10" />
+                {bulkEditMode ? (
+                  <th className="px-3 py-2 w-10">
+                    <input
+                      type="checkbox"
+                      aria-label="Select all visible players"
+                      checked={allVisibleSelected}
+                      ref={(el) => {
+                        if (el) el.indeterminate = someVisibleSelected
+                      }}
+                      disabled={selectableVisibleIds.length === 0}
+                      onChange={toggleSelectAllVisible}
+                    />
+                  </th>
+                ) : null}
                 <SortableHeader
                   label="First"
                   active={sortKey === 'first'}
@@ -957,7 +1298,7 @@ export default function PlayersPage() {
                   </th>
                 ) : null}
                 {visibleColumns.email ? <th className="px-3 py-2">Email</th> : null}
-                {visibleColumns.homeLeagues ? (
+                {showHomeLeaguesColumn ? (
                   <th className="px-3 py-2 align-bottom">
                     <div className="space-y-1">
                       <span className="block text-sm font-medium text-gray-700">
@@ -990,14 +1331,17 @@ export default function PlayersPage() {
                   key={p.id}
                   className={`border-t border-gray-100 ${genderRowClass(p.gender, p.isMerged)}`}
                 >
-                  <td className="px-3 py-2">
-                    <input
-                      type="checkbox"
-                      checked={selectedIds.has(p.id)}
-                      disabled={p.isMerged}
-                      onChange={() => toggleSelect(p.id)}
-                    />
-                  </td>
+                  {bulkEditMode ? (
+                    <td className="px-3 py-2">
+                      <input
+                        type="checkbox"
+                        aria-label={`Select ${p.rosterName}`}
+                        checked={selectedIds.has(p.id)}
+                        disabled={p.isMerged}
+                        onChange={() => toggleSelect(p.id)}
+                      />
+                    </td>
+                  ) : null}
                   <td className="px-3 py-2">
                     <SkillStyledText skillLevel={p.skillLevel}>{p.firstName}</SkillStyledText>
                     {p.hasStrongPersonality ? (
@@ -1127,7 +1471,7 @@ export default function PlayersPage() {
                   {visibleColumns.email ? (
                     <td className="px-3 py-2">{p.primaryEmail ?? '—'}</td>
                   ) : null}
-                  {visibleColumns.homeLeagues ? (
+                  {showHomeLeaguesColumn ? (
                     <td className="px-3 py-2">
                       {p.homeLeagues.length > 0 ? (
                         <div className="flex flex-wrap gap-x-3 gap-y-1">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a **Bulk edit** mode on the Players page so admins can filter (e.g. W/NB/O or Boston home league), select all matching players, and apply shared updates in one go.

## What changed
- New `PATCH /api/players/bulk` with validated patch for gender, skill, strong personality (+ required notes when enabling), and home-league add/remove by code
- `bulkUpdatePlayers` reuses existing per-player mutations/audit; home-league add is idempotent and remove is a no-op when missing
- Players UI: bulk edit toggle (mutually exclusive with quick fill), gated checkboxes, select-all-visible, field panel, merge kept inside bulk mode

## How to use
1. Open Players → **Bulk edit**
2. Filter (gender / home league / skill / search)
3. **Select all visible** (or pick rows)
4. Set fields to change (leave others as “No change”) → **Apply**

## Tests
- `app/__tests__/players-bulk.test.ts` — patch validation
- `app/players/__tests__/page.test.tsx` — bulk UI select-all + apply, mutual exclusion with quick fill
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af82d3f7-7a72-46cd-9515-1fb1158f7cd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af82d3f7-7a72-46cd-9515-1fb1158f7cd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

