### PR TITLE
Prevent unjournaled Drizzle migrations (runbook + CI check)

### DIFF
--- a/.cursor/drizzle-migrations-runbook.md
+++ b/.cursor/drizzle-migrations-runbook.md
@@ -1,0 +1,71 @@
+# Drizzle migrations (prevent / debug)
+
+Deploy applies pending migrations automatically: `npm run build` → `db:migrate:deploy` → `drizzle-kit migrate` when `DATABASE_URL` is set (see [`scripts/migrate-on-deploy.mjs`](../scripts/migrate-on-deploy.mjs)).
+
+**Only journaled migrations run.** A SQL file under `drizzle/` that is missing from `drizzle/meta/_journal.json` is ignored forever. That is how prod can ship schema/code that expects a column the DB never got.
+
+## Adding a schema change (checklist)
+
+1. Update [`app/db/schema.ts`](../app/db/schema.ts).
+2. Prefer generating the migration (keeps journal + SQL in sync):
+
+   ```bash
+   npm run db:generate
+   ```
+
+3. If you must hand-write SQL:
+   - Use the **next unused** numeric prefix (`0000` …). Never reuse a number already on another tag.
+   - Add a matching entry to [`drizzle/meta/_journal.json`](../drizzle/meta/_journal.json):
+     - `idx`: next integer (0-based)
+     - `tag`: filename without `.sql` (e.g. `0011_event_pairing_enabled`)
+     - `breakpoints`: `true` (same as existing entries)
+   - Confirm `ls drizzle/*.sql` has **exactly one** file per journal `tag`.
+4. Before merging, verify locally:
+
+   ```bash
+   # journal tags must match SQL basenames
+   node -e "
+   const j=require('./drizzle/meta/_journal.json');
+   const fs=require('fs');
+   const tags=new Set(j.entries.map(e=>e.tag));
+   const files=fs.readdirSync('drizzle').filter(f=>f.endsWith('.sql')).map(f=>f.replace(/\\.sql$/,''));
+   const unjournaled=files.filter(t=>!tags.has(t));
+   const missing=j.entries.map(e=>e.tag).filter(t=>!files.includes(t));
+   if (unjournaled.length||missing.length) {
+     console.error({unjournaled, missing});
+     process.exit(1);
+   }
+   console.log('ok', j.entries.length, 'migrations');
+   "
+   ```
+
+5. After merge: check the Vercel **Production** build log for `[db:migrate:deploy] Applying pending Drizzle migrations…` and no drizzle errors. Then hit an endpoint that reads the new column/table.
+
+## Symptoms of a missing / unjournaled migration
+
+| Symptom | Likely cause |
+|--------|----------------|
+| Prod 500 on `/events` or event APIs right after a schema PR | Code selects a new column; DB never altered |
+| Postgres: `column "…" does not exist` / `relation "…" does not exist` | Migration SQL never applied |
+| SQL file exists in repo but prod DB lacks the change | Tag missing from `_journal.json`, or wrong/duplicate prefix so you thought it shipped |
+| `drizzle-kit migrate` says nothing to do | Journal has no pending entries (unjournaled SQL does not count) |
+
+## Debug steps
+
+1. Compare schema field ↔ latest SQL ↔ journal tag for that change.
+2. Confirm Production deploy used the merge commit SHA that includes the journal entry.
+3. In Neon (or any SQL client on `DATABASE_URL`): `\d events` / `information_schema.columns` for the expected column.
+4. If the column is missing but SQL+journal are correct: re-run migrate with Production `DATABASE_URL` (`npm run db:migrate`) or redeploy `main`.
+5. If SQL exists but is unjournaled: add the journal entry (new `idx`/`tag`), ship a follow-up PR, redeploy. Prefer renaming if the prefix already collides (`0010_*` twice is invalid).
+
+## Do not
+
+- Drop a lone `.sql` file into `drizzle/` without updating `_journal.json`.
+- Reuse a migration number already used by another tag (e.g. two `0010_*.sql` files).
+- Change CI/workflows to skip migrate failures in order to “make the build green.”
+- Assume Preview success proves Production schema: Preview and Production are separate DBs unless configured otherwise; both need migrate on their own deploys.
+
+## Related
+
+- Env / Neon setup: [players-and-auth-runbook.md](./players-and-auth-runbook.md)
+- Migrations live in [`drizzle/`](../drizzle/); journal in [`drizzle/meta/_journal.json`](../drizzle/meta/_journal.json)

--- a/.cursor/players-and-auth-runbook.md
+++ b/.cursor/players-and-auth-runbook.md
@@ -44,10 +44,16 @@ Auth env for the stable preview host is scoped to the **`preview`** Git branch i
 2. Schema changes ship as SQL under [`drizzle/`](../drizzle/). Deploys apply
    them automatically: `npm run build` runs `db:migrate:deploy` before
    `next build` whenever `DATABASE_URL` is set.
-3. Locally (or if you need to migrate without a full build):
+3. **Every** SQL file must be listed in [`drizzle/meta/_journal.json`](../drizzle/meta/_journal.json)
+   or deploy will never apply it (prod can then 500 on missing columns). Use
+   `npm run db:generate` when possible; see
+   [drizzle-migrations-runbook.md](./drizzle-migrations-runbook.md) for the
+   checklist and debugging `column does not exist` after a schema PR.
+4. Locally (or if you need to migrate without a full build):
 
 ```bash
 npm run db:migrate
+npm run db:check-migrations   # SQL files ↔ journal tags
 ```
 
 `db:migrate:deploy` skips cleanly when `DATABASE_URL` is unset (CI builds).

--- a/.cursor/rules/drizzle-migrations.mdc
+++ b/.cursor/rules/drizzle-migrations.mdc
@@ -1,0 +1,19 @@
+---
+description: When changing app/db/schema.ts or drizzle SQL, keep migrations journaled so deploy applies them
+globs:
+  - app/db/schema.ts
+  - drizzle/**
+  - scripts/migrate-on-deploy.mjs
+  - scripts/check-migrations.mjs
+alwaysApply: false
+---
+
+# Drizzle migrations
+
+Deploy only applies migrations listed in `drizzle/meta/_journal.json` via `drizzle-kit migrate`.
+
+- Prefer `npm run db:generate` after schema edits.
+- Never add a lone `drizzle/*.sql` without a matching journal `tag`.
+- Never reuse a numeric prefix already used by another migration file.
+- Run `npm run db:check-migrations` before finishing.
+- If prod 500s with `column … does not exist` after a schema PR, follow `.cursor/drizzle-migrations-runbook.md`.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Run linter
         run: npm run lint
 
+      - name: Check Drizzle migration journal
+        run: npm run db:check-migrations
+
       - name: Run tests
         run: npm run test:run
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:migrate:deploy": "node scripts/migrate-on-deploy.mjs",
+    "db:check-migrations": "node scripts/check-migrations.mjs",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio"
   },

--- a/scripts/check-migrations.mjs
+++ b/scripts/check-migrations.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Fail if drizzle/*.sql and drizzle/meta/_journal.json are out of sync.
+ * Unjournaled SQL is never applied by `drizzle-kit migrate` on deploy.
+ */
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const drizzleDir = join(root, 'drizzle')
+const journalPath = join(drizzleDir, 'meta', '_journal.json')
+
+const journal = JSON.parse(readFileSync(journalPath, 'utf8'))
+const tags = journal.entries.map((e) => e.tag)
+const tagSet = new Set(tags)
+
+const sqlFiles = readdirSync(drizzleDir)
+  .filter((f) => f.endsWith('.sql'))
+  .map((f) => f.replace(/\.sql$/, ''))
+
+const unjournaled = sqlFiles.filter((t) => !tagSet.has(t))
+const missingFiles = tags.filter((t) => !sqlFiles.includes(t))
+
+const prefixes = sqlFiles.map((t) => t.split('_')[0])
+const duplicatePrefixes = [
+  ...new Set(
+    prefixes.filter((p, i) => prefixes.indexOf(p) !== i)
+  ),
+]
+
+const duplicateTags = tags.filter((t, i) => tags.indexOf(t) !== i)
+
+let failed = false
+
+if (unjournaled.length) {
+  failed = true
+  console.error(
+    '[db:check-migrations] SQL files not in _journal.json (will NEVER run on deploy):',
+    unjournaled
+  )
+}
+if (missingFiles.length) {
+  failed = true
+  console.error(
+    '[db:check-migrations] Journal tags with no matching drizzle/*.sql file:',
+    missingFiles
+  )
+}
+if (duplicatePrefixes.length) {
+  failed = true
+  console.error(
+    '[db:check-migrations] Duplicate migration number prefixes:',
+    duplicatePrefixes
+  )
+}
+if (duplicateTags.length) {
+  failed = true
+  console.error('[db:check-migrations] Duplicate journal tags:', duplicateTags)
+}
+
+if (failed) {
+  console.error(
+    '[db:check-migrations] See .cursor/drizzle-migrations-runbook.md'
+  )
+  process.exit(1)
+}
+
+console.log(
+  `[db:check-migrations] ok — ${tags.length} journal entries, ${sqlFiles.length} SQL files`
+)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why
#105 shipped `events.pairing_enabled` in code but the SQL file was never journaled, so deploy never applied it and prod event pages 500’d. #106 fixed the migration; this PR prevents a repeat.

## What
- **Runbook:** [`.cursor/drizzle-migrations-runbook.md`](.cursor/drizzle-migrations-runbook.md) — checklist, symptoms (`column does not exist`), debug steps
- **Cursor rule:** [`.cursor/rules/drizzle-migrations.mdc`](.cursor/rules/drizzle-migrations.mdc) — scoped to schema/drizzle paths
- **CI guard:** `npm run db:check-migrations` (`scripts/check-migrations.mjs`) fails if `drizzle/*.sql` and `_journal.json` diverge or prefixes collide; wired into Tests workflow
- Cross-link from the players/auth DB setup runbook

## Note
Does not change runtime app behavior beyond adding the CI check.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa008255-9654-452d-ad14-edde82d0700d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa008255-9654-452d-ad14-edde82d0700d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

