### PR TITLE
Player edit modal UX and male/female gender rename

### DIFF
--- a/.cursor/players-and-auth-runbook.md
+++ b/.cursor/players-and-auth-runbook.md
@@ -72,6 +72,6 @@ Sign in at `/login`. TopNav shows the signed-in email and Log out.
 - UI: `/players`
 - Import TeamLinkt CSV (dry run → commit). Matching: email, then first+last name.
 - Skill levels: 1 Beginner, 2 Intermediate, 3 Advanced, 4 Worlds level (`null` = Unset).
-- Gender: man / woman / nonbinary / other (imported from TeamLinkt Gender column). List sorts women/nonbinary/other together for drafting. Birthdate from TeamLinkt is not stored or shown.
+- Gender: male / female / nonbinary / other (imported from TeamLinkt Gender column). List sorts female/nonbinary/other together for drafting. Birthdate from TeamLinkt is not stored or shown.
 - Import fills skill when the CSV has a Skill / Skill Level column (`2`/`Intermediate`, `3`/`Advanced`, etc.). Creates get the value; updates only set skill when the existing player is unset.
 - All writes audit to `player_changes` with `actor` = Google email and `source` = `admin` or `import`.

--- a/app/__tests__/event-draft-seed.test.ts
+++ b/app/__tests__/event-draft-seed.test.ts
@@ -60,12 +60,12 @@ describe('defaultTeamCount', () => {
 describe('autoSeedDraftGroups', () => {
   it('assigns every player to a team 1..N', () => {
     const players = [
-      player('a', 4, 'woman'),
-      player('b', 3, 'man'),
-      player('c', 2, 'woman'),
-      player('d', 1, 'man'),
+      player('a', 4, 'female'),
+      player('b', 3, 'male'),
+      player('c', 2, 'female'),
+      player('d', 1, 'male'),
       player('e', 3, 'nonbinary'),
-      player('f', 2, 'man'),
+      player('f', 2, 'male'),
     ]
     const result = autoSeedDraftGroups(players, 2)
     expect(result.size).toBe(6)
@@ -80,7 +80,7 @@ describe('autoSeedDraftGroups', () => {
       player(
         `p${i}`,
         (i % 4) + 1,
-        i % 2 === 0 ? 'woman' : 'man'
+        i % 2 === 0 ? 'female' : 'male'
       )
     )
     const teamCount = 3
@@ -94,8 +94,8 @@ describe('autoSeedDraftGroups', () => {
 
   it('spreads gender groups across teams', () => {
     const players = [
-      ...Array.from({ length: 6 }, (_, i) => player(`w${i}`, 3, 'woman')),
-      ...Array.from({ length: 6 }, (_, i) => player(`m${i}`, 3, 'man')),
+      ...Array.from({ length: 6 }, (_, i) => player(`w${i}`, 3, 'female')),
+      ...Array.from({ length: 6 }, (_, i) => player(`m${i}`, 3, 'male')),
     ]
     const result = autoSeedDraftGroups(players, 3)
     const byTeam = Array.from({ length: 3 }, () =>
@@ -113,14 +113,14 @@ describe('autoSeedDraftGroups', () => {
 
   it('balances skill totals across teams', () => {
     const players = [
-      player('a', 4, 'woman'),
-      player('b', 4, 'man'),
-      player('c', 1, 'woman'),
-      player('d', 1, 'man'),
-      player('e', 3, 'woman'),
-      player('f', 3, 'man'),
-      player('g', 2, 'woman'),
-      player('h', 2, 'man'),
+      player('a', 4, 'female'),
+      player('b', 4, 'male'),
+      player('c', 1, 'female'),
+      player('d', 1, 'male'),
+      player('e', 3, 'female'),
+      player('f', 3, 'male'),
+      player('g', 2, 'female'),
+      player('h', 2, 'male'),
     ]
     const result = autoSeedDraftGroups(players, 2)
     const teams = [[], []] as DraftSeedPlayer[][]
@@ -134,8 +134,8 @@ describe('autoSeedDraftGroups', () => {
   it('places unset gender into teams without crashing', () => {
     const players = [
       player('a', 3, null),
-      player('b', 2, 'man'),
-      player('c', 4, 'woman'),
+      player('b', 2, 'male'),
+      player('c', 4, 'female'),
     ]
     const result = autoSeedDraftGroups(players, 2)
     expect(result.size).toBe(3)
@@ -146,7 +146,7 @@ describe('autoSeedDraftGroups', () => {
       player(
         `p${i}`,
         (i % 4) + 1,
-        i % 2 === 0 ? 'woman' : 'man'
+        i % 2 === 0 ? 'female' : 'male'
       )
     )
     const a = autoSeedDraftGroups(players, 2, {
@@ -163,7 +163,7 @@ describe('autoSeedDraftGroups', () => {
 
   it('is deterministic when shuffle is off', () => {
     const players = Array.from({ length: 12 }, (_, i) =>
-      player(`p${i}`, (i % 3) + 1, i % 2 === 0 ? 'woman' : 'man')
+      player(`p${i}`, (i % 3) + 1, i % 2 === 0 ? 'female' : 'male')
     )
     const a = autoSeedDraftGroups(players, 3)
     const b = autoSeedDraftGroups(players, 3)
@@ -172,12 +172,12 @@ describe('autoSeedDraftGroups', () => {
 
   it('keeps paired players on the same team', () => {
     const players: DraftSeedPlayer[] = [
-      { id: 'a', skillLevel: 4, gender: 'woman', pairId: 'pair-1' },
-      { id: 'b', skillLevel: 3, gender: 'man', pairId: 'pair-1' },
-      { id: 'c', skillLevel: 2, gender: 'woman' },
-      { id: 'd', skillLevel: 2, gender: 'man' },
-      { id: 'e', skillLevel: 1, gender: 'woman' },
-      { id: 'f', skillLevel: 1, gender: 'man' },
+      { id: 'a', skillLevel: 4, gender: 'female', pairId: 'pair-1' },
+      { id: 'b', skillLevel: 3, gender: 'male', pairId: 'pair-1' },
+      { id: 'c', skillLevel: 2, gender: 'female' },
+      { id: 'd', skillLevel: 2, gender: 'male' },
+      { id: 'e', skillLevel: 1, gender: 'female' },
+      { id: 'f', skillLevel: 1, gender: 'male' },
     ]
     const result = autoSeedDraftGroups(players, 2)
     expect(result.get('a')).toBe(result.get('b'))
@@ -186,12 +186,12 @@ describe('autoSeedDraftGroups', () => {
 
   it('still assigns all players when pairs are present', () => {
     const players: DraftSeedPlayer[] = [
-      { id: 'a', skillLevel: 4, gender: 'woman', pairId: 'p1' },
-      { id: 'b', skillLevel: 4, gender: 'man', pairId: 'p1' },
-      { id: 'c', skillLevel: 3, gender: 'woman', pairId: 'p2' },
-      { id: 'd', skillLevel: 3, gender: 'man', pairId: 'p2' },
-      { id: 'e', skillLevel: 2, gender: 'woman' },
-      { id: 'f', skillLevel: 2, gender: 'man' },
+      { id: 'a', skillLevel: 4, gender: 'female', pairId: 'p1' },
+      { id: 'b', skillLevel: 4, gender: 'male', pairId: 'p1' },
+      { id: 'c', skillLevel: 3, gender: 'female', pairId: 'p2' },
+      { id: 'd', skillLevel: 3, gender: 'male', pairId: 'p2' },
+      { id: 'e', skillLevel: 2, gender: 'female' },
+      { id: 'f', skillLevel: 2, gender: 'male' },
     ]
     const result = autoSeedDraftGroups(players, 3)
     expect(result.size).toBe(6)
@@ -203,9 +203,9 @@ describe('autoSeedDraftGroups', () => {
 describe('summarizeDraftAssignments', () => {
   it('summarizes unassigned and per-team stats', () => {
     const registrations = [
-      { id: 'a', skillLevel: 4, gender: 'woman' },
-      { id: 'b', skillLevel: 2, gender: 'man' },
-      { id: 'c', skillLevel: 3, gender: 'woman' },
+      { id: 'a', skillLevel: 4, gender: 'female' },
+      { id: 'b', skillLevel: 2, gender: 'male' },
+      { id: 'c', skillLevel: 3, gender: 'female' },
     ]
     const summary = summarizeDraftAssignments(
       registrations,
@@ -223,7 +223,7 @@ describe('summarizeDraftAssignments', () => {
 
 describe('emptySeedDraftGroups', () => {
   it('marks everyone unassigned', () => {
-    const players = [player('a', 1, 'man'), player('b', 2, 'woman')]
+    const players = [player('a', 1, 'male'), player('b', 2, 'female')]
     const result = emptySeedDraftGroups(players)
     expect(result.get('a')).toBeNull()
     expect(result.get('b')).toBeNull()
@@ -233,8 +233,8 @@ describe('emptySeedDraftGroups', () => {
 describe('copyExistingDraftGroups', () => {
   it('copies permanent draft groups into the workspace map', () => {
     const result = copyExistingDraftGroups([
-      { id: 'a', skillLevel: 1, gender: 'man', draftGroup: 2 },
-      { id: 'b', skillLevel: 2, gender: 'woman', draftGroup: null },
+      { id: 'a', skillLevel: 1, gender: 'male', draftGroup: 2 },
+      { id: 'b', skillLevel: 2, gender: 'female', draftGroup: null },
     ])
     expect(result.get('a')).toBe(2)
     expect(result.get('b')).toBeNull()

--- a/app/__tests__/players-bulk.test.ts
+++ b/app/__tests__/players-bulk.test.ts
@@ -9,10 +9,10 @@ describe('parseBulkPlayerRequest', () => {
   it('accepts a gender-only patch and dedupes player ids', () => {
     const parsed = parseBulkPlayerRequest({
       playerIds: ['a', 'b', 'a'],
-      patch: { gender: 'woman' },
+      patch: { gender: 'female' },
     })
     expect(parsed.playerIds).toEqual(['a', 'b'])
-    expect(parsed.patch).toEqual({ gender: 'woman' })
+    expect(parsed.patch).toEqual({ gender: 'female' })
   })
 
   it('accepts clearing gender and skill to null', () => {
@@ -61,7 +61,7 @@ describe('parseBulkPlayerRequest', () => {
   })
 
   it('rejects empty playerIds, empty patch, and invalid enums', () => {
-    expect(() => parseBulkPlayerRequest({ playerIds: [], patch: { gender: 'woman' } })).toThrow(
+    expect(() => parseBulkPlayerRequest({ playerIds: [], patch: { gender: 'female' } })).toThrow(
       /playerIds must be a non-empty array/
     )
     expect(() => parseBulkPlayerRequest({ playerIds: ['p1'], patch: {} })).toThrow(
@@ -90,7 +90,7 @@ describe('parseBulkPlayerRequest', () => {
 
 describe('bulkPatchHasCoreFields', () => {
   it('detects scalar fields vs home-league-only patches', () => {
-    expect(bulkPatchHasCoreFields({ gender: 'man' })).toBe(true)
+    expect(bulkPatchHasCoreFields({ gender: 'male' })).toBe(true)
     expect(bulkPatchHasCoreFields({ addHomeLeague: 'boston_dodgeball_league' })).toBe(false)
     const empty: BulkPlayerPatch = {}
     expect(bulkPatchHasCoreFields(empty)).toBe(false)

--- a/app/__tests__/teamlinkt-import.test.ts
+++ b/app/__tests__/teamlinkt-import.test.ts
@@ -73,19 +73,19 @@ describe('jersey name defaults', () => {
 
 describe('parseGender', () => {
   it('maps TeamLinkt gender labels', () => {
-    expect(parseGender('Female')).toBe('woman')
-    expect(parseGender('Male')).toBe('man')
+    expect(parseGender('Female')).toBe('female')
+    expect(parseGender('Male')).toBe('male')
     expect(parseGender('Other')).toBe('other')
-    expect(parseGender('Cisgender Woman')).toBe('woman')
+    expect(parseGender('Cisgender Woman')).toBe('female')
     expect(parseGender('Non-binary')).toBe('nonbinary')
     expect(parseGender('')).toBeNull()
   })
 
-  it('groups woman/nonbinary/other together', () => {
-    expect(genderGroup('woman')).toBe('w_nb_o')
+  it('groups female/nonbinary/other together', () => {
+    expect(genderGroup('female')).toBe('w_nb_o')
     expect(genderGroup('nonbinary')).toBe('w_nb_o')
     expect(genderGroup('other')).toBe('w_nb_o')
-    expect(genderGroup('man')).toBe('men')
+    expect(genderGroup('male')).toBe('men')
     expect(genderGroup(null)).toBe('unset')
   })
 })
@@ -176,7 +176,7 @@ describe('teamlinkt csv parse', () => {
       firstName: 'Abby',
       lastName: 'Lee',
       email: 'lee@example.com',
-      gender: 'woman',
+      gender: 'female',
     })
     // Birthdate is in raw CSV but not mapped onto the player row
     expect(parsed.rows[0]).not.toHaveProperty('birthdate')

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -24,7 +24,7 @@ export const players = pgTable(
     /** Null = default to last name until manually set. */
     jerseyName: text('jersey_name'),
     skillLevel: integer('skill_level'),
-    /** Canonical: man | woman | nonbinary | other */
+    /** Canonical: male | female | nonbinary | other */
     gender: text('gender'),
     isMerged: boolean('is_merged').notNull().default(false),
     mergedIntoPlayerId: uuid('merged_into_player_id'),

--- a/app/lib/players/gender.ts
+++ b/app/lib/players/gender.ts
@@ -1,31 +1,35 @@
 export const GENDERS = {
-  man: 'Man',
-  woman: 'Woman',
+  male: 'Male',
+  female: 'Female',
   nonbinary: 'Nonbinary',
   other: 'Other',
 } as const
 
 export type Gender = keyof typeof GENDERS
 
-/** Drafting / roster balance: woman + nonbinary + other count together. */
+/** Drafting / roster balance: female + nonbinary + other count together. */
 export type GenderGroup = 'w_nb_o' | 'men' | 'unset'
 
 const GENDER_ALIASES: Record<string, Gender> = {
-  man: 'man',
-  male: 'man',
-  m: 'man',
-  'cisgender man': 'man',
-  cisgender_man: 'man',
-  'cis man': 'man',
-  cis_man: 'man',
-  woman: 'woman',
-  female: 'woman',
-  f: 'woman',
-  w: 'woman',
-  'cisgender woman': 'woman',
-  cisgender_woman: 'woman',
-  'cis woman': 'woman',
-  cis_woman: 'woman',
+  male: 'male',
+  man: 'male',
+  m: 'male',
+  'cisgender man': 'male',
+  cisgender_man: 'male',
+  'cis man': 'male',
+  cis_man: 'male',
+  'cisgender male': 'male',
+  cisgender_male: 'male',
+  female: 'female',
+  woman: 'female',
+  f: 'female',
+  w: 'female',
+  'cisgender woman': 'female',
+  cisgender_woman: 'female',
+  'cis woman': 'female',
+  cis_woman: 'female',
+  'cisgender female': 'female',
+  cisgender_female: 'female',
   nonbinary: 'nonbinary',
   'non binary': 'nonbinary',
   nb: 'nonbinary',
@@ -38,7 +42,7 @@ const GENDER_ALIASES: Record<string, Gender> = {
 }
 
 export function isValidGender(value: unknown): value is Gender {
-  return value === 'man' || value === 'woman' || value === 'nonbinary' || value === 'other'
+  return value === 'male' || value === 'female' || value === 'nonbinary' || value === 'other'
 }
 
 export function genderLabel(gender: string | null | undefined): string {
@@ -48,8 +52,8 @@ export function genderLabel(gender: string | null | undefined): string {
 }
 
 export function genderGroup(gender: string | null | undefined): GenderGroup {
-  if (gender === 'woman' || gender === 'nonbinary' || gender === 'other') return 'w_nb_o'
-  if (gender === 'man') return 'men'
+  if (gender === 'female' || gender === 'nonbinary' || gender === 'other') return 'w_nb_o'
+  if (gender === 'male') return 'men'
   return 'unset'
 }
 

--- a/app/players/__tests__/page.test.tsx
+++ b/app/players/__tests__/page.test.tsx
@@ -16,8 +16,8 @@ function player(overrides: Partial<Record<string, unknown>> = {}) {
     jerseyName: 'Player',
     skillLevel: 2,
     skillLabel: 'Intermediate',
-    gender: 'woman',
-    genderLabel: 'Woman',
+    gender: 'female',
+    genderLabel: 'Female',
     genderGroupLabel: 'W/NB/O',
     primaryEmail: null,
     isMerged: false,
@@ -40,7 +40,7 @@ function playerSnapshot(overrides: Partial<Record<string, unknown>> = {}) {
     jerseyName: 'Player',
     jerseyNameCustom: null,
     skillLevel: 2,
-    gender: 'woman',
+    gender: 'female',
     isMerged: false,
     mergedIntoPlayerId: null,
     hasStrongPersonality: false,
@@ -101,8 +101,8 @@ describe('PlayersPage quick fill mode', () => {
             rosterName: 'Blair NoSkill',
             skillLevel: null,
             skillLabel: 'Unset',
-            gender: 'man',
-            genderLabel: 'Man',
+            gender: 'male',
+            genderLabel: 'Male',
             genderGroupLabel: 'M',
           }),
           player({
@@ -184,7 +184,7 @@ describe('PlayersPage quick fill mode', () => {
 
     await screen.findByText('1 player')
     await userEvent.click(screen.getByRole('button', { name: 'Quick fill missing info (1)' }))
-    await userEvent.selectOptions(screen.getByLabelText('Set gender for Alex NoGender'), 'woman')
+    await userEvent.selectOptions(screen.getByLabelText('Set gender for Alex NoGender'), 'female')
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
 
@@ -192,7 +192,7 @@ describe('PlayersPage quick fill mode', () => {
     expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ gender: 'woman' }),
+      body: JSON.stringify({ gender: 'female' }),
     })
 
     await waitFor(() =>
@@ -227,7 +227,7 @@ describe('PlayersPage quick fill mode', () => {
             lastName: 'BothMissing',
             rosterName: 'Drew BothMissing',
             skillLevel: 2,
-            gender: 'man',
+            gender: 'male',
           }),
         })
       )
@@ -237,7 +237,7 @@ describe('PlayersPage quick fill mode', () => {
 
     await screen.findByText('1 player')
     await userEvent.click(screen.getByRole('button', { name: 'Quick fill missing info (1)' }))
-    await userEvent.selectOptions(screen.getByLabelText('Set gender for Drew BothMissing'), 'man')
+    await userEvent.selectOptions(screen.getByLabelText('Set gender for Drew BothMissing'), 'male')
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
 
@@ -246,7 +246,7 @@ describe('PlayersPage quick fill mode', () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
     expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({
       method: 'PATCH',
-      body: JSON.stringify({ skillLevel: 2, gender: 'man' }),
+      body: JSON.stringify({ skillLevel: 2, gender: 'male' }),
     })
   })
 })
@@ -274,22 +274,22 @@ describe('PlayersPage bulk edit mode', () => {
               firstName: 'Ada',
               lastName: 'Woman',
               rosterName: 'Ada Woman',
-              gender: 'woman',
+              gender: 'female',
             }),
             player({
               id: 'w2',
               firstName: 'Bea',
               lastName: 'Woman',
               rosterName: 'Bea Woman',
-              gender: 'woman',
+              gender: 'female',
             }),
             player({
               id: 'm1',
               firstName: 'Cal',
               lastName: 'Man',
               rosterName: 'Cal Man',
-              gender: 'man',
-              genderLabel: 'Man',
+              gender: 'male',
+              genderLabel: 'Male',
               genderGroupLabel: 'M',
             }),
           ],
@@ -306,7 +306,7 @@ describe('PlayersPage bulk edit mode', () => {
               rosterName: 'Ada Woman',
               skillLevel: 3,
               skillLabel: 'Advanced',
-              gender: 'woman',
+              gender: 'female',
             }),
             player({
               id: 'w2',
@@ -315,15 +315,15 @@ describe('PlayersPage bulk edit mode', () => {
               rosterName: 'Bea Woman',
               skillLevel: 3,
               skillLabel: 'Advanced',
-              gender: 'woman',
+              gender: 'female',
             }),
             player({
               id: 'm1',
               firstName: 'Cal',
               lastName: 'Man',
               rosterName: 'Cal Man',
-              gender: 'man',
-              genderLabel: 'Man',
+              gender: 'male',
+              genderLabel: 'Male',
               genderGroupLabel: 'M',
             }),
           ],

--- a/app/players/page.tsx
+++ b/app/players/page.tsx
@@ -648,7 +648,10 @@ export default function PlayersPage() {
     }
   }
 
-  async function saveEdit(patch: Record<string, unknown>) {
+  async function saveEdit(
+    patch: Record<string, unknown>,
+    options?: { closeOnSuccess?: boolean }
+  ) {
     if (!editing) return
     setSaving(true)
     setFormError(null)
@@ -660,8 +663,13 @@ export default function PlayersPage() {
       })
       const data = await res.json()
       if (!res.ok) throw new Error(data.error || 'Save failed')
-      setEditing(data.player)
-      await loadPlayers()
+      if (options?.closeOnSuccess) {
+        await loadPlayers()
+        setEditing(null)
+      } else {
+        setEditing(data.player)
+        await loadPlayers()
+      }
     } catch (err) {
       setFormError(err instanceof Error ? err.message : 'Save failed')
     } finally {
@@ -1633,7 +1641,7 @@ export default function PlayersPage() {
           saving={saving}
           formError={formError}
           onClose={() => setEditing(null)}
-          onSaveCore={(fields) => void saveEdit(fields)}
+          onSaveCore={(fields) => void saveEdit(fields, { closeOnSuccess: true })}
           onAddEmail={(email) => void saveEdit({ addEmail: email })}
           onRemoveEmail={(id) => void saveEdit({ removeEmailId: id })}
           onSetPrimary={(id) => void saveEdit({ setPrimaryEmailId: id })}
@@ -1949,108 +1957,120 @@ function EditPanel(props: {
           </div>
         ) : null}
 
-        <div className="grid grid-cols-2 gap-3">
-          <label className="text-sm col-span-1">
-            First name
-            <input
-              className="mt-1 w-full rounded border px-3 py-2"
-              value={firstName}
-              disabled={p.isMerged}
-              onChange={(e) => setFirstName(e.target.value)}
-            />
-          </label>
-          <label className="text-sm">
-            Last name
-            <input
-              className="mt-1 w-full rounded border px-3 py-2"
-              value={lastName}
-              disabled={p.isMerged}
-              onChange={(e) => setLastName(e.target.value)}
-            />
-          </label>
-          <label className="text-sm col-span-2">
-            Roster name
-            <input
-              className="mt-1 w-full rounded border px-3 py-2"
-              value={rosterName}
-              disabled={p.isMerged}
-              onChange={(e) => setRosterName(e.target.value)}
-            />
-          </label>
-          <label className="text-sm col-span-2">
-            Nickname
-            <input
-              className="mt-1 w-full rounded border px-3 py-2"
-              value={nickname}
-              disabled={p.isMerged}
-              onChange={(e) => setNickname(e.target.value)}
-              placeholder={nicknameDefault}
-            />
-            <span className="mt-1 block text-xs text-gray-500">
-              Defaults to first name + last initial ({nicknameDefault}
-              {p.nicknameCustom ? '' : ' — currently using default'}
-              ). Clear or match the default to keep it automatic.
-            </span>
-          </label>
-          <label className="text-sm">
-            Jersey #
-            <input
-              className="mt-1 w-full rounded border px-3 py-2"
-              value={jerseyNumber}
-              disabled={p.isMerged}
-              onChange={(e) => setJerseyNumber(e.target.value)}
-            />
-          </label>
-          <label className="text-sm">
-            Jersey name
-            <input
-              className="mt-1 w-full rounded border px-3 py-2"
-              value={jerseyName}
-              disabled={p.isMerged}
-              onChange={(e) => setJerseyName(e.target.value)}
-              placeholder={jerseyNameDefault}
-            />
-            <span className="mt-1 block text-xs text-gray-500">
-              Defaults to last name ({jerseyNameDefault}
-              {p.jerseyNameCustom ? '' : ' — currently using default'}
-              ).
-            </span>
-          </label>
-          <label className="text-sm">
-            Skill
-            <select
-              className="mt-1 w-full rounded border px-3 py-2"
-              value={skillLevel}
-              disabled={p.isMerged}
-              onChange={(e) => setSkillLevel(e.target.value)}
-            >
-              <option value="">Unset</option>
-              {Object.entries(SKILL_LEVELS).map(([value, label]) => (
-                <option key={value} value={value}>
-                  {value}: {label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="text-sm">
-            Gender
-            <select
-              className="mt-1 w-full rounded border px-3 py-2"
-              value={gender}
-              disabled={p.isMerged}
-              onChange={(e) => setGender(e.target.value)}
-            >
-              <option value="">Unset</option>
-              {Object.entries(GENDERS).map(([value, label]) => (
-                <option key={value} value={value}>
-                  {label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <div className="col-span-2 rounded border border-amber-200 bg-amber-50/50 px-3 py-2">
-            <p className="text-sm font-medium text-amber-900">Player flags</p>
-            <label className="mt-2 text-sm flex items-start gap-2">
+        <div className="space-y-2">
+          <h3 className="font-medium text-sm">Roster</h3>
+          <div className="grid grid-cols-2 gap-3">
+            <label className="text-sm">
+              Skill
+              <select
+                className="mt-1 w-full rounded border px-3 py-2"
+                value={skillLevel}
+                disabled={p.isMerged}
+                onChange={(e) => setSkillLevel(e.target.value)}
+              >
+                <option value="">Unset</option>
+                {Object.entries(SKILL_LEVELS).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {value}: {label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="text-sm">
+              Gender
+              <select
+                className="mt-1 w-full rounded border px-3 py-2"
+                value={gender}
+                disabled={p.isMerged}
+                onChange={(e) => setGender(e.target.value)}
+              >
+                <option value="">Unset</option>
+                {Object.entries(GENDERS).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="text-sm">
+              Jersey #
+              <input
+                className="mt-1 w-full rounded border px-3 py-2"
+                value={jerseyNumber}
+                disabled={p.isMerged}
+                onChange={(e) => setJerseyNumber(e.target.value)}
+              />
+            </label>
+            <label className="text-sm">
+              Jersey name
+              <input
+                className="mt-1 w-full rounded border px-3 py-2"
+                value={jerseyName}
+                disabled={p.isMerged}
+                onChange={(e) => setJerseyName(e.target.value)}
+                placeholder={jerseyNameDefault}
+              />
+              <span className="mt-1 block text-xs text-gray-500">
+                Defaults to last name ({jerseyNameDefault}
+                {p.jerseyNameCustom ? '' : ' — currently using default'}
+                ).
+              </span>
+            </label>
+          </div>
+        </div>
+
+        <div className="border-t pt-4 space-y-2">
+          <h3 className="font-medium text-sm">Name</h3>
+          <div className="grid grid-cols-2 gap-3">
+            <label className="text-sm col-span-1">
+              First name
+              <input
+                className="mt-1 w-full rounded border px-3 py-2"
+                value={firstName}
+                disabled={p.isMerged}
+                onChange={(e) => setFirstName(e.target.value)}
+              />
+            </label>
+            <label className="text-sm">
+              Last name
+              <input
+                className="mt-1 w-full rounded border px-3 py-2"
+                value={lastName}
+                disabled={p.isMerged}
+                onChange={(e) => setLastName(e.target.value)}
+              />
+            </label>
+            <label className="text-sm col-span-2">
+              Roster name
+              <input
+                className="mt-1 w-full rounded border px-3 py-2"
+                value={rosterName}
+                disabled={p.isMerged}
+                onChange={(e) => setRosterName(e.target.value)}
+              />
+            </label>
+            <label className="text-sm col-span-2">
+              Nickname
+              <input
+                className="mt-1 w-full rounded border px-3 py-2"
+                value={nickname}
+                disabled={p.isMerged}
+                onChange={(e) => setNickname(e.target.value)}
+                placeholder={nicknameDefault}
+              />
+              <span className="mt-1 block text-xs text-gray-500">
+                Defaults to first name + last initial ({nicknameDefault}
+                {p.nicknameCustom ? '' : ' — currently using default'}
+                ). Clear or match the default to keep it automatic.
+              </span>
+            </label>
+          </div>
+        </div>
+
+        <div className="border-t pt-4 space-y-2">
+          <h3 className="font-medium text-sm">Flags</h3>
+          <div className="rounded border border-amber-200 bg-amber-50/50 px-3 py-2">
+            <label className="text-sm flex items-start gap-2">
               <input
                 type="checkbox"
                 className="mt-0.5"
@@ -2070,7 +2090,7 @@ function EditPanel(props: {
             ) : null}
           </div>
           {hasStrongPersonality ? (
-            <label className="text-sm col-span-2">
+            <label className="text-sm block">
               Strong personality notes
               <textarea
                 className="mt-1 w-full rounded border px-3 py-2 text-sm"

--- a/drizzle/0010_gender_male_female.sql
+++ b/drizzle/0010_gender_male_female.sql
@@ -1,0 +1,2 @@
+UPDATE "players" SET "gender" = 'male' WHERE "gender" = 'man';
+UPDATE "players" SET "gender" = 'female' WHERE "gender" = 'woman';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1753232000000,
       "tag": "0009_player_home_leagues",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1753296000000,
+      "tag": "0010_gender_male_female",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Close the edit player panel after a successful **Save details** (emails/aliases/home leagues still save in place without closing).
- Regroup edit fields into **Roster** (skill, gender, jersey), **Name**, and **Flags**, with frequently edited roster fields first.
- Rename canonical gender values from `man`/`woman` to `male`/`female` (UI labels, validation, import aliases, tests, schema comment, and DB migration `0010_gender_male_female.sql`).

## Notes
- Create flow unchanged: create still closes and opens edit so related entities can be added.
- Drafting pool key `men` / labels `M` and `W/NB/O` left as-is (balance-group IDs, not person gender values).
- Legacy CSV values like `Man`/`Woman` still parse via aliases.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12be61fd-f41c-4847-8ea0-eb420f0c2200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12be61fd-f41c-4847-8ea0-eb420f0c2200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

