### PR TITLE
Add players event/home-league filters and minimal columns

### DIFF
--- a/app/api/players/route.ts
+++ b/app/api/players/route.ts
@@ -18,6 +18,7 @@ export async function GET(request: NextRequest) {
     const q = searchParams.get('q') ?? undefined
     const skillParam = searchParams.get('skill')
     const homeLeagueParam = searchParams.get('homeLeague')
+    const eventIdParam = searchParams.get('eventId')
     const includeMerged = searchParams.get('includeMerged') === '1'
 
     let skill: number | 'unset' | null = null
@@ -27,12 +28,21 @@ export async function GET(request: NextRequest) {
       if (isValidSkillLevel(n)) skill = n
     }
 
-    let homeLeague: string | null = null
-    if (homeLeagueParam && isValidHomeLeague(homeLeagueParam)) {
+    let homeLeague: string | 'unset' | null = null
+    if (homeLeagueParam === 'unset') homeLeague = 'unset'
+    else if (homeLeagueParam && isValidHomeLeague(homeLeagueParam)) {
       homeLeague = homeLeagueParam
     }
 
-    const players = await listPlayers({ q, skill, homeLeague, includeMerged })
+    const eventId =
+      eventIdParam &&
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+        eventIdParam
+      )
+        ? eventIdParam
+        : null
+
+    const players = await listPlayers({ q, skill, homeLeague, eventId, includeMerged })
     return NextResponse.json({ players })
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Failed to list players'

--- a/app/lib/players/queries.ts
+++ b/app/lib/players/queries.ts
@@ -1,6 +1,7 @@
-import { and, asc, desc, eq, ilike, inArray, isNull, or, sql } from 'drizzle-orm'
+import { and, asc, desc, eq, ilike, inArray, isNull, notInArray, or, sql } from 'drizzle-orm'
 import { getDb } from '@/app/lib/db'
 import {
+  eventRegistrations,
   playerAliases,
   playerChanges,
   playerEmails,
@@ -19,7 +20,8 @@ import type { PlayerListItem, PlayerSnapshot } from '@/app/lib/players/types'
 export async function listPlayers(opts: {
   q?: string
   skill?: number | 'unset' | null
-  homeLeague?: string | null
+  homeLeague?: string | 'unset' | null
+  eventId?: string | null
   includeMerged?: boolean
 }): Promise<PlayerListItem[]> {
   const db = getDb()
@@ -35,12 +37,25 @@ export async function listPlayers(opts: {
     conditions.push(eq(players.skillLevel, opts.skill))
   }
 
-  if (opts.homeLeague && isValidHomeLeague(opts.homeLeague)) {
+  if (opts.homeLeague === 'unset') {
+    const playersWithHomeLeague = db
+      .select({ playerId: playerHomeLeagues.playerId })
+      .from(playerHomeLeagues)
+    conditions.push(notInArray(players.id, playersWithHomeLeague))
+  } else if (opts.homeLeague && isValidHomeLeague(opts.homeLeague)) {
     const matchingHomeLeagueIds = db
       .select({ playerId: playerHomeLeagues.playerId })
       .from(playerHomeLeagues)
       .where(eq(playerHomeLeagues.homeLeague, opts.homeLeague))
     conditions.push(inArray(players.id, matchingHomeLeagueIds))
+  }
+
+  if (opts.eventId) {
+    const registeredIds = db
+      .select({ playerId: eventRegistrations.playerId })
+      .from(eventRegistrations)
+      .where(eq(eventRegistrations.eventId, opts.eventId))
+    conditions.push(inArray(players.id, registeredIds))
   }
 
   if (opts.q?.trim()) {

--- a/app/players/__tests__/page.test.tsx
+++ b/app/players/__tests__/page.test.tsx
@@ -455,6 +455,101 @@ describe('PlayersPage home leagues', () => {
       method: 'PATCH',
       body: JSON.stringify({ addHomeLeague: 'boston_dodgeball_league' }),
     })
-    expect(await screen.findByText(/1\.\s*Boston Dodgeball League|Boston Dodgeball League/)).toBeInTheDocument()
+    expect(await screen.findByText('1.')).toBeInTheDocument()
+    expect(screen.getAllByText('Boston Dodgeball League').length).toBeGreaterThanOrEqual(1)
+  })
+})
+
+describe('PlayersPage tournament filters and columns', () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock)
+    window.localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('minimal view hides full name, roster name, and email', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        players: [
+          player({
+            primaryEmail: 'alex@example.com',
+            rosterName: 'Alex Player',
+          }),
+        ],
+      })
+    )
+
+    render(<PlayersPage />)
+
+    await screen.findByText('1 player')
+    expect(screen.getByRole('columnheader', { name: /First/ })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: /Last/ })).toBeInTheDocument()
+    expect(screen.getByText('Alex Player')).toBeInTheDocument()
+    expect(screen.getByText('alex@example.com')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Columns' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Minimal view' }))
+
+    expect(screen.queryByRole('columnheader', { name: /First/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('columnheader', { name: /Last/ })).not.toBeInTheDocument()
+    expect(screen.queryByText('Alex Player')).not.toBeInTheDocument()
+    expect(screen.queryByText('alex@example.com')).not.toBeInTheDocument()
+    expect(screen.getByText('Alex P')).toBeInTheDocument()
+  })
+
+  it('filters by event participation and home league none set', async () => {
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.startsWith('/api/events')) {
+        return Promise.resolve(
+          jsonResponse({
+            events: [
+              {
+                id: '11111111-1111-4111-8111-111111111111',
+                name: 'Throw Down',
+                eventDate: '2026-07-01',
+                eventType: 'tournament',
+                eventTypeLabel: 'Tournament',
+                notes: null,
+                registrationCount: 12,
+              },
+            ],
+          })
+        )
+      }
+      return Promise.resolve(jsonResponse({ players: [player()] }))
+    })
+
+    render(<PlayersPage />)
+    await screen.findByText('1 player')
+
+    const eventSelect = screen.getByLabelText('Filter by event')
+    await userEvent.click(eventSelect)
+    await waitFor(() =>
+      expect(screen.getByRole('option', { name: 'Throw Down (2026-07-01)' })).toBeInTheDocument()
+    )
+    await userEvent.selectOptions(eventSelect, '11111111-1111-4111-8111-111111111111')
+
+    await waitFor(() => {
+      const urls = fetchMock.mock.calls.map((call) => String(call[0]))
+      expect(
+        urls.some((url) =>
+          url.includes('eventId=11111111-1111-4111-8111-111111111111')
+        )
+      ).toBe(true)
+    })
+
+    await userEvent.selectOptions(screen.getByLabelText('Filter by home league'), 'unset')
+
+    await waitFor(() => {
+      const urls = fetchMock.mock.calls.map((call) => String(call[0]))
+      expect(urls.some((url) => url.includes('homeLeague=unset'))).toBe(true)
+    })
   })
 })

--- a/app/players/page.tsx
+++ b/app/players/page.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/app/lib/players/home-league'
 import { shouldPromptForStrongPersonalityNotes } from '@/app/lib/players/strong-personality'
 import type { PlayerListItem, PlayerSnapshot } from '@/app/lib/players/types'
+import type { EventListItem } from '@/app/lib/events/types'
 
 type HistoryRow = {
   id: string
@@ -235,6 +236,7 @@ function SortableHeader(props: {
 type SortKey = 'first' | 'last' | 'jersey' | 'jerseyName' | 'gender' | 'skill'
 
 type ColumnKey =
+  | 'fullName'
   | 'roster'
   | 'nickname'
   | 'jerseyNumber'
@@ -245,6 +247,7 @@ type ColumnKey =
   | 'homeLeagues'
 
 const COLUMN_OPTIONS: { key: ColumnKey; label: string }[] = [
+  { key: 'fullName', label: 'Full name' },
   { key: 'roster', label: 'Roster name' },
   { key: 'nickname', label: 'Nickname' },
   { key: 'jerseyNumber', label: 'Jersey #' },
@@ -256,6 +259,7 @@ const COLUMN_OPTIONS: { key: ColumnKey; label: string }[] = [
 ]
 
 const DEFAULT_VISIBLE_COLUMNS: Record<ColumnKey, boolean> = {
+  fullName: true,
   roster: true,
   nickname: true,
   jerseyNumber: false,
@@ -264,6 +268,14 @@ const DEFAULT_VISIBLE_COLUMNS: Record<ColumnKey, boolean> = {
   skill: true,
   email: true,
   homeLeagues: false,
+}
+
+/** Compact roster view for drafting teams. */
+const MINIMAL_VISIBLE_COLUMNS: Record<ColumnKey, boolean> = {
+  ...DEFAULT_VISIBLE_COLUMNS,
+  fullName: false,
+  roster: false,
+  email: false,
 }
 
 const COLUMNS_STORAGE_KEY = 'bdl-admin.players.visibleColumns'
@@ -336,7 +348,12 @@ export default function PlayersPage() {
   const [error, setError] = useState<string | null>(null)
   const [q, setQ] = useState('')
   const [skillFilter, setSkillFilter] = useState('')
-  const [homeLeagueFilter, setHomeLeagueFilter] = useState<'' | HomeLeague>('')
+  const [homeLeagueFilter, setHomeLeagueFilter] = useState<'' | 'unset' | HomeLeague>('')
+  const [eventFilter, setEventFilter] = useState('')
+  const [events, setEvents] = useState<EventListItem[]>([])
+  const [eventsStatus, setEventsStatus] = useState<'idle' | 'loading' | 'loaded' | 'error'>(
+    'idle'
+  )
   const [genderFilter, setGenderFilter] = useState<'' | GenderGroup>('')
   const [sortKey, setSortKey] = useState<SortKey>('last')
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc')
@@ -378,13 +395,15 @@ export default function PlayersPage() {
     setVisibleColumns((prev) => ({ ...prev, [key]: !prev[key] }))
   }
 
+  const showFullNameColumns = visibleColumns.fullName
   const showGenderColumn = visibleColumns.gender || quickFillMode
   const showSkillColumn = visibleColumns.skill || quickFillMode
   const showHomeLeaguesColumn = visibleColumns.homeLeagues || bulkEditMode
 
   const visibleColumnCount =
-    2 + // first + last always shown
+    (showFullNameColumns ? 2 : 0) +
     COLUMN_OPTIONS.filter((c) => {
+      if (c.key === 'fullName') return false
       if (c.key === 'gender') return showGenderColumn
       if (c.key === 'skill') return showSkillColumn
       if (c.key === 'homeLeagues') return showHomeLeaguesColumn
@@ -392,6 +411,20 @@ export default function PlayersPage() {
     }).length +
     (bulkEditMode ? 1 : 0) + // checkbox
     1 // actions
+
+  const loadEvents = useCallback(async () => {
+    if (eventsStatus === 'loading' || eventsStatus === 'loaded') return
+    setEventsStatus('loading')
+    try {
+      const res = await fetch('/api/events')
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to load events')
+      setEvents(data.events ?? [])
+      setEventsStatus('loaded')
+    } catch {
+      setEventsStatus('error')
+    }
+  }, [eventsStatus])
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [editing, setEditing] = useState<PlayerSnapshot | null>(null)
@@ -425,6 +458,7 @@ export default function PlayersPage() {
       if (q.trim()) params.set('q', q.trim())
       if (skillFilter) params.set('skill', skillFilter)
       if (homeLeagueFilter) params.set('homeLeague', homeLeagueFilter)
+      if (eventFilter) params.set('eventId', eventFilter)
       if (includeMerged) params.set('includeMerged', '1')
       const res = await fetch(`/api/players?${params}`)
       const data = await res.json()
@@ -435,7 +469,7 @@ export default function PlayersPage() {
     } finally {
       setLoading(false)
     }
-  }, [q, skillFilter, homeLeagueFilter, includeMerged])
+  }, [q, skillFilter, homeLeagueFilter, eventFilter, includeMerged])
 
   useEffect(() => {
     void loadPlayers()
@@ -933,6 +967,52 @@ export default function PlayersPage() {
             className="rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 w-64"
           />
         </label>
+        <label className="text-sm text-gray-900">
+          <span className="block text-gray-600 mb-1">Event</span>
+          <select
+            aria-label="Filter by event"
+            value={eventFilter}
+            onFocus={() => void loadEvents()}
+            onChange={(e) => setEventFilter(e.target.value)}
+            className="rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 max-w-[16rem]"
+          >
+            <option value="">All events</option>
+            {eventsStatus === 'loading' ? (
+              <option value="" disabled>
+                Loading…
+              </option>
+            ) : null}
+            {eventsStatus === 'error' ? (
+              <option value="" disabled>
+                Failed to load events
+              </option>
+            ) : null}
+            {events.map((event) => (
+              <option key={event.id} value={event.id}>
+                {event.name} ({event.eventDate})
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="text-sm text-gray-900">
+          <span className="block text-gray-600 mb-1">Home league</span>
+          <select
+            aria-label="Filter by home league"
+            value={homeLeagueFilter}
+            onChange={(e) =>
+              setHomeLeagueFilter(e.target.value as '' | 'unset' | HomeLeague)
+            }
+            className="rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 max-w-[14rem]"
+          >
+            <option value="">All</option>
+            <option value="unset">None set</option>
+            {Object.entries(HOME_LEAGUES).map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </label>
         <label className="flex items-center gap-2 text-sm text-gray-900 pb-2">
           <input
             type="checkbox"
@@ -951,7 +1031,6 @@ export default function PlayersPage() {
           </button>
           {columnsOpen ? (
             <div className="absolute left-0 top-full z-20 mt-1 w-52 rounded border border-gray-200 bg-white p-2 shadow-lg">
-              <p className="px-1 pb-1 text-xs text-gray-500">First/last always shown</p>
               {COLUMN_OPTIONS.map((col) => (
                 <label
                   key={col.key}
@@ -968,6 +1047,13 @@ export default function PlayersPage() {
               <button
                 type="button"
                 className="mt-1 w-full rounded px-1 py-1 text-left text-xs text-blue-700 hover:bg-blue-50"
+                onClick={() => setVisibleColumns({ ...MINIMAL_VISIBLE_COLUMNS })}
+              >
+                Minimal view
+              </button>
+              <button
+                type="button"
+                className="w-full rounded px-1 py-1 text-left text-xs text-blue-700 hover:bg-blue-50"
                 onClick={() => setVisibleColumns({ ...DEFAULT_VISIBLE_COLUMNS })}
               >
                 Reset defaults
@@ -1218,18 +1304,22 @@ export default function PlayersPage() {
                     />
                   </th>
                 ) : null}
-                <SortableHeader
-                  label="First"
-                  active={sortKey === 'first'}
-                  dir={sortDir}
-                  onClick={() => toggleSort('first')}
-                />
-                <SortableHeader
-                  label="Last"
-                  active={sortKey === 'last'}
-                  dir={sortDir}
-                  onClick={() => toggleSort('last')}
-                />
+                {showFullNameColumns ? (
+                  <SortableHeader
+                    label="First"
+                    active={sortKey === 'first'}
+                    dir={sortDir}
+                    onClick={() => toggleSort('first')}
+                  />
+                ) : null}
+                {showFullNameColumns ? (
+                  <SortableHeader
+                    label="Last"
+                    active={sortKey === 'last'}
+                    dir={sortDir}
+                    onClick={() => toggleSort('last')}
+                  />
+                ) : null}
                 {visibleColumns.roster ? <th className="px-3 py-2">Roster name</th> : null}
                 {visibleColumns.nickname ? <th className="px-3 py-2">Nickname</th> : null}
                 {visibleColumns.jerseyNumber ? (
@@ -1299,28 +1389,7 @@ export default function PlayersPage() {
                 ) : null}
                 {visibleColumns.email ? <th className="px-3 py-2">Email</th> : null}
                 {showHomeLeaguesColumn ? (
-                  <th className="px-3 py-2 align-bottom">
-                    <div className="space-y-1">
-                      <span className="block text-sm font-medium text-gray-700">
-                        Home leagues
-                      </span>
-                      <select
-                        aria-label="Filter by home league"
-                        value={homeLeagueFilter}
-                        onChange={(e) =>
-                          setHomeLeagueFilter(e.target.value as '' | HomeLeague)
-                        }
-                        className="block w-full max-w-[12rem] rounded border border-gray-300 bg-white px-1.5 py-1 text-xs text-gray-900"
-                      >
-                        <option value="">All</option>
-                        {Object.entries(HOME_LEAGUES).map(([value, label]) => (
-                          <option key={value} value={value}>
-                            {label}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                  </th>
+                  <th className="px-3 py-2">Home leagues</th>
                 ) : null}
                 <th className="px-3 py-2">Actions</th>
               </tr>
@@ -1342,21 +1411,25 @@ export default function PlayersPage() {
                       />
                     </td>
                   ) : null}
-                  <td className="px-3 py-2">
-                    <SkillStyledText skillLevel={p.skillLevel}>{p.firstName}</SkillStyledText>
-                    {p.hasStrongPersonality ? (
-                      <span
-                        title={p.strongPersonalityNotes || 'Strong personality'}
-                        className="ml-1 cursor-help text-amber-500"
-                        aria-label="Strong personality"
-                      >
-                        ⚡
-                      </span>
-                    ) : null}
-                  </td>
-                  <td className="px-3 py-2">
-                    <SkillStyledText skillLevel={p.skillLevel}>{p.lastName}</SkillStyledText>
-                  </td>
+                  {showFullNameColumns ? (
+                    <td className="px-3 py-2">
+                      <SkillStyledText skillLevel={p.skillLevel}>{p.firstName}</SkillStyledText>
+                      {p.hasStrongPersonality ? (
+                        <span
+                          title={p.strongPersonalityNotes || 'Strong personality'}
+                          className="ml-1 cursor-help text-amber-500"
+                          aria-label="Strong personality"
+                        >
+                          ⚡
+                        </span>
+                      ) : null}
+                    </td>
+                  ) : null}
+                  {showFullNameColumns ? (
+                    <td className="px-3 py-2">
+                      <SkillStyledText skillLevel={p.skillLevel}>{p.lastName}</SkillStyledText>
+                    </td>
+                  ) : null}
                   {visibleColumns.roster ? (
                     <td className="px-3 py-2">
                       <SkillStyledText skillLevel={p.skillLevel}>{p.rosterName}</SkillStyledText>
@@ -1365,6 +1438,15 @@ export default function PlayersPage() {
                   {visibleColumns.nickname ? (
                     <td className="px-3 py-2">
                       <SkillStyledText skillLevel={p.skillLevel}>{p.nickname}</SkillStyledText>
+                      {!showFullNameColumns && p.hasStrongPersonality ? (
+                        <span
+                          title={p.strongPersonalityNotes || 'Strong personality'}
+                          className="ml-1 cursor-help text-amber-500"
+                          aria-label="Strong personality"
+                        >
+                          ⚡
+                        </span>
+                      ) : null}
                     </td>
                   ) : null}
                   {visibleColumns.jerseyNumber ? (


### PR DESCRIPTION
## Summary
- Filter players by event registration and by home league (including none set) for tournament team building
- Make full name (first/last) toggleable and add a Minimal view that hides email, roster name, and full name
- Move the home-league filter to the top bar so it works without enabling the column

## Test plan
- [ ] On `/players`, open the Event filter and confirm events load; selecting one shows only registered players
- [ ] Filter Home league to a specific league and to **None set**; confirm results match
- [ ] Open Columns → **Minimal view**; confirm first/last, roster name, and email are hidden; nickname/gender/skill remain
- [ ] Toggle Full name / Reset defaults and confirm column prefs persist after refresh
- [ ] Run `npm test -- --run app/players/__tests__/page.test.tsx`


Made with [Cursor](https://cursor.com)