### PR TITLE
Event and import tweaks: pairing, captains, home league, nicer import

### DIFF
--- a/app/api/events/[id]/registrations/[registrationId]/route.ts
+++ b/app/api/events/[id]/registrations/[registrationId]/route.ts
@@ -36,11 +36,23 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     }
 
     if (body.unpair === true) {
+      if (!event.pairingEnabled) {
+        return NextResponse.json(
+          { error: 'Pairing is disabled for this event' },
+          { status: 400 }
+        )
+      }
       const result = await unpairRegistration(id, registrationId)
       return NextResponse.json({ result })
     }
 
     if ('pairWithRegistrationId' in body) {
+      if (!event.pairingEnabled) {
+        return NextResponse.json(
+          { error: 'Pairing is disabled for this event' },
+          { status: 400 }
+        )
+      }
       if (
         typeof body.pairWithRegistrationId !== 'string' ||
         !body.pairWithRegistrationId
@@ -87,8 +99,10 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
         ? 404
         : message.includes('draftGroup') ||
             message.includes('pair') ||
+            message.includes('Pairing') ||
             message.includes('Cannot pair') ||
-            message.includes('already paired')
+            message.includes('already paired') ||
+            message.includes('captain')
           ? 400
           : 500
     return NextResponse.json({ error: message }, { status })

--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -42,6 +42,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       eventDate?: string
       eventType?: string | null
       notes?: string | null
+      pairingEnabled?: boolean
     }
 
     if (
@@ -50,6 +51,16 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       !isValidEventType(body.eventType)
     ) {
       return NextResponse.json({ error: 'Invalid eventType' }, { status: 400 })
+    }
+
+    if (
+      body.pairingEnabled !== undefined &&
+      typeof body.pairingEnabled !== 'boolean'
+    ) {
+      return NextResponse.json(
+        { error: 'pairingEnabled must be a boolean' },
+        { status: 400 }
+      )
     }
 
     const event = await updateEvent(id, body)

--- a/app/components/events/EventDraftBoard.tsx
+++ b/app/components/events/EventDraftBoard.tsx
@@ -44,6 +44,7 @@ type Props = {
   onDiscard: () => void
   applying: boolean
   error: string | null
+  pairingEnabled?: boolean
   snapshots: EventDraftSnapshotListItem[]
   snapshotsBusy: boolean
   onSaveSnapshot: (name: string) => Promise<void>
@@ -66,6 +67,27 @@ function parseColumnId(id: string): number | null {
 
 function displayName(player: EventRegistrationListItem): string {
   return player.nickname || `${player.firstName} ${player.lastName}`
+}
+
+function captainBadgeForAssignment(
+  player: EventRegistrationListItem,
+  team: number | null,
+  registrations: EventRegistrationListItem[],
+  assignments: DraftAssignment
+): '(C)' | '(CC)' | null {
+  if (!player.isCaptain || team == null) return null
+  const captainsOnTeam = registrations.filter((r) => {
+    if (!r.isCaptain) return false
+    const assigned = assignments.get(r.id)
+    const effective = assigned !== undefined ? assigned : r.draftGroup
+    return effective === team
+  })
+  return captainsOnTeam.length > 1 ? '(CC)' : '(C)'
+}
+
+function homeLeagueText(player: EventRegistrationListItem): string | null {
+  if (!player.homeLeagues || player.homeLeagues.length === 0) return null
+  return player.homeLeagues.map((h) => h.label).join(', ')
 }
 
 function sortPlayers(
@@ -97,8 +119,12 @@ function playerCardClass(gender: string | null): string {
 function DraftPlayerCard(props: {
   player: EventRegistrationListItem
   dragging?: boolean
+  pairingEnabled?: boolean
+  showHomeLeague?: boolean
+  captainBadge?: '(C)' | '(CC)' | null
 }) {
-  const { player, dragging } = props
+  const { player, dragging, pairingEnabled, showHomeLeague, captainBadge } = props
+  const league = homeLeagueText(player)
   return (
     <div
       className={`rounded border px-2 py-1.5 text-xs shadow-sm ${playerCardClass(player.gender)} ${
@@ -107,6 +133,14 @@ function DraftPlayerCard(props: {
     >
       <div className="font-medium text-gray-900">
         {player.nickname || `${player.firstName} ${player.lastName}`}
+        {captainBadge ? (
+          <span
+            className="ml-1 text-[10px] font-semibold text-blue-700"
+            title={captainBadge === '(CC)' ? 'Co-captain' : 'Captain'}
+          >
+            {captainBadge}
+          </span>
+        ) : null}
         {player.hasStrongPersonality ? (
           <span
             title={player.strongPersonalityNotes || 'Strong personality'}
@@ -116,7 +150,7 @@ function DraftPlayerCard(props: {
             ⚡
           </span>
         ) : null}
-        {player.pairId ? (
+        {pairingEnabled !== false && player.pairId ? (
           <span
             className="ml-1 text-[10px] font-semibold uppercase tracking-wide text-violet-700"
             title={
@@ -135,11 +169,19 @@ function DraftPlayerCard(props: {
         {player.genderGroupLabel}
         {player.skillLevel != null ? ` · ${player.skillLevel}` : ''}
       </div>
+      {showHomeLeague && league ? (
+        <div className="mt-0.5 text-[10px] text-gray-500">{league}</div>
+      ) : null}
     </div>
   )
 }
 
-function DraggablePlayer(props: { player: EventRegistrationListItem }) {
+function DraggablePlayer(props: {
+  player: EventRegistrationListItem
+  pairingEnabled?: boolean
+  showHomeLeague?: boolean
+  captainBadge?: '(C)' | '(CC)' | null
+}) {
   const { attributes, listeners, setNodeRef, transform, isDragging } =
     useDraggable({ id: props.player.id })
   const style = transform
@@ -150,11 +192,16 @@ function DraggablePlayer(props: { player: EventRegistrationListItem }) {
     <div
       ref={setNodeRef}
       style={style}
-      className={`cursor-grab active:cursor-grabbing ${isDragging ? 'opacity-40' : ''}`}
+      className={`cursor-grab touch-none ${isDragging ? 'opacity-40' : ''}`}
       {...listeners}
       {...attributes}
     >
-      <DraftPlayerCard player={props.player} />
+      <DraftPlayerCard
+        player={props.player}
+        pairingEnabled={props.pairingEnabled}
+        showHomeLeague={props.showHomeLeague}
+        captainBadge={props.captainBadge}
+      />
     </div>
   )
 }
@@ -188,6 +235,9 @@ function TeamColumn(props: {
   scoreImbalanced?: boolean
   genderImbalanced?: boolean
   emphasizeUnassigned?: boolean
+  pairingEnabled?: boolean
+  showHomeLeague?: boolean
+  captainBadgeFor?: (player: EventRegistrationListItem) => '(C)' | '(CC)' | null
   onCopy?: () => Promise<void>
 }) {
   const id = columnId(props.team)
@@ -315,7 +365,13 @@ function TeamColumn(props: {
       </div>
       <div className="flex flex-1 flex-col gap-1.5 overflow-y-auto p-2">
         {sortedPlayers.map((p) => (
-          <DraggablePlayer key={p.id} player={p} />
+          <DraggablePlayer
+            key={p.id}
+            player={p}
+            pairingEnabled={props.pairingEnabled}
+            showHomeLeague={props.showHomeLeague}
+            captainBadge={props.captainBadgeFor?.(p) ?? null}
+          />
         ))}
       </div>
     </div>
@@ -333,6 +389,7 @@ export function EventDraftBoard(props: Props) {
     onDiscard,
     applying,
     error,
+    pairingEnabled = true,
     snapshots,
     snapshotsBusy,
     onSaveSnapshot,
@@ -346,6 +403,7 @@ export function EventDraftBoard(props: Props) {
   const [playerSort, setPlayerSort] = useState<PlayerSort>('name')
   const [copyIncludeJersey, setCopyIncludeJersey] = useState(false)
   const [copyUseRosterName, setCopyUseRosterName] = useState(false)
+  const [showHomeLeague, setShowHomeLeague] = useState(false)
   const [snapshotName, setSnapshotName] = useState('')
   const [compareA, setCompareA] = useState<'workspace' | string>('workspace')
   const [compareB, setCompareB] = useState<string>('')
@@ -448,10 +506,13 @@ export function EventDraftBoard(props: Props) {
     const sorted = sortPlayers(teamPlayers, playerSort)
     const lines = sorted.map((p) => {
       const name = copyUseRosterName ? (p.rosterName || displayName(p)) : displayName(p)
-      if (copyIncludeJersey && p.jerseyNumber != null) {
-        return `#${p.jerseyNumber} ${name}`
+      let line =
+        copyIncludeJersey && p.jerseyNumber != null ? `#${p.jerseyNumber} ${name}` : name
+      if (showHomeLeague) {
+        const league = homeLeagueText(p)
+        if (league) line = `${line} — ${league}`
       }
-      return name
+      return line
     })
     try {
       await navigator.clipboard.writeText(lines.join('\n'))
@@ -486,7 +547,7 @@ export function EventDraftBoard(props: Props) {
     const next = new Map(assignments)
     next.set(playerId, targetTeam)
     const dragged = registrations.find((r) => r.id === playerId)
-    if (dragged?.partnerRegistrationId) {
+    if (pairingEnabled && dragged?.partnerRegistrationId) {
       next.set(dragged.partnerRegistrationId, targetTeam)
     }
     onAssignmentsChange(next)
@@ -506,7 +567,7 @@ export function EventDraftBoard(props: Props) {
           <h2 className="text-lg font-semibold text-gray-900">Draft mode</h2>
           <p className="text-sm text-gray-600">
             Working copy only — permanent draft groups are unchanged until you Apply.
-            Paired players move together.
+            {pairingEnabled ? ' Paired players move together.' : ''}
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
@@ -754,6 +815,14 @@ export function EventDraftBoard(props: Props) {
           />
           Use roster name
         </label>
+        <label className="flex items-center gap-1.5 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={showHomeLeague}
+            onChange={(e) => setShowHomeLeague(e.target.checked)}
+          />
+          Show home league
+        </label>
       </div>
 
       <DndContext
@@ -769,6 +838,11 @@ export function EventDraftBoard(props: Props) {
             players={unassignedPlayers}
             sort={playerSort}
             emphasizeUnassigned
+            pairingEnabled={pairingEnabled}
+            showHomeLeague={showHomeLeague}
+            captainBadgeFor={(p) =>
+              captainBadgeForAssignment(p, null, registrations, assignments)
+            }
           />
           {Array.from({ length: teamCount }, (_, i) => i + 1).map((t) => {
             const teamPlayers = byColumn.get(columnId(t)) ?? []
@@ -796,13 +870,31 @@ export function EventDraftBoard(props: Props) {
                   teamStats.genderDeltas[t - 1] >
                     Math.max(1, teamStats.avgGenderDelta + 1)
                 }
+                pairingEnabled={pairingEnabled}
+                showHomeLeague={showHomeLeague}
+                captainBadgeFor={(p) =>
+                  captainBadgeForAssignment(p, t, registrations, assignments)
+                }
                 onCopy={() => copyTeam(teamPlayers)}
               />
             )
           })}
         </div>
         <DragOverlay>
-          {activePlayer ? <DraftPlayerCard player={activePlayer} dragging /> : null}
+          {activePlayer ? (
+            <DraftPlayerCard
+              player={activePlayer}
+              dragging
+              pairingEnabled={pairingEnabled}
+              showHomeLeague={showHomeLeague}
+              captainBadge={captainBadgeForAssignment(
+                activePlayer,
+                assignments.get(activePlayer.id) ?? null,
+                registrations,
+                assignments
+              )}
+            />
+          ) : null}
         </DragOverlay>
       </DndContext>
     </div>

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -97,6 +97,8 @@ export const events = pgTable(
     /** Canonical: tournament | open_gym | other */
     eventType: text('event_type').notNull().default('tournament'),
     notes: text('notes'),
+    /** When false, pair UI/behavior is disabled for the event */
+    pairingEnabled: boolean('pairing_enabled').notNull().default(true),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -38,6 +38,7 @@ type EventDetail = {
   eventType: string
   eventTypeLabel: string
   notes: string | null
+  pairingEnabled: boolean
 }
 
 type ImportAction = {
@@ -108,6 +109,18 @@ function genderRowLabel(row: (typeof GENDER_ROWS)[number]): string {
   return 'Unset'
 }
 
+/** (C) for sole captain on a team; (CC) when the team has multiple captains. */
+function captainBadge(
+  registration: EventRegistrationListItem,
+  all: EventRegistrationListItem[]
+): '(C)' | '(CC)' | null {
+  if (!registration.isCaptain || registration.draftGroup == null) return null
+  const captainsOnTeam = all.filter(
+    (r) => r.draftGroup === registration.draftGroup && r.isCaptain
+  )
+  return captainsOnTeam.length > 1 ? '(CC)' : '(C)'
+}
+
 export default function EventTrackerPage() {
   return (
     <Suspense
@@ -139,7 +152,7 @@ function EventTrackerPageContent() {
 
   const [importOpen, setImportOpen] = useState(false)
   const [importCsv, setImportCsv] = useState('')
-  const [importFilename, setImportFilename] = useState('teamlinkt.csv')
+  const [importFilename, setImportFilename] = useState('pasted.csv')
   const [importProfileFields, setImportProfileFields] = useState<
     'skip' | 'fill_blank' | 'overwrite'
   >('skip')
@@ -290,7 +303,16 @@ function EventTrackerPageContent() {
       setRegistrations((prev) =>
         prev.map((r) =>
           r.id === registrationId
-            ? { ...r, draftGroup: data.registration.draftGroup }
+            ? {
+                ...r,
+                draftGroup: data.registration.draftGroup,
+                isCaptain:
+                  typeof data.registration.isCaptain === 'boolean'
+                    ? data.registration.isCaptain
+                    : draftGroup == null
+                      ? false
+                      : r.isCaptain,
+              }
             : r
         )
       )
@@ -301,6 +323,33 @@ function EventTrackerPageContent() {
       setFormError(err instanceof Error ? err.message : 'Failed to update draft group')
     } finally {
       setSavingId(null)
+    }
+  }
+
+  async function togglePairingEnabled(pairingEnabled: boolean) {
+    if (!event) return
+    setFormError(null)
+    try {
+      const res = await fetch(`/api/events/${eventId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pairingEnabled }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to update pairing')
+      setEvent((prev) =>
+        prev
+          ? {
+              ...prev,
+              pairingEnabled: Boolean(data.event.pairingEnabled),
+            }
+          : prev
+      )
+      setMessage(
+        pairingEnabled ? 'Pairing enabled for this event' : 'Pairing disabled for this event'
+      )
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Failed to update pairing')
     }
   }
 
@@ -379,11 +428,12 @@ function EventTrackerPageContent() {
   }
 
   function seedPlayersFromRegistrations() {
+    const pairingOn = event?.pairingEnabled !== false
     return registrations.map((r) => ({
       id: r.id,
       skillLevel: r.skillLevel,
       gender: r.gender,
-      pairId: r.pairId,
+      pairId: pairingOn ? r.pairId : null,
       draftGroup: r.draftGroup,
     }))
   }
@@ -449,10 +499,14 @@ function EventTrackerPageContent() {
       const data = await res.json()
       if (!res.ok) throw new Error(data.error || 'Failed to apply draft')
       setRegistrations((prev) =>
-        prev.map((r) => ({
-          ...r,
-          draftGroup: draftAssignments.get(r.id) ?? null,
-        }))
+        prev.map((r) => {
+          const draftGroup = draftAssignments.get(r.id) ?? null
+          return {
+            ...r,
+            draftGroup,
+            isCaptain: draftGroup == null ? false : r.isCaptain,
+          }
+        })
       )
       const maxAssigned = Math.max(
         0,
@@ -634,7 +688,7 @@ function EventTrackerPageContent() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           csv: importCsv,
-          filename: importFilename,
+          filename: importFilename.trim() || 'pasted.csv',
           dryRun: true,
           profileFields: importProfileFields,
           eventId,
@@ -654,6 +708,15 @@ function EventTrackerPageContent() {
   }
 
   async function commitImport() {
+    if (!importPreview) {
+      if (
+        !window.confirm(
+          'Import without a dry run? This will create/update players and register them for this event.'
+        )
+      ) {
+        return
+      }
+    }
     setImportBusy(true)
     setFormError(null)
     try {
@@ -662,7 +725,7 @@ function EventTrackerPageContent() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           csv: importCsv,
-          filename: importFilename,
+          filename: importFilename.trim() || 'pasted.csv',
           dryRun: false,
           profileFields: importProfileFields,
           eventId,
@@ -673,6 +736,7 @@ function EventTrackerPageContent() {
       const summary = data.summary as Record<string, number>
       setImportOpen(false)
       setImportCsv('')
+      setImportFilename('pasted.csv')
       setImportPreview(null)
       setImportProfileFields('skip')
       setMessage(
@@ -723,6 +787,14 @@ function EventTrackerPageContent() {
           {event.notes ? (
             <p className="text-sm text-gray-600 mt-1">{event.notes}</p>
           ) : null}
+          <label className="mt-3 flex items-center gap-2 text-sm text-gray-800">
+            <input
+              type="checkbox"
+              checked={event.pairingEnabled !== false}
+              onChange={(e) => void togglePairingEnabled(e.target.checked)}
+            />
+            Allow pairing
+          </label>
         </div>
         <div className="flex flex-wrap gap-2">
           {draftPhase === 'off' ? (
@@ -873,6 +945,7 @@ function EventTrackerPageContent() {
           onDiscard={discardDraft}
           applying={draftApplying}
           error={draftError}
+          pairingEnabled={event.pairingEnabled !== false}
           snapshots={snapshots}
           snapshotsBusy={snapshotsBusy}
           onSaveSnapshot={saveSnapshot}
@@ -1010,14 +1083,19 @@ function EventTrackerPageContent() {
                   <th className="px-3 py-2 font-medium">Email</th>
                   <th className="px-3 py-2 font-medium">Draft group</th>
                   <th className="px-3 py-2 font-medium">Captain</th>
-                  <th className="px-3 py-2 font-medium">Pair</th>
+                  {event.pairingEnabled !== false ? (
+                    <th className="px-3 py-2 font-medium">Pair</th>
+                  ) : null}
                   <th className="px-3 py-2 font-medium"> </th>
                 </tr>
               </thead>
               <tbody>
                 {filtered.length === 0 ? (
                   <tr>
-                    <td colSpan={8} className="px-3 py-6 text-center text-gray-500">
+                    <td
+                      colSpan={event.pairingEnabled !== false ? 8 : 7}
+                      className="px-3 py-6 text-center text-gray-500"
+                    >
                       {registrations.length === 0
                         ? 'No registrations yet. Import a TeamLinkt CSV for this event.'
                         : 'No players match this filter.'}
@@ -1027,6 +1105,8 @@ function EventTrackerPageContent() {
                   filtered.map((r) => {
                     const label =
                       r.nickname || `${r.firstName} ${r.lastName}`
+                    const badge = captainBadge(r, registrations)
+                    const onTeam = r.draftGroup != null
                     const unpairedOptions = registrations.filter(
                       (other) =>
                         other.id !== r.id &&
@@ -1042,10 +1122,15 @@ function EventTrackerPageContent() {
                           <SkillStyledText skillLevel={r.skillLevel}>
                             {label}
                           </SkillStyledText>
-                          {r.isCaptain ? (
-                            <span className="ml-1 text-xs font-medium text-blue-700">(C)</span>
+                          {badge ? (
+                            <span
+                              className="ml-1 text-xs font-medium text-blue-700"
+                              title={badge === '(CC)' ? 'Co-captain' : 'Captain'}
+                            >
+                              {badge}
+                            </span>
                           ) : null}
-                          {r.partnerNickname ? (
+                          {event.pairingEnabled !== false && r.partnerNickname ? (
                             <div className="text-xs text-violet-700">
                               Paired with {r.partnerNickname}
                             </div>
@@ -1081,50 +1166,69 @@ function EventTrackerPageContent() {
                           </select>
                         </td>
                         <td className="px-3 py-2">
-                          <button
-                            type="button"
-                            className={`text-xs disabled:opacity-40 ${r.isCaptain ? 'font-medium text-blue-700 hover:text-blue-900' : 'text-gray-500 hover:text-gray-700'}`}
-                            disabled={savingId === r.id}
-                            onClick={() => void toggleCaptain(r.id, !r.isCaptain)}
-                            title={r.isCaptain ? 'Remove captain' : 'Set as captain'}
-                          >
-                            {r.isCaptain ? '(C) Remove' : 'Set (C)'}
-                          </button>
-                        </td>
-                        <td className="px-3 py-2">
-                          {r.pairId ? (
+                          {onTeam ? (
                             <button
                               type="button"
-                              className="text-xs text-violet-700 hover:underline disabled:opacity-40"
+                              className={`text-xs disabled:opacity-40 ${r.isCaptain ? 'font-medium text-blue-700 hover:text-blue-900' : 'text-gray-500 hover:text-gray-700'}`}
                               disabled={savingId === r.id}
-                              onClick={() => void unpair(r.id)}
+                              onClick={() => void toggleCaptain(r.id, !r.isCaptain)}
+                              title={
+                                r.isCaptain
+                                  ? badge === '(CC)'
+                                    ? 'Remove co-captain'
+                                    : 'Remove captain'
+                                  : 'Set as captain'
+                              }
                             >
-                              Unpair
+                              {r.isCaptain
+                                ? `${badge ?? '(C)'} Remove`
+                                : 'Set (C)'}
                             </button>
-                          ) : unpairedOptions.length > 0 ? (
-                            <select
-                              className="max-w-[10rem] rounded border border-gray-300 px-2 py-1 text-xs disabled:opacity-40"
-                              disabled={savingId === r.id}
-                              defaultValue=""
-                              onChange={(e) => {
-                                const partnerId = e.target.value
-                                e.target.value = ''
-                                if (!partnerId) return
-                                void pairWith(r.id, partnerId)
-                              }}
-                            >
-                              <option value="">Pair with…</option>
-                              {unpairedOptions.map((other) => (
-                                <option key={other.id} value={other.id}>
-                                  {other.nickname ||
-                                    `${other.firstName} ${other.lastName}`}
-                                </option>
-                              ))}
-                            </select>
                           ) : (
-                            <span className="text-xs text-gray-400">—</span>
+                            <span
+                              className="text-xs text-gray-400"
+                              title="Assign to a team first"
+                            >
+                              —
+                            </span>
                           )}
                         </td>
+                        {event.pairingEnabled !== false ? (
+                          <td className="px-3 py-2">
+                            {r.pairId ? (
+                              <button
+                                type="button"
+                                className="text-xs text-violet-700 hover:underline disabled:opacity-40"
+                                disabled={savingId === r.id}
+                                onClick={() => void unpair(r.id)}
+                              >
+                                Unpair
+                              </button>
+                            ) : unpairedOptions.length > 0 ? (
+                              <select
+                                className="max-w-[10rem] rounded border border-gray-300 px-2 py-1 text-xs disabled:opacity-40"
+                                disabled={savingId === r.id}
+                                defaultValue=""
+                                onChange={(e) => {
+                                  const partnerId = e.target.value
+                                  e.target.value = ''
+                                  if (!partnerId) return
+                                  void pairWith(r.id, partnerId)
+                                }}
+                              >
+                                <option value="">Pair with…</option>
+                                {unpairedOptions.map((other) => (
+                                  <option key={other.id} value={other.id}>
+                                    {other.nickname ||
+                                      `${other.firstName} ${other.lastName}`}
+                                  </option>
+                                ))}
+                              </select>
+                            ) : (
+                              <span className="text-xs text-gray-400">—</span>
+                            )}
+                          </td>
+                        ) : null}
                         <td className="px-3 py-2">
                           <button
                             type="button"
@@ -1173,14 +1277,6 @@ function EventTrackerPageContent() {
               </select>
             </label>
             <label className="block text-sm">
-              <span className="text-gray-600">Filename</span>
-              <input
-                className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
-                value={importFilename}
-                onChange={(e) => setImportFilename(e.target.value)}
-              />
-            </label>
-            <label className="block text-sm">
               <span className="text-gray-600">CSV file</span>
               <input
                 type="file"
@@ -1196,6 +1292,11 @@ function EventTrackerPageContent() {
                   })
                 }}
               />
+              {importFilename && importFilename !== 'pasted.csv' ? (
+                <span className="mt-1 block text-xs text-gray-500">
+                  Using file: {importFilename}
+                </span>
+              ) : null}
             </label>
             <textarea
               className="w-full h-40 rounded border border-gray-300 px-3 py-2 font-mono text-xs"
@@ -1266,11 +1367,11 @@ function EventTrackerPageContent() {
               </button>
               <button
                 type="button"
-                disabled={importBusy || !importPreview}
+                disabled={importBusy || !importCsv.trim()}
                 className="rounded bg-blue-600 px-3 py-2 text-sm text-white disabled:opacity-40"
                 onClick={() => void commitImport()}
               >
-                Commit import
+                {importPreview ? 'Commit import' : 'Import now'}
               </button>
             </div>
           </div>

--- a/app/lib/events/mutations.ts
+++ b/app/lib/events/mutations.ts
@@ -35,6 +35,7 @@ export async function createEvent(input: {
   eventDate: string
   eventType?: string | null
   notes?: string | null
+  pairingEnabled?: boolean
 }): Promise<EventRecord> {
   const db = getDb()
   const name = input.name.trim()
@@ -48,10 +49,11 @@ export async function createEvent(input: {
   }
 
   const notes = input.notes?.trim() ? input.notes.trim() : null
+  const pairingEnabled = input.pairingEnabled !== false
 
   const [created] = await db
     .insert(events)
-    .values({ name, eventDate, eventType, notes })
+    .values({ name, eventDate, eventType, notes, pairingEnabled })
     .returning()
 
   return created
@@ -64,6 +66,7 @@ export async function updateEvent(
     eventDate?: string
     eventType?: string | null
     notes?: string | null
+    pairingEnabled?: boolean
   }
 ): Promise<EventRecord> {
   const db = getDb()
@@ -72,6 +75,7 @@ export async function updateEvent(
     eventDate?: string
     eventType?: string
     notes?: string | null
+    pairingEnabled?: boolean
     updatedAt: Date
   } = { updatedAt: new Date() }
 
@@ -94,6 +98,9 @@ export async function updateEvent(
   }
   if (patch.notes !== undefined) {
     updates.notes = patch.notes?.trim() ? patch.notes.trim() : null
+  }
+  if (patch.pairingEnabled !== undefined) {
+    updates.pairingEnabled = Boolean(patch.pairingEnabled)
   }
 
   const [updated] = await db
@@ -165,7 +172,7 @@ export async function updateRegistrationDraftGroup(
   eventId: string,
   registrationId: string,
   draftGroupInput: unknown
-): Promise<{ id: string; draftGroup: number | null }> {
+): Promise<{ id: string; draftGroup: number | null; isCaptain: boolean }> {
   const draftGroup = parseDraftGroup(draftGroupInput)
   if (draftGroup === undefined) {
     throw new Error('draftGroup is required')
@@ -174,7 +181,12 @@ export async function updateRegistrationDraftGroup(
   const db = getDb()
   const [updated] = await db
     .update(eventRegistrations)
-    .set({ draftGroup, updatedAt: new Date() })
+    .set({
+      draftGroup,
+      // Captains only apply to players on a team
+      ...(draftGroup == null ? { isCaptain: false } : {}),
+      updatedAt: new Date(),
+    })
     .where(
       and(
         eq(eventRegistrations.id, registrationId),
@@ -184,6 +196,7 @@ export async function updateRegistrationDraftGroup(
     .returning({
       id: eventRegistrations.id,
       draftGroup: eventRegistrations.draftGroup,
+      isCaptain: eventRegistrations.isCaptain,
     })
 
   if (!updated) throw new Error('Registration not found')
@@ -194,8 +207,27 @@ export async function updateRegistrationCaptain(
   eventId: string,
   registrationId: string,
   isCaptain: boolean
-): Promise<{ id: string; isCaptain: boolean }> {
+): Promise<{ id: string; isCaptain: boolean; draftGroup: number | null }> {
   const db = getDb()
+  const [existing] = await db
+    .select({
+      id: eventRegistrations.id,
+      draftGroup: eventRegistrations.draftGroup,
+    })
+    .from(eventRegistrations)
+    .where(
+      and(
+        eq(eventRegistrations.id, registrationId),
+        eq(eventRegistrations.eventId, eventId)
+      )
+    )
+    .limit(1)
+
+  if (!existing) throw new Error('Registration not found')
+  if (isCaptain && existing.draftGroup == null) {
+    throw new Error('Only players on a team can be captains')
+  }
+
   const [updated] = await db
     .update(eventRegistrations)
     .set({ isCaptain, updatedAt: new Date() })
@@ -208,10 +240,24 @@ export async function updateRegistrationCaptain(
     .returning({
       id: eventRegistrations.id,
       isCaptain: eventRegistrations.isCaptain,
+      draftGroup: eventRegistrations.draftGroup,
     })
 
   if (!updated) throw new Error('Registration not found')
   return updated
+}
+
+async function assertPairingEnabled(eventId: string): Promise<void> {
+  const db = getDb()
+  const [event] = await db
+    .select({ pairingEnabled: events.pairingEnabled })
+    .from(events)
+    .where(eq(events.id, eventId))
+    .limit(1)
+  if (!event) throw new Error('Event not found')
+  if (!event.pairingEnabled) {
+    throw new Error('Pairing is disabled for this event')
+  }
 }
 
 export async function pairRegistrations(
@@ -222,6 +268,8 @@ export async function pairRegistrations(
   if (registrationIdA === registrationIdB) {
     throw new Error('Cannot pair a registration with itself')
   }
+
+  await assertPairingEnabled(eventId)
 
   const db = getDb()
   const rows = await db
@@ -263,6 +311,8 @@ export async function unpairRegistration(
   eventId: string,
   registrationId: string
 ): Promise<{ clearedPairId: string | null; registrationIds: string[] }> {
+  await assertPairingEnabled(eventId)
+
   const db = getDb()
   const [row] = await db
     .select({
@@ -525,7 +575,11 @@ export async function bulkUpdateRegistrationDraftGroups(
   for (const { registrationId, draftGroup } of parsed) {
     const [updated] = await db
       .update(eventRegistrations)
-      .set({ draftGroup, updatedAt: now })
+      .set({
+        draftGroup,
+        ...(draftGroup == null ? { isCaptain: false } : {}),
+        updatedAt: now,
+      })
       .where(
         and(
           eq(eventRegistrations.id, registrationId),

--- a/app/lib/events/queries.ts
+++ b/app/lib/events/queries.ts
@@ -4,6 +4,7 @@ import {
   eventRegistrations,
   events,
   playerEmails,
+  playerHomeLeagues,
   players,
 } from '@/app/db/schema'
 import {
@@ -17,6 +18,10 @@ import {
   skillLevelLabel,
 } from '@/app/lib/players/skill'
 import { genderGroupLabel, genderLabel } from '@/app/lib/players/gender'
+import {
+  homeLeagueLabel,
+  homeLeagueLogoUrl,
+} from '@/app/lib/players/home-league'
 
 export async function listEvents(): Promise<EventListItem[]> {
   const db = getDb()
@@ -96,6 +101,12 @@ export async function listEventRegistrations(
     .from(playerEmails)
     .where(inArray(playerEmails.playerId, playerIds))
 
+  const homeLeagueRows = await db
+    .select()
+    .from(playerHomeLeagues)
+    .where(inArray(playerHomeLeagues.playerId, playerIds))
+    .orderBy(asc(playerHomeLeagues.sortOrder))
+
   const primaryByPlayer = new Map<string, string>()
   for (const e of emails) {
     if (e.isPrimary && !primaryByPlayer.has(e.playerId)) {
@@ -106,6 +117,20 @@ export async function listEventRegistrations(
     if (!primaryByPlayer.has(e.playerId)) {
       primaryByPlayer.set(e.playerId, e.email)
     }
+  }
+
+  const homeLeaguesByPlayer = new Map<
+    string,
+    { homeLeague: string; label: string; logoUrl: string | null }[]
+  >()
+  for (const row of homeLeagueRows) {
+    const list = homeLeaguesByPlayer.get(row.playerId) ?? []
+    list.push({
+      homeLeague: row.homeLeague,
+      label: homeLeagueLabel(row.homeLeague),
+      logoUrl: homeLeagueLogoUrl(row.homeLeague),
+    })
+    homeLeaguesByPlayer.set(row.playerId, list)
   }
 
   const nicknameById = new Map(
@@ -157,6 +182,7 @@ export async function listEventRegistrations(
       primaryEmail: primaryByPlayer.get(r.playerId) ?? null,
       hasStrongPersonality: r.hasStrongPersonality,
       strongPersonalityNotes: r.strongPersonalityNotes,
+      homeLeagues: homeLeaguesByPlayer.get(r.playerId) ?? [],
     }
   })
 }

--- a/app/lib/events/types.ts
+++ b/app/lib/events/types.ts
@@ -18,6 +18,7 @@ export type EventRecord = {
   eventDate: string
   eventType: string
   notes: string | null
+  pairingEnabled: boolean
   createdAt: Date
   updatedAt: Date
 }
@@ -30,6 +31,12 @@ export type EventListItem = {
   eventTypeLabel: string
   notes: string | null
   registrationCount: number
+}
+
+export type EventRegistrationHomeLeague = {
+  homeLeague: string
+  label: string
+  logoUrl: string | null
 }
 
 export type EventRegistrationListItem = {
@@ -57,6 +64,7 @@ export type EventRegistrationListItem = {
   primaryEmail: string | null
   hasStrongPersonality: boolean
   strongPersonalityNotes: string | null
+  homeLeagues: EventRegistrationHomeLeague[]
 }
 
 export type EventDraftSnapshotListItem = {

--- a/app/players/page.tsx
+++ b/app/players/page.tsx
@@ -436,7 +436,9 @@ export default function PlayersPage() {
 
   const [importOpen, setImportOpen] = useState(false)
   const [importCsv, setImportCsv] = useState('')
-  const [importFilename, setImportFilename] = useState('teamlinkt.csv')
+  const [importFilename, setImportFilename] = useState('pasted.csv')
+  const [importScope, setImportScope] = useState<'generic' | 'event'>('generic')
+  const [importEventId, setImportEventId] = useState('')
   const [importProfileFields, setImportProfileFields] = useState<
     'skip' | 'fill_blank' | 'overwrite'
   >('skip')
@@ -811,19 +813,39 @@ export default function PlayersPage() {
     }
   }
 
+  function importRequestBody(dryRun: boolean) {
+    const body: Record<string, unknown> = {
+      csv: importCsv,
+      filename: importFilename.trim() || 'pasted.csv',
+      dryRun,
+      profileFields: importProfileFields,
+    }
+    if (importScope === 'event' && importEventId) {
+      body.eventId = importEventId
+    }
+    return body
+  }
+
+  function validateImportScope(): string | null {
+    if (importScope === 'event' && !importEventId) {
+      return 'Select an event for this import'
+    }
+    return null
+  }
+
   async function previewImport() {
+    const scopeError = validateImportScope()
+    if (scopeError) {
+      setFormError(scopeError)
+      return
+    }
     setImportBusy(true)
     setFormError(null)
     try {
       const res = await fetch('/api/players/import', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          csv: importCsv,
-          filename: importFilename,
-          dryRun: true,
-          profileFields: importProfileFields,
-        }),
+        body: JSON.stringify(importRequestBody(true)),
       })
       const data = await readApiJson(res)
       if (!res.ok) throw new Error(String(data.error || 'Preview failed'))
@@ -838,19 +860,32 @@ export default function PlayersPage() {
     }
   }
 
-  async function commitImport() {
+  async function commitImport(opts?: { skipDryRunConfirm?: boolean }) {
+    const scopeError = validateImportScope()
+    if (scopeError) {
+      setFormError(scopeError)
+      return
+    }
+    if (!importPreview && opts?.skipDryRunConfirm !== false) {
+      const scopeLabel =
+        importScope === 'event'
+          ? `and register them for the selected event`
+          : 'without attaching an event'
+      if (
+        !window.confirm(
+          `Import without a dry run? This will create/update players ${scopeLabel}.`
+        )
+      ) {
+        return
+      }
+    }
     setImportBusy(true)
     setFormError(null)
     try {
       const res = await fetch('/api/players/import', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          csv: importCsv,
-          filename: importFilename,
-          dryRun: false,
-          profileFields: importProfileFields,
-        }),
+        body: JSON.stringify(importRequestBody(false)),
       })
       const data = await readApiJson(res)
       if (!res.ok) throw new Error(String(data.error || 'Import failed'))
@@ -859,14 +894,23 @@ export default function PlayersPage() {
         updated: number
         skipped: number
         ambiguous: number
+        register?: number
+        alreadyRegistered?: number
       }
       setImportOpen(false)
       setImportCsv('')
+      setImportFilename('pasted.csv')
       setImportPreview(null)
       setImportProfileFields('skip')
+      setImportScope('generic')
+      setImportEventId('')
       await loadPlayers()
+      const eventPart =
+        typeof summary.register === 'number'
+          ? `, ${summary.register} registered, ${summary.alreadyRegistered ?? 0} already registered`
+          : ''
       alert(
-        `Import done: ${summary.created} created, ${summary.updated} updated, ${summary.skipped} skipped, ${summary.ambiguous} ambiguous`
+        `Import done: ${summary.created} created, ${summary.updated} updated, ${summary.skipped} skipped, ${summary.ambiguous} ambiguous${eventPart}`
       )
     } catch (err) {
       setFormError(err instanceof Error ? err.message : 'Import failed')
@@ -942,7 +986,12 @@ export default function PlayersPage() {
               setImportOpen(true)
               setImportPreview(null)
               setImportProfileFields('skip')
+              setImportScope('generic')
+              setImportEventId('')
+              setImportFilename('pasted.csv')
+              setImportCsv('')
               setFormError(null)
+              void loadEvents()
             }}
             className="rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800 hover:bg-gray-50"
           >
@@ -1724,9 +1773,67 @@ export default function PlayersPage() {
             <p className="text-sm text-gray-600">
               New players always get skill, gender, and jersey from the CSV. For existing
               players, those fields are left alone by default so manual edits are preserved.
-              To attach registrations to a tournament or other event, import from the Events
-              page instead.
+              Choose an event below to also register matched players for that event.
             </p>
+            <fieldset className="space-y-2 text-sm">
+              <legend className="text-gray-600">Import type</legend>
+              <label className="flex items-center gap-2">
+                <input
+                  type="radio"
+                  name="importScope"
+                  checked={importScope === 'generic'}
+                  onChange={() => {
+                    setImportScope('generic')
+                    setImportEventId('')
+                    setImportPreview(null)
+                  }}
+                />
+                Generic import (players only)
+              </label>
+              <label className="flex items-center gap-2">
+                <input
+                  type="radio"
+                  name="importScope"
+                  checked={importScope === 'event'}
+                  onChange={() => {
+                    setImportScope('event')
+                    setImportPreview(null)
+                    void loadEvents()
+                  }}
+                />
+                For an event (also register players)
+              </label>
+              {importScope === 'event' ? (
+                <label className="block text-sm pl-6">
+                  <span className="text-gray-600">Event</span>
+                  <select
+                    className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+                    value={importEventId}
+                    onChange={(e) => {
+                      setImportEventId(e.target.value)
+                      setImportPreview(null)
+                    }}
+                  >
+                    <option value="">Select an event…</option>
+                    {eventsStatus === 'loading' ? (
+                      <option value="" disabled>
+                        Loading…
+                      </option>
+                    ) : null}
+                    {eventsStatus === 'error' ? (
+                      <option value="" disabled>
+                        Failed to load events
+                      </option>
+                    ) : null}
+                    {events.map((event) => (
+                      <option key={event.id} value={event.id}>
+                        {event.name} ({event.eventDate})
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              ) : null}
+            </fieldset>
             <label className="block text-sm">
               <span className="text-gray-600">Existing players: skill / gender / jersey</span>
               <select
@@ -1745,14 +1852,6 @@ export default function PlayersPage() {
               </select>
             </label>
             <label className="block text-sm">
-              <span className="text-gray-600">Filename</span>
-              <input
-                className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
-                value={importFilename}
-                onChange={(e) => setImportFilename(e.target.value)}
-              />
-            </label>
-            <label className="block text-sm">
               <span className="text-gray-600">CSV file</span>
               <input
                 type="file"
@@ -1768,12 +1867,25 @@ export default function PlayersPage() {
                   })
                 }}
               />
+              {importFilename && importFilename !== 'pasted.csv' ? (
+                <span className="mt-1 block text-xs text-gray-500">
+                  Using file: {importFilename}
+                </span>
+              ) : null}
             </label>
             <textarea
               className="w-full h-40 rounded border border-gray-300 px-3 py-2 font-mono text-xs"
               value={importCsv}
               onChange={(e) => {
                 setImportCsv(e.target.value)
+                if (importFilename !== 'pasted.csv' && !e.target.value) {
+                  setImportFilename('pasted.csv')
+                } else if (
+                  importFilename === 'pasted.csv' ||
+                  importFilename === 'teamlinkt.csv'
+                ) {
+                  setImportFilename('pasted.csv')
+                }
                 setImportPreview(null)
               }}
               placeholder="Or paste CSV contents here…"
@@ -1785,6 +1897,12 @@ export default function PlayersPage() {
                   Preview: {importPreview.summary.create} create,{' '}
                   {importPreview.summary.update} update, {importPreview.summary.skip} skip,{' '}
                   {importPreview.summary.ambiguous} ambiguous
+                  {typeof importPreview.summary.register === 'number' ? (
+                    <>
+                      ; {importPreview.summary.register} will register,{' '}
+                      {importPreview.summary.alreadyRegistered ?? 0} already registered
+                    </>
+                  ) : null}
                 </p>
                 <div className="max-h-48 overflow-y-auto border rounded">
                   <table className="min-w-full text-xs">
@@ -1832,11 +1950,15 @@ export default function PlayersPage() {
               </button>
               <button
                 type="button"
-                disabled={importBusy || !importPreview}
+                disabled={
+                  importBusy ||
+                  !importCsv.trim() ||
+                  (importScope === 'event' && !importEventId)
+                }
                 className="rounded bg-blue-600 px-3 py-2 text-sm text-white disabled:opacity-40"
                 onClick={() => void commitImport()}
               >
-                Commit import
+                {importPreview ? 'Commit import' : 'Import now'}
               </button>
             </div>
           </div>

--- a/drizzle/0010_event_pairing_enabled.sql
+++ b/drizzle/0010_event_pairing_enabled.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "events" ADD COLUMN IF NOT EXISTS "pairing_enabled" boolean DEFAULT true NOT NULL;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Improves TeamLinkt import UX and several event roster behaviors.

### Import (`/players` + event page)
- Choose **generic** vs **for an event** when importing from the players page (event dropdown registers players)
- Removed manual filename field; uses the picked file name (or `pasted.csv`)
- **Import now** works without a dry run (with confirm); dry run remains optional
- Same filename + skip-dry-run UX on the event import modal

### Event pairing
- New `events.pairing_enabled` flag (default on) with migration `0010_event_pairing_enabled.sql`
- Toggle on the event detail page; when off, pair UI is hidden and draft seed/move-together ignores pairs
- Pair/unpair API rejects when pairing is disabled

### Captains
- Captains only allowed when on a team (`draftGroup` set); API rejects otherwise
- Clearing team assignment auto-clears captain (single + bulk)
- Multiple captains on a team show as **(CC)** co-captains; sole captain remains **(C)**
- Draft board cards show captain badges

### Home league on draft/copy
- Registration list includes home leagues
- Draft board: **Show home league** toggle for player cards and copied roster lines

## Notes
- Run DB migration `drizzle/0010_event_pairing_enabled.sql` before deploying.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa008255-9654-452d-ad14-edde82d0700d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa008255-9654-452d-ad14-edde82d0700d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

