### PR TITLE
Gate deploys through preview; add event ball and gender

### DIFF
--- a/.cursor/players-and-auth-runbook.md
+++ b/.cursor/players-and-auth-runbook.md
@@ -28,6 +28,16 @@ On production `*.bostondodgeballleague.com` hosts, `admin_session` is set with `
 
 Auth env for the stable preview host is scoped to the **`preview`** Git branch in Vercel.
 
+## Deploy flow
+
+1. Open feature PRs against **`preview`** (not `main`).
+2. Merge to `preview` → Vercel deploys `admin-preview.bostondodgeballleague.com`.
+3. CI **Preview smoke** waits for that deploy and checks `/login`, `/players`, and `/events` respond (auth redirect or 200). You can also run `npm run smoke:preview` locally.
+4. After preview looks good, open **`preview` → `main`**. The **Main merge gate** requires the head branch to be `preview` and re-checks that stable preview is healthy.
+5. Merge to `main` → production at `admin.bostondodgeballleague.com`.
+
+If `preview` has fallen behind `main`, fast-forward or merge `main` into `preview` before landing new work there.
+
 ## Google Cloud OAuth
 
 1. Create or reuse a **Web** OAuth client.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Base branch
+
+- **Feature / fix PRs:** target **`preview`** (not `main`).
+- **Production promote:** open **`preview` → `main`** only after the preview deploy is up and Preview smoke has passed.
+
+## Summary
+
+-
+
+## Test plan
+
+- [ ] Lint / unit / build CI green
+- [ ] If targeting `preview`: confirm [admin-preview](https://admin-preview.bostondodgeballleague.com) deploys and `/players` + `/events` load (sign in)
+- [ ] If targeting `main`: head branch is `preview` and Preview smoke is green

--- a/.github/workflows/main-merge-gate.yml
+++ b/.github/workflows/main-merge-gate.yml
@@ -1,0 +1,36 @@
+name: Main merge gate
+
+# Production merges must come from the preview branch after preview is healthy.
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  from-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require head branch is preview
+        run: |
+          if [ "${{ github.head_ref }}" != "preview" ]; then
+            echo "::error::PRs into main must come from the preview branch (got '${{ github.head_ref }}'). Open feature PRs against preview, verify the preview deploy, then open preview → main."
+            exit 1
+          fi
+          echo "Head branch is preview."
+
+  preview-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Confirm stable preview is healthy
+        env:
+          PREVIEW_BASE_URL: https://admin-preview.bostondodgeballleague.com
+        run: node scripts/smoke-preview.mjs

--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -1,0 +1,28 @@
+name: Preview smoke
+
+# After merges land on preview, wait for the Vercel stable preview deploy
+# and confirm /login, /players, and /events respond (auth redirect or 200).
+on:
+  push:
+    branches: [preview]
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Smoke check stable preview
+        env:
+          PREVIEW_BASE_URL: https://admin-preview.bostondodgeballleague.com
+        run: node scripts/smoke-preview.mjs --wait

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   pull_request:
-    branches: [main]
+    branches: [preview, main]
   push:
-    branches: [main]
+    branches: [preview, main]
 
 jobs:
   test:
@@ -31,4 +31,3 @@ jobs:
 
       - name: Build project
         run: npm run build
-

--- a/app/__tests__/event-ball-gender.test.ts
+++ b/app/__tests__/event-ball-gender.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ballTypeLabel,
+  eventGenderLabel,
+  isValidBallType,
+  isValidEventGender,
+} from '@/app/lib/events/types'
+
+describe('event ball type', () => {
+  it('accepts foam and cloth', () => {
+    expect(isValidBallType('foam')).toBe(true)
+    expect(isValidBallType('cloth')).toBe(true)
+    expect(isValidBallType('rubber')).toBe(false)
+  })
+
+  it('labels known values and defaults unknown to Foam', () => {
+    expect(ballTypeLabel('foam')).toBe('Foam')
+    expect(ballTypeLabel('cloth')).toBe('Cloth')
+    expect(ballTypeLabel('nope')).toBe('Foam')
+  })
+})
+
+describe('event gender', () => {
+  it('accepts mixed, open, and she_they', () => {
+    expect(isValidEventGender('mixed')).toBe(true)
+    expect(isValidEventGender('open')).toBe(true)
+    expect(isValidEventGender('she_they')).toBe(true)
+    expect(isValidEventGender('women')).toBe(false)
+  })
+
+  it('labels known values and defaults unknown to Mixed', () => {
+    expect(eventGenderLabel('mixed')).toBe('Mixed')
+    expect(eventGenderLabel('open')).toBe('Open')
+    expect(eventGenderLabel('she_they')).toBe('She/they')
+    expect(eventGenderLabel('nope')).toBe('Mixed')
+  })
+})

--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -5,7 +5,14 @@ import {
 } from '@/app/lib/admin-auth'
 import { deleteEvent, updateEvent } from '@/app/lib/events/mutations'
 import { getEvent } from '@/app/lib/events/queries'
-import { eventTypeLabel, isValidEventType } from '@/app/lib/events/types'
+import {
+  ballTypeLabel,
+  eventGenderLabel,
+  eventTypeLabel,
+  isValidBallType,
+  isValidEventGender,
+  isValidEventType,
+} from '@/app/lib/events/types'
 
 type RouteContext = { params: Promise<{ id: string }> }
 
@@ -23,6 +30,8 @@ export async function GET(request: NextRequest, context: RouteContext) {
       event: {
         ...event,
         eventTypeLabel: eventTypeLabel(event.eventType),
+        ballTypeLabel: ballTypeLabel(event.ballType),
+        genderLabel: eventGenderLabel(event.gender),
       },
     })
   } catch (err) {
@@ -41,6 +50,8 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       name?: string
       eventDate?: string
       eventType?: string | null
+      ballType?: string | null
+      gender?: string | null
       notes?: string | null
       pairingEnabled?: boolean
     }
@@ -51,6 +62,20 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       !isValidEventType(body.eventType)
     ) {
       return NextResponse.json({ error: 'Invalid eventType' }, { status: 400 })
+    }
+    if (
+      body.ballType != null &&
+      body.ballType !== '' &&
+      !isValidBallType(body.ballType)
+    ) {
+      return NextResponse.json({ error: 'Invalid ballType' }, { status: 400 })
+    }
+    if (
+      body.gender != null &&
+      body.gender !== '' &&
+      !isValidEventGender(body.gender)
+    ) {
+      return NextResponse.json({ error: 'Invalid gender' }, { status: 400 })
     }
 
     if (
@@ -68,6 +93,8 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       event: {
         ...event,
         eventTypeLabel: eventTypeLabel(event.eventType),
+        ballTypeLabel: ballTypeLabel(event.ballType),
+        genderLabel: eventGenderLabel(event.gender),
       },
     })
   } catch (err) {

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -5,7 +5,11 @@ import {
 } from '@/app/lib/admin-auth'
 import { createEvent } from '@/app/lib/events/mutations'
 import { listEvents } from '@/app/lib/events/queries'
-import { isValidEventType } from '@/app/lib/events/types'
+import {
+  isValidBallType,
+  isValidEventGender,
+  isValidEventType,
+} from '@/app/lib/events/types'
 
 export async function GET(request: NextRequest) {
   const session = getAdminSessionFromRequest(request)
@@ -29,6 +33,8 @@ export async function POST(request: NextRequest) {
       name?: string
       eventDate?: string
       eventType?: string | null
+      ballType?: string | null
+      gender?: string | null
       notes?: string | null
     }
 
@@ -45,11 +51,27 @@ export async function POST(request: NextRequest) {
     ) {
       return NextResponse.json({ error: 'Invalid eventType' }, { status: 400 })
     }
+    if (
+      body.ballType != null &&
+      body.ballType !== '' &&
+      !isValidBallType(body.ballType)
+    ) {
+      return NextResponse.json({ error: 'Invalid ballType' }, { status: 400 })
+    }
+    if (
+      body.gender != null &&
+      body.gender !== '' &&
+      !isValidEventGender(body.gender)
+    ) {
+      return NextResponse.json({ error: 'Invalid gender' }, { status: 400 })
+    }
 
     const event = await createEvent({
       name: body.name,
       eventDate: body.eventDate,
       eventType: body.eventType,
+      ballType: body.ballType,
+      gender: body.gender,
       notes: body.notes,
     })
 

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -96,6 +96,10 @@ export const events = pgTable(
     eventDate: date('event_date').notNull(),
     /** Canonical: tournament | open_gym | other */
     eventType: text('event_type').notNull().default('tournament'),
+    /** Canonical: foam | cloth */
+    ballType: text('ball_type').notNull().default('foam'),
+    /** Canonical: mixed | open | she_they */
+    gender: text('gender').notNull().default('mixed'),
     notes: text('notes'),
     /** When false, pair UI/behavior is disabled for the event */
     pairingEnabled: boolean('pairing_enabled').notNull().default(true),

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -37,6 +37,10 @@ type EventDetail = {
   eventDate: string
   eventType: string
   eventTypeLabel: string
+  ballType: string
+  ballTypeLabel: string
+  gender: string
+  genderLabel: string
   notes: string | null
   pairingEnabled: boolean
 }
@@ -782,7 +786,8 @@ function EventTrackerPageContent() {
           </Link>
           <h1 className="text-2xl font-semibold mt-1">{event.name}</h1>
           <p className="text-sm text-gray-600">
-            {formatDisplayDate(event.eventDate)} · {event.eventTypeLabel}
+            {formatDisplayDate(event.eventDate)} · {event.eventTypeLabel} ·{' '}
+            {event.ballTypeLabel} · {event.genderLabel}
           </p>
           {event.notes ? (
             <p className="text-sm text-gray-600 mt-1">{event.notes}</p>

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -4,7 +4,12 @@ import Link from 'next/link'
 import { Suspense, useCallback, useEffect, useState } from 'react'
 import { withDevMode } from '@/app/lib/devMode'
 import { useDevMode } from '@/app/hooks/useDevMode'
-import { EVENT_TYPES, type EventListItem } from '@/app/lib/events/types'
+import {
+  BALL_TYPES,
+  EVENT_GENDERS,
+  EVENT_TYPES,
+  type EventListItem,
+} from '@/app/lib/events/types'
 
 function formatDisplayDate(isoDate: string): string {
   const d = new Date(`${isoDate}T12:00:00`)
@@ -40,6 +45,8 @@ function EventsPageContent() {
   const [name, setName] = useState('')
   const [eventDate, setEventDate] = useState('')
   const [eventType, setEventType] = useState<string>('tournament')
+  const [ballType, setBallType] = useState<string>('foam')
+  const [gender, setGender] = useState<string>('mixed')
   const [notes, setNotes] = useState('')
 
   const loadEvents = useCallback(async () => {
@@ -72,6 +79,8 @@ function EventsPageContent() {
           name,
           eventDate,
           eventType,
+          ballType,
+          gender,
           notes: notes.trim() || null,
         }),
       })
@@ -81,6 +90,8 @@ function EventsPageContent() {
       setName('')
       setEventDate('')
       setEventType('tournament')
+      setBallType('foam')
+      setGender('mixed')
       setNotes('')
       await loadEvents()
     } catch (err) {
@@ -128,6 +139,8 @@ function EventsPageContent() {
                 <th className="px-3 py-2 font-medium">Date</th>
                 <th className="px-3 py-2 font-medium">Name</th>
                 <th className="px-3 py-2 font-medium">Type</th>
+                <th className="px-3 py-2 font-medium">Ball</th>
+                <th className="px-3 py-2 font-medium">Gender</th>
                 <th className="px-3 py-2 font-medium">Registrations</th>
               </tr>
             </thead>
@@ -146,6 +159,8 @@ function EventsPageContent() {
                     </Link>
                   </td>
                   <td className="px-3 py-2">{event.eventTypeLabel}</td>
+                  <td className="px-3 py-2">{event.ballTypeLabel}</td>
+                  <td className="px-3 py-2">{event.genderLabel}</td>
                   <td className="px-3 py-2">{event.registrationCount}</td>
                 </tr>
               ))}
@@ -184,6 +199,34 @@ function EventsPageContent() {
                 onChange={(e) => setEventType(e.target.value)}
               >
                 {Object.entries(EVENT_TYPES).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="block text-sm">
+              <span className="text-gray-600">Ball</span>
+              <select
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+                value={ballType}
+                onChange={(e) => setBallType(e.target.value)}
+              >
+                {Object.entries(BALL_TYPES).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="block text-sm">
+              <span className="text-gray-600">Gender</span>
+              <select
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+                value={gender}
+                onChange={(e) => setGender(e.target.value)}
+              >
+                {Object.entries(EVENT_GENDERS).map(([value, label]) => (
                   <option key={value} value={value}>
                     {label}
                   </option>

--- a/app/lib/events/mutations.ts
+++ b/app/lib/events/mutations.ts
@@ -7,9 +7,13 @@ import {
   events,
 } from '@/app/db/schema'
 import {
+  isValidBallType,
+  isValidEventGender,
   isValidEventType,
   parseDraftGroup,
+  type BallType,
   type EventDraftSnapshotListItem,
+  type EventGender,
   type EventRecord,
   type EventType,
 } from '@/app/lib/events/types'
@@ -34,6 +38,8 @@ export async function createEvent(input: {
   name: string
   eventDate: string
   eventType?: string | null
+  ballType?: string | null
+  gender?: string | null
   notes?: string | null
   pairingEnabled?: boolean
 }): Promise<EventRecord> {
@@ -48,12 +54,24 @@ export async function createEvent(input: {
     eventType = input.eventType
   }
 
+  let ballType: BallType = 'foam'
+  if (input.ballType != null && input.ballType !== '') {
+    if (!isValidBallType(input.ballType)) throw new Error('Invalid ballType')
+    ballType = input.ballType
+  }
+
+  let gender: EventGender = 'mixed'
+  if (input.gender != null && input.gender !== '') {
+    if (!isValidEventGender(input.gender)) throw new Error('Invalid gender')
+    gender = input.gender
+  }
+
   const notes = input.notes?.trim() ? input.notes.trim() : null
   const pairingEnabled = input.pairingEnabled !== false
 
   const [created] = await db
     .insert(events)
-    .values({ name, eventDate, eventType, notes, pairingEnabled })
+    .values({ name, eventDate, eventType, ballType, gender, notes, pairingEnabled })
     .returning()
 
   return created
@@ -65,6 +83,8 @@ export async function updateEvent(
     name?: string
     eventDate?: string
     eventType?: string | null
+    ballType?: string | null
+    gender?: string | null
     notes?: string | null
     pairingEnabled?: boolean
   }
@@ -74,6 +94,8 @@ export async function updateEvent(
     name?: string
     eventDate?: string
     eventType?: string
+    ballType?: string
+    gender?: string
     notes?: string | null
     pairingEnabled?: boolean
     updatedAt: Date
@@ -94,6 +116,24 @@ export async function updateEvent(
       throw new Error('Invalid eventType')
     } else {
       updates.eventType = patch.eventType
+    }
+  }
+  if (patch.ballType !== undefined) {
+    if (patch.ballType == null || patch.ballType === '') {
+      updates.ballType = 'foam'
+    } else if (!isValidBallType(patch.ballType)) {
+      throw new Error('Invalid ballType')
+    } else {
+      updates.ballType = patch.ballType
+    }
+  }
+  if (patch.gender !== undefined) {
+    if (patch.gender == null || patch.gender === '') {
+      updates.gender = 'mixed'
+    } else if (!isValidEventGender(patch.gender)) {
+      throw new Error('Invalid gender')
+    } else {
+      updates.gender = patch.gender
     }
   }
   if (patch.notes !== undefined) {

--- a/app/lib/events/queries.ts
+++ b/app/lib/events/queries.ts
@@ -8,6 +8,8 @@ import {
   players,
 } from '@/app/db/schema'
 import {
+  ballTypeLabel,
+  eventGenderLabel,
   eventTypeLabel,
   type EventListItem,
   type EventRecord,
@@ -31,6 +33,8 @@ export async function listEvents(): Promise<EventListItem[]> {
       name: events.name,
       eventDate: events.eventDate,
       eventType: events.eventType,
+      ballType: events.ballType,
+      gender: events.gender,
       notes: events.notes,
       registrationCount: count(eventRegistrations.id),
     })
@@ -45,6 +49,10 @@ export async function listEvents(): Promise<EventListItem[]> {
     eventDate: r.eventDate,
     eventType: r.eventType,
     eventTypeLabel: eventTypeLabel(r.eventType),
+    ballType: r.ballType,
+    ballTypeLabel: ballTypeLabel(r.ballType),
+    gender: r.gender,
+    genderLabel: eventGenderLabel(r.gender),
     notes: r.notes,
     registrationCount: Number(r.registrationCount),
   }))

--- a/app/lib/events/types.ts
+++ b/app/lib/events/types.ts
@@ -6,6 +6,21 @@ export const EVENT_TYPES = {
 
 export type EventType = keyof typeof EVENT_TYPES
 
+export const BALL_TYPES = {
+  foam: 'Foam',
+  cloth: 'Cloth',
+} as const
+
+export type BallType = keyof typeof BALL_TYPES
+
+export const EVENT_GENDERS = {
+  mixed: 'Mixed',
+  open: 'Open',
+  she_they: 'She/they',
+} as const
+
+export type EventGender = keyof typeof EVENT_GENDERS
+
 export const REGISTRATION_STATUS = {
   registered: 'Registered',
 } as const
@@ -17,6 +32,8 @@ export type EventRecord = {
   name: string
   eventDate: string
   eventType: string
+  ballType: string
+  gender: string
   notes: string | null
   pairingEnabled: boolean
   createdAt: Date
@@ -29,6 +46,10 @@ export type EventListItem = {
   eventDate: string
   eventType: string
   eventTypeLabel: string
+  ballType: string
+  ballTypeLabel: string
+  gender: string
+  genderLabel: string
   notes: string | null
   registrationCount: number
 }
@@ -83,6 +104,24 @@ export function isValidEventType(value: unknown): value is EventType {
 export function eventTypeLabel(type: string | null | undefined): string {
   if (type && isValidEventType(type)) return EVENT_TYPES[type]
   return EVENT_TYPES.other
+}
+
+export function isValidBallType(value: unknown): value is BallType {
+  return value === 'foam' || value === 'cloth'
+}
+
+export function ballTypeLabel(type: string | null | undefined): string {
+  if (type && isValidBallType(type)) return BALL_TYPES[type]
+  return BALL_TYPES.foam
+}
+
+export function isValidEventGender(value: unknown): value is EventGender {
+  return value === 'mixed' || value === 'open' || value === 'she_they'
+}
+
+export function eventGenderLabel(gender: string | null | undefined): string {
+  if (gender && isValidEventGender(gender)) return EVENT_GENDERS[gender]
+  return EVENT_GENDERS.mixed
 }
 
 /** Positive integer draft bucket, or null to clear / unassigned. */

--- a/drizzle/0012_event_ball_type_gender.sql
+++ b/drizzle/0012_event_ball_type_gender.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "events" ADD COLUMN IF NOT EXISTS "ball_type" text DEFAULT 'foam' NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "events" ADD COLUMN IF NOT EXISTS "gender" text DEFAULT 'mixed' NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1753300000000,
       "tag": "0011_event_pairing_enabled",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1753301000000,
+      "tag": "0012_event_ball_type_gender",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "db:migrate": "drizzle-kit migrate",
     "db:migrate:deploy": "node scripts/migrate-on-deploy.mjs",
     "db:push": "drizzle-kit push",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "smoke:preview": "node scripts/smoke-preview.mjs"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/scripts/smoke-preview.mjs
+++ b/scripts/smoke-preview.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * Smoke-check that the stable preview host serves key admin routes.
+ * Auth-gated pages should redirect to /login (not 5xx). /login should be 200.
+ *
+ * Usage:
+ *   PREVIEW_BASE_URL=https://admin-preview.bostondodgeballleague.com node scripts/smoke-preview.mjs
+ *   node scripts/smoke-preview.mjs --wait   # retry until healthy or timeout
+ */
+
+const BASE =
+  process.env.PREVIEW_BASE_URL?.replace(/\/$/, '') ||
+  'https://admin-preview.bostondodgeballleague.com'
+
+const WAIT = process.argv.includes('--wait')
+const MAX_ATTEMPTS = WAIT ? 36 : 1
+const DELAY_MS = 10_000
+
+const PATHS = [
+  { path: '/login', expect: 'ok' },
+  { path: '/players', expect: 'auth_redirect' },
+  { path: '/events', expect: 'auth_redirect' },
+]
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function checkPath({ path, expect }) {
+  const url = `${BASE}${path}`
+  const res = await fetch(url, {
+    method: 'GET',
+    redirect: 'manual',
+    headers: { Accept: 'text/html,application/json' },
+  })
+
+  const status = res.status
+  const location = res.headers.get('location') || ''
+
+  if (expect === 'ok') {
+    if (status !== 200) {
+      throw new Error(`${path}: expected 200, got ${status}`)
+    }
+    return
+  }
+
+  if (expect === 'auth_redirect') {
+    // Middleware redirects unauthenticated HTML routes to /login.
+    if (status !== 307 && status !== 302 && status !== 303) {
+      throw new Error(
+        `${path}: expected auth redirect (302/303/307), got ${status}`
+      )
+    }
+    if (!location.includes('/login')) {
+      throw new Error(
+        `${path}: redirect Location should include /login, got ${location || '(empty)'}`
+      )
+    }
+    return
+  }
+
+  throw new Error(`Unknown expect: ${expect}`)
+}
+
+async function runOnce() {
+  const results = []
+  for (const spec of PATHS) {
+    await checkPath(spec)
+    results.push(`${spec.path} ok`)
+  }
+  return results
+}
+
+async function main() {
+  console.log(`Smoke checking ${BASE}`)
+  let lastError = null
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      const results = await runOnce()
+      for (const line of results) console.log(`  ✓ ${line}`)
+      console.log('Smoke checks passed.')
+      process.exit(0)
+    } catch (err) {
+      lastError = err
+      const msg = err instanceof Error ? err.message : String(err)
+      console.warn(`  attempt ${attempt}/${MAX_ATTEMPTS}: ${msg}`)
+      if (attempt < MAX_ATTEMPTS) await sleep(DELAY_MS)
+    }
+  }
+
+  console.error(`Smoke checks failed: ${lastError?.message || lastError}`)
+  process.exit(1)
+}
+
+main()


### PR DESCRIPTION
## Summary
- Route feature work through **preview** before production: CI on `preview`/`main`, Preview smoke for `/login` `/players` `/events`, and a Main merge gate that only allows `preview` → `main` when stable preview is healthy
- Add event **ball type** (foam default, cloth) and **gender** (mixed default, open, she/they) across schema, API, create form, list, and detail
- Sync note: `preview` was fast-forwarded to current `main` before this PR

## Test plan
- [ ] CI green on this PR (lint / unit / build)
- [ ] After merge to `preview`, confirm Preview smoke passes against [admin-preview](https://admin-preview.bostondodgeballleague.com)
- [ ] Sign in on preview: `/players` and `/events` load; create an event with ball + gender and confirm list/detail show them
- [ ] Promote later with a separate `preview` → `main` PR once preview looks good


Made with [Cursor](https://cursor.com)