### PR TITLE
Add Non-BDL travel events for away tournaments and website drafts

### DIFF
--- a/app/__tests__/non-bdl-events.test.ts
+++ b/app/__tests__/non-bdl-events.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import { buildGoodLuckBlurb } from '@/app/lib/non-bdl-events/good-luck'
+import {
+  hostOrgDisplayLabel,
+  parseHostOrgForCreate,
+  parseHostOrgPatch,
+} from '@/app/lib/non-bdl-events/types'
+
+describe('non-bdl host org', () => {
+  it('accepts known league only', () => {
+    expect(
+      parseHostOrgForCreate({ hostOrgHomeLeague: 'philly_dodgeball' })
+    ).toEqual({
+      hostOrgHomeLeague: 'philly_dodgeball',
+      hostOrgName: null,
+    })
+  })
+
+  it('accepts free text only', () => {
+    expect(parseHostOrgForCreate({ hostOrgName: 'Local Club' })).toEqual({
+      hostOrgHomeLeague: null,
+      hostOrgName: 'Local Club',
+    })
+  })
+
+  it('rejects empty host org', () => {
+    expect(() => parseHostOrgForCreate({})).toThrow(/host org is required/)
+    expect(() =>
+      parseHostOrgForCreate({ hostOrgHomeLeague: '', hostOrgName: '' })
+    ).toThrow(/host org is required/)
+  })
+
+  it('patch cannot clear both host fields', () => {
+    expect(() =>
+      parseHostOrgPatch(
+        { hostOrgHomeLeague: null, hostOrgName: null },
+        {
+          hostOrgHomeLeague: 'philly_dodgeball',
+          hostOrgName: null,
+        }
+      )
+    ).toThrow(/host org is required/)
+  })
+
+  it('formats display label', () => {
+    expect(hostOrgDisplayLabel('philly_dodgeball', null)).toBe(
+      'Philly Dodgeball'
+    )
+    expect(hostOrgDisplayLabel(null, 'Custom Host')).toBe('Custom Host')
+    expect(hostOrgDisplayLabel('philly_dodgeball', 'Foam Fest Host')).toBe(
+      'Foam Fest Host (Philly Dodgeball)'
+    )
+  })
+})
+
+describe('good luck blurb', () => {
+  it('groups players by team', () => {
+    const blurb = buildGoodLuckBlurb({
+      event: {
+        name: 'Philly Foam Classic',
+        eventDate: '2026-08-15',
+        ballType: 'foam',
+        division: 'Open',
+        city: 'Philadelphia',
+        hostOrgHomeLeague: 'philly_dodgeball',
+        hostOrgName: null,
+      },
+      teams: [
+        {
+          id: 't1',
+          eventId: 'e1',
+          name: 'Squish Squad',
+          resultText: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+      attendees: [
+        {
+          id: 'a1',
+          eventId: 'e1',
+          playerId: 'p1',
+          teamId: 't1',
+          teamName: 'Squish Squad',
+          notes: null,
+          firstName: 'Alex',
+          lastName: 'Rivera',
+          rosterName: 'Alex Rivera',
+          nickname: 'Alex R',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 'a2',
+          eventId: 'e1',
+          playerId: 'p2',
+          teamId: null,
+          teamName: null,
+          notes: null,
+          firstName: 'Sam',
+          lastName: 'Lee',
+          rosterName: 'Sam Lee',
+          nickname: 'Sam L',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+    })
+
+    expect(blurb).toContain('Philly Foam Classic')
+    expect(blurb).toContain('Foam ball')
+    expect(blurb).toContain('Open division')
+    expect(blurb).toContain('Squish Squad: Alex R')
+    expect(blurb).toContain('Playing (team TBD): Sam L')
+    expect(blurb).toContain('Go BDL!')
+  })
+})

--- a/app/api/non-bdl-events/[id]/attendees/[attendeeId]/route.ts
+++ b/app/api/non-bdl-events/[id]/attendees/[attendeeId]/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import {
+  deleteNonBdlEventAttendee,
+  updateNonBdlEventAttendee,
+} from '@/app/lib/non-bdl-events/mutations'
+import { listNonBdlEventAttendees } from '@/app/lib/non-bdl-events/queries'
+
+type RouteContext = { params: Promise<{ id: string; attendeeId: string }> }
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id, attendeeId } = await context.params
+    const body = (await request.json()) as {
+      teamId?: string | null
+      notes?: string | null
+    }
+    await updateNonBdlEventAttendee(id, attendeeId, body)
+    const attendees = await listNonBdlEventAttendees(id)
+    const attendee = attendees.find((a) => a.id === attendeeId)
+    return NextResponse.json({ attendee })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to update attendee'
+    const status =
+      message === 'Attendee not found' ||
+      message === 'Team not found for this event'
+        ? 404
+        : 400
+    return NextResponse.json({ error: message }, { status })
+  }
+}
+
+export async function DELETE(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id, attendeeId } = await context.params
+    await deleteNonBdlEventAttendee(id, attendeeId)
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to delete attendee'
+    const status = message === 'Attendee not found' ? 404 : 400
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/non-bdl-events/[id]/attendees/route.ts
+++ b/app/api/non-bdl-events/[id]/attendees/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import { addNonBdlEventAttendee } from '@/app/lib/non-bdl-events/mutations'
+import {
+  getNonBdlEvent,
+  listNonBdlEventAttendees,
+} from '@/app/lib/non-bdl-events/queries'
+
+type RouteContext = { params: Promise<{ id: string }> }
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id } = await context.params
+    const event = await getNonBdlEvent(id)
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    }
+    const attendees = await listNonBdlEventAttendees(id)
+    return NextResponse.json({ attendees })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to list attendees'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id } = await context.params
+    const body = (await request.json()) as {
+      playerId?: string
+      teamId?: string | null
+      notes?: string | null
+    }
+    if (!body.playerId) {
+      return NextResponse.json(
+        { error: 'playerId is required' },
+        { status: 400 }
+      )
+    }
+    const result = await addNonBdlEventAttendee({
+      eventId: id,
+      playerId: body.playerId,
+      teamId: body.teamId,
+      notes: body.notes,
+    })
+    const attendees = await listNonBdlEventAttendees(id)
+    const attendee = attendees.find((a) => a.id === result.id)
+    return NextResponse.json(
+      { attendee, created: result.created },
+      { status: result.created ? 201 : 200 }
+    )
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to add attendee'
+    const status =
+      message === 'Event not found' || message === 'Player not found'
+        ? 404
+        : 400
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/non-bdl-events/[id]/photos/[photoId]/route.ts
+++ b/app/api/non-bdl-events/[id]/photos/[photoId]/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import {
+  deleteNonBdlEventPhoto,
+  updateNonBdlEventPhoto,
+} from '@/app/lib/non-bdl-events/mutations'
+
+type RouteContext = { params: Promise<{ id: string; photoId: string }> }
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id, photoId } = await context.params
+    const body = (await request.json()) as {
+      caption?: string | null
+      sortOrder?: number
+      teamIds?: string[]
+      playerIds?: string[]
+    }
+    const photo = await updateNonBdlEventPhoto(id, photoId, body)
+    return NextResponse.json({ photo })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to update photo'
+    const status = message === 'Photo not found' ? 404 : 400
+    return NextResponse.json({ error: message }, { status })
+  }
+}
+
+export async function DELETE(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id, photoId } = await context.params
+    await deleteNonBdlEventPhoto(id, photoId)
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to delete photo'
+    const status = message === 'Photo not found' ? 404 : 400
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/non-bdl-events/[id]/photos/upload/route.ts
+++ b/app/api/non-bdl-events/[id]/photos/upload/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import { uploadNonBdlEventPhoto } from '@/app/lib/non-bdl-events/mutations'
+
+type RouteContext = { params: Promise<{ id: string }> }
+
+function parseIdList(value: FormDataEntryValue | null): string[] {
+  if (value == null) return []
+  const raw = String(value).trim()
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (Array.isArray(parsed)) {
+      return parsed.filter((v): v is string => typeof v === 'string')
+    }
+  } catch {
+    // comma-separated fallback
+  }
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id } = await context.params
+    const formData = await request.formData()
+    const file = formData.get('file')
+    if (!(file instanceof File)) {
+      return NextResponse.json({ error: 'file is required' }, { status: 400 })
+    }
+    const caption = formData.get('caption')?.toString() ?? null
+    const teamIds = parseIdList(formData.get('teamIds'))
+    const playerIds = parseIdList(formData.get('playerIds'))
+
+    const photo = await uploadNonBdlEventPhoto({
+      eventId: id,
+      file,
+      caption,
+      teamIds,
+      playerIds,
+    })
+    return NextResponse.json({ photo }, { status: 201 })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to upload photo'
+    const status = message === 'Event not found' ? 404 : 400
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/non-bdl-events/[id]/route.ts
+++ b/app/api/non-bdl-events/[id]/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import {
+  deleteNonBdlEvent,
+  updateNonBdlEvent,
+} from '@/app/lib/non-bdl-events/mutations'
+import { getNonBdlEventDetail } from '@/app/lib/non-bdl-events/queries'
+import {
+  ballTypeLabel,
+  hostOrgDisplayLabel,
+  isValidBallType,
+} from '@/app/lib/non-bdl-events/types'
+import { buildGoodLuckFromDetail } from '@/app/lib/non-bdl-events/good-luck'
+import { isValidHomeLeague } from '@/app/lib/players/home-league'
+
+type RouteContext = { params: Promise<{ id: string }> }
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id } = await context.params
+    const detail = await getNonBdlEventDetail(id)
+    if (!detail) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    }
+    return NextResponse.json({
+      ...detail,
+      goodLuckBlurb: buildGoodLuckFromDetail(detail),
+    })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to load non-BDL event'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id } = await context.params
+    const body = (await request.json()) as {
+      name?: string
+      eventDate?: string
+      ballType?: string | null
+      division?: string | null
+      city?: string | null
+      hostOrgHomeLeague?: string | null
+      hostOrgName?: string | null
+      notes?: string | null
+    }
+
+    if (
+      body.ballType != null &&
+      body.ballType !== '' &&
+      !isValidBallType(body.ballType)
+    ) {
+      return NextResponse.json({ error: 'Invalid ballType' }, { status: 400 })
+    }
+    if (
+      body.hostOrgHomeLeague != null &&
+      body.hostOrgHomeLeague !== '' &&
+      !isValidHomeLeague(body.hostOrgHomeLeague)
+    ) {
+      return NextResponse.json(
+        { error: 'Invalid hostOrgHomeLeague' },
+        { status: 400 }
+      )
+    }
+
+    const event = await updateNonBdlEvent(id, body)
+    return NextResponse.json({
+      event: {
+        ...event,
+        ballTypeLabel: ballTypeLabel(event.ballType),
+        hostOrgLabel: hostOrgDisplayLabel(
+          event.hostOrgHomeLeague,
+          event.hostOrgName
+        ),
+      },
+    })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to update non-BDL event'
+    const status = message === 'Event not found' ? 404 : 400
+    return NextResponse.json({ error: message }, { status })
+  }
+}
+
+export async function DELETE(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id } = await context.params
+    await deleteNonBdlEvent(id)
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to delete non-BDL event'
+    const status = message === 'Event not found' ? 404 : 400
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/non-bdl-events/[id]/stories/[storyId]/route.ts
+++ b/app/api/non-bdl-events/[id]/stories/[storyId]/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import {
+  deleteNonBdlEventStory,
+  updateNonBdlEventStory,
+} from '@/app/lib/non-bdl-events/mutations'
+
+type RouteContext = { params: Promise<{ id: string; storyId: string }> }
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id, storyId } = await context.params
+    const body = (await request.json()) as {
+      title?: string | null
+      body?: string
+      sortOrder?: number
+      teamIds?: string[]
+      playerIds?: string[]
+    }
+    const story = await updateNonBdlEventStory(id, storyId, body)
+    return NextResponse.json({ story })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to update story'
+    const status = message === 'Story not found' ? 404 : 400
+    return NextResponse.json({ error: message }, { status })
+  }
+}
+
+export async function DELETE(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id, storyId } = await context.params
+    await deleteNonBdlEventStory(id, storyId)
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to delete story'
+    const status = message === 'Story not found' ? 404 : 400
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/non-bdl-events/[id]/stories/route.ts
+++ b/app/api/non-bdl-events/[id]/stories/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import { createNonBdlEventStory } from '@/app/lib/non-bdl-events/mutations'
+import { getNonBdlEvent } from '@/app/lib/non-bdl-events/queries'
+
+type RouteContext = { params: Promise<{ id: string }> }
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id } = await context.params
+    const event = await getNonBdlEvent(id)
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    }
+    const body = (await request.json()) as {
+      title?: string | null
+      body?: string
+      sortOrder?: number
+      teamIds?: string[]
+      playerIds?: string[]
+    }
+    if (!body.body?.trim()) {
+      return NextResponse.json({ error: 'body is required' }, { status: 400 })
+    }
+    const story = await createNonBdlEventStory({
+      eventId: id,
+      title: body.title,
+      body: body.body,
+      sortOrder: body.sortOrder,
+      teamIds: body.teamIds,
+      playerIds: body.playerIds,
+    })
+    return NextResponse.json({ story }, { status: 201 })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to create story'
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+}

--- a/app/api/non-bdl-events/[id]/teams/[teamId]/route.ts
+++ b/app/api/non-bdl-events/[id]/teams/[teamId]/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import {
+  deleteNonBdlEventTeam,
+  updateNonBdlEventTeam,
+} from '@/app/lib/non-bdl-events/mutations'
+
+type RouteContext = { params: Promise<{ id: string; teamId: string }> }
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id, teamId } = await context.params
+    const body = (await request.json()) as {
+      name?: string
+      resultText?: string | null
+    }
+    const team = await updateNonBdlEventTeam(id, teamId, body)
+    return NextResponse.json({ team })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to update team'
+    const status =
+      message === 'Team not found' || message === 'Team not found for this event'
+        ? 404
+        : 400
+    return NextResponse.json({ error: message }, { status })
+  }
+}
+
+export async function DELETE(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id, teamId } = await context.params
+    await deleteNonBdlEventTeam(id, teamId)
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to delete team'
+    const status =
+      message === 'Team not found' || message === 'Team not found for this event'
+        ? 404
+        : 400
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/non-bdl-events/[id]/teams/route.ts
+++ b/app/api/non-bdl-events/[id]/teams/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import { createNonBdlEventTeam } from '@/app/lib/non-bdl-events/mutations'
+import {
+  getNonBdlEvent,
+  listNonBdlEventTeams,
+} from '@/app/lib/non-bdl-events/queries'
+
+type RouteContext = { params: Promise<{ id: string }> }
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id } = await context.params
+    const event = await getNonBdlEvent(id)
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    }
+    const teams = await listNonBdlEventTeams(id)
+    return NextResponse.json({ teams })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to list teams'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id } = await context.params
+    const body = (await request.json()) as {
+      name?: string
+      resultText?: string | null
+    }
+    if (!body.name?.trim()) {
+      return NextResponse.json({ error: 'name is required' }, { status: 400 })
+    }
+    const team = await createNonBdlEventTeam({
+      eventId: id,
+      name: body.name,
+      resultText: body.resultText,
+    })
+    return NextResponse.json({ team }, { status: 201 })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to create team'
+    const status = message === 'Event not found' ? 404 : 400
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/non-bdl-events/route.ts
+++ b/app/api/non-bdl-events/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import { createNonBdlEvent } from '@/app/lib/non-bdl-events/mutations'
+import { listNonBdlEvents } from '@/app/lib/non-bdl-events/queries'
+import { isValidBallType } from '@/app/lib/non-bdl-events/types'
+import { isValidHomeLeague } from '@/app/lib/players/home-league'
+
+export async function GET(request: NextRequest) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const events = await listNonBdlEvents()
+    return NextResponse.json({ events })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to list non-BDL events'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const body = (await request.json()) as {
+      name?: string
+      eventDate?: string
+      ballType?: string | null
+      division?: string | null
+      city?: string | null
+      hostOrgHomeLeague?: string | null
+      hostOrgName?: string | null
+      notes?: string | null
+    }
+
+    if (!body.name?.trim()) {
+      return NextResponse.json({ error: 'name is required' }, { status: 400 })
+    }
+    if (!body.eventDate?.trim()) {
+      return NextResponse.json(
+        { error: 'eventDate is required' },
+        { status: 400 }
+      )
+    }
+    if (
+      body.ballType != null &&
+      body.ballType !== '' &&
+      !isValidBallType(body.ballType)
+    ) {
+      return NextResponse.json({ error: 'Invalid ballType' }, { status: 400 })
+    }
+    if (
+      body.hostOrgHomeLeague != null &&
+      body.hostOrgHomeLeague !== '' &&
+      !isValidHomeLeague(body.hostOrgHomeLeague)
+    ) {
+      return NextResponse.json(
+        { error: 'Invalid hostOrgHomeLeague' },
+        { status: 400 }
+      )
+    }
+
+    const event = await createNonBdlEvent({
+      name: body.name,
+      eventDate: body.eventDate,
+      ballType: body.ballType,
+      division: body.division,
+      city: body.city,
+      hostOrgHomeLeague: body.hostOrgHomeLeague,
+      hostOrgName: body.hostOrgName,
+      notes: body.notes,
+    })
+
+    return NextResponse.json({ event }, { status: 201 })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to create non-BDL event'
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+}

--- a/app/components/TopNav.tsx
+++ b/app/components/TopNav.tsx
@@ -100,6 +100,9 @@ export default function TopNav() {
         <Link href={withDevMode('/events', devMode)} className="hover:underline">
           Events
         </Link>
+        <Link href={withDevMode('/non-bdl-events', devMode)} className="hover:underline">
+          Non-BDL Events
+        </Link>
         {devMode && (
           <NavDropdown label="Developer">
             <Link

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -188,3 +188,176 @@ export const eventDraftSnapshots = pgTable(
   },
   (table) => [index('event_draft_snapshots_event_id_idx').on(table.eventId)]
 )
+
+/** External / travel events (not BDL-hosted). */
+export const nonBdlEvents = pgTable(
+  'non_bdl_events',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    name: text('name').notNull(),
+    eventDate: date('event_date').notNull(),
+    /** Canonical: foam | cloth */
+    ballType: text('ball_type').notNull().default('foam'),
+    division: text('division'),
+    city: text('city'),
+    /** Optional HOME_LEAGUES code for known host orgs */
+    hostOrgHomeLeague: text('host_org_home_league'),
+    /** Free-text host org (required when no home-league code) */
+    hostOrgName: text('host_org_name'),
+    notes: text('notes'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index('non_bdl_events_event_date_idx').on(table.eventDate)]
+)
+
+export const nonBdlEventTeams = pgTable(
+  'non_bdl_event_teams',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    eventId: uuid('event_id')
+      .notNull()
+      .references(() => nonBdlEvents.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    /** Free-text “how they did” */
+    resultText: text('result_text'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index('non_bdl_event_teams_event_id_idx').on(table.eventId)]
+)
+
+export const nonBdlEventAttendees = pgTable(
+  'non_bdl_event_attendees',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    eventId: uuid('event_id')
+      .notNull()
+      .references(() => nonBdlEvents.id, { onDelete: 'cascade' }),
+    playerId: uuid('player_id')
+      .notNull()
+      .references(() => players.id, { onDelete: 'cascade' }),
+    teamId: uuid('team_id').references(() => nonBdlEventTeams.id, {
+      onDelete: 'set null',
+    }),
+    notes: text('notes'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('non_bdl_event_attendees_event_player_uidx').on(
+      table.eventId,
+      table.playerId
+    ),
+    index('non_bdl_event_attendees_event_id_idx').on(table.eventId),
+    index('non_bdl_event_attendees_player_id_idx').on(table.playerId),
+    index('non_bdl_event_attendees_team_id_idx').on(table.teamId),
+  ]
+)
+
+export const nonBdlEventStories = pgTable(
+  'non_bdl_event_stories',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    eventId: uuid('event_id')
+      .notNull()
+      .references(() => nonBdlEvents.id, { onDelete: 'cascade' }),
+    title: text('title'),
+    body: text('body').notNull(),
+    sortOrder: integer('sort_order').notNull().default(0),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index('non_bdl_event_stories_event_id_idx').on(table.eventId)]
+)
+
+export const nonBdlEventStoryTeamTags = pgTable(
+  'non_bdl_event_story_team_tags',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    storyId: uuid('story_id')
+      .notNull()
+      .references(() => nonBdlEventStories.id, { onDelete: 'cascade' }),
+    teamId: uuid('team_id')
+      .notNull()
+      .references(() => nonBdlEventTeams.id, { onDelete: 'cascade' }),
+  },
+  (table) => [
+    uniqueIndex('non_bdl_event_story_team_tags_uidx').on(table.storyId, table.teamId),
+    index('non_bdl_event_story_team_tags_story_id_idx').on(table.storyId),
+  ]
+)
+
+export const nonBdlEventStoryPlayerTags = pgTable(
+  'non_bdl_event_story_player_tags',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    storyId: uuid('story_id')
+      .notNull()
+      .references(() => nonBdlEventStories.id, { onDelete: 'cascade' }),
+    playerId: uuid('player_id')
+      .notNull()
+      .references(() => players.id, { onDelete: 'cascade' }),
+  },
+  (table) => [
+    uniqueIndex('non_bdl_event_story_player_tags_uidx').on(
+      table.storyId,
+      table.playerId
+    ),
+    index('non_bdl_event_story_player_tags_story_id_idx').on(table.storyId),
+  ]
+)
+
+export const nonBdlEventPhotos = pgTable(
+  'non_bdl_event_photos',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    eventId: uuid('event_id')
+      .notNull()
+      .references(() => nonBdlEvents.id, { onDelete: 'cascade' }),
+    blobUrl: text('blob_url').notNull(),
+    pathname: text('pathname').notNull(),
+    caption: text('caption'),
+    sortOrder: integer('sort_order').notNull().default(0),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index('non_bdl_event_photos_event_id_idx').on(table.eventId)]
+)
+
+export const nonBdlEventPhotoTeamTags = pgTable(
+  'non_bdl_event_photo_team_tags',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    photoId: uuid('photo_id')
+      .notNull()
+      .references(() => nonBdlEventPhotos.id, { onDelete: 'cascade' }),
+    teamId: uuid('team_id')
+      .notNull()
+      .references(() => nonBdlEventTeams.id, { onDelete: 'cascade' }),
+  },
+  (table) => [
+    uniqueIndex('non_bdl_event_photo_team_tags_uidx').on(table.photoId, table.teamId),
+    index('non_bdl_event_photo_team_tags_photo_id_idx').on(table.photoId),
+  ]
+)
+
+export const nonBdlEventPhotoPlayerTags = pgTable(
+  'non_bdl_event_photo_player_tags',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    photoId: uuid('photo_id')
+      .notNull()
+      .references(() => nonBdlEventPhotos.id, { onDelete: 'cascade' }),
+    playerId: uuid('player_id')
+      .notNull()
+      .references(() => players.id, { onDelete: 'cascade' }),
+  },
+  (table) => [
+    uniqueIndex('non_bdl_event_photo_player_tags_uidx').on(
+      table.photoId,
+      table.playerId
+    ),
+    index('non_bdl_event_photo_player_tags_photo_id_idx').on(table.photoId),
+  ]
+)

--- a/app/lib/non-bdl-events/good-luck.ts
+++ b/app/lib/non-bdl-events/good-luck.ts
@@ -1,0 +1,104 @@
+import type {
+  NonBdlEventAttendeeItem,
+  NonBdlEventDetail,
+  NonBdlEventTeamItem,
+} from '@/app/lib/non-bdl-events/types'
+import {
+  ballTypeLabel,
+  hostOrgDisplayLabel,
+} from '@/app/lib/non-bdl-events/types'
+
+function formatDisplayDate(isoDate: string): string {
+  const d = new Date(`${isoDate}T12:00:00`)
+  if (Number.isNaN(d.getTime())) return isoDate
+  return d.toLocaleDateString(undefined, {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+export function buildGoodLuckBlurb(input: {
+  event: {
+    name: string
+    eventDate: string
+    ballType: string
+    division: string | null
+    city: string | null
+    hostOrgHomeLeague: string | null
+    hostOrgName: string | null
+  }
+  teams: NonBdlEventTeamItem[]
+  attendees: NonBdlEventAttendeeItem[]
+}): string {
+  const host = hostOrgDisplayLabel(
+    input.event.hostOrgHomeLeague,
+    input.event.hostOrgName
+  )
+  const date = formatDisplayDate(input.event.eventDate)
+  const ball = ballTypeLabel(input.event.ballType)
+  const placeParts = [
+    input.event.city?.trim() || null,
+    host !== '—' ? host : null,
+  ].filter(Boolean)
+
+  const header = [
+    `Good luck to our BDL players heading to ${input.event.name}!`,
+    `${date}${placeParts.length ? ` · ${placeParts.join(' · ')}` : ''}`,
+    [
+      `${ball} ball`,
+      input.event.division?.trim() ? `${input.event.division.trim()} division` : null,
+    ]
+      .filter(Boolean)
+      .join(' · '),
+  ]
+    .filter(Boolean)
+    .join('\n')
+
+  if (input.attendees.length === 0) {
+    return `${header}\n\n(No players listed yet.)`
+  }
+
+  const byTeam = new Map<string | null, NonBdlEventAttendeeItem[]>()
+  for (const a of input.attendees) {
+    const key = a.teamId
+    const list = byTeam.get(key) ?? []
+    list.push(a)
+    byTeam.set(key, list)
+  }
+
+  const teamNameById = new Map(input.teams.map((t) => [t.id, t.name]))
+  const sections: string[] = []
+
+  const assignedTeamIds = [...byTeam.keys()].filter((id): id is string => id != null)
+  assignedTeamIds.sort((a, b) =>
+    (teamNameById.get(a) ?? '').localeCompare(teamNameById.get(b) ?? '')
+  )
+
+  for (const teamId of assignedTeamIds) {
+    const members = byTeam.get(teamId) ?? []
+    members.sort((a, b) => a.nickname.localeCompare(b.nickname))
+    const teamName = teamNameById.get(teamId) ?? 'Team'
+    const names = members.map((m) => m.nickname).join(', ')
+    sections.push(`${teamName}: ${names}`)
+  }
+
+  const unassigned = byTeam.get(null) ?? []
+  if (unassigned.length > 0) {
+    unassigned.sort((a, b) => a.nickname.localeCompare(b.nickname))
+    sections.push(
+      `Playing (team TBD): ${unassigned.map((m) => m.nickname).join(', ')}`
+    )
+  }
+
+  return `${header}\n\n${sections.join('\n')}\n\nGo BDL!`
+}
+
+export function buildGoodLuckFromDetail(detail: NonBdlEventDetail): string {
+  return buildGoodLuckBlurb({
+    event: detail.event,
+    teams: detail.teams,
+    attendees: detail.attendees,
+  })
+}

--- a/app/lib/non-bdl-events/mutations.ts
+++ b/app/lib/non-bdl-events/mutations.ts
@@ -1,0 +1,830 @@
+import { and, desc, eq } from 'drizzle-orm'
+import { del, put } from '@vercel/blob'
+import { getDb } from '@/app/lib/db'
+import {
+  nonBdlEventAttendees,
+  nonBdlEventPhotoPlayerTags,
+  nonBdlEventPhotos,
+  nonBdlEventPhotoTeamTags,
+  nonBdlEvents,
+  nonBdlEventStories,
+  nonBdlEventStoryPlayerTags,
+  nonBdlEventStoryTeamTags,
+  nonBdlEventTeams,
+  players,
+} from '@/app/db/schema'
+import { parseEventDate } from '@/app/lib/events/mutations'
+import {
+  assertPlayersAttendEvent,
+  assertTeamBelongsToEvent,
+  assertTeamsBelongToEvent,
+  getNonBdlEvent,
+} from '@/app/lib/non-bdl-events/queries'
+import {
+  isValidBallType,
+  parseHostOrgForCreate,
+  parseHostOrgPatch,
+  type BallType,
+  type NonBdlEventPhotoItem,
+  type NonBdlEventRecord,
+  type NonBdlEventStoryItem,
+  type NonBdlEventTeamItem,
+} from '@/app/lib/non-bdl-events/types'
+
+const PHOTO_BLOB_PREFIX = 'non-bdl-event-photos/'
+
+const ALLOWED_BLOB_HOST_SUFFIXES = ['.blob.vercel-storage.com']
+
+function isVercelBlobHost(hostname: string): boolean {
+  return ALLOWED_BLOB_HOST_SUFFIXES.some(
+    (suffix) => hostname === suffix.slice(1) || hostname.endsWith(suffix)
+  )
+}
+
+function normalizeBlobPathname(pathname: string): string {
+  return pathname.startsWith('/') ? pathname.slice(1) : pathname
+}
+
+function isUnderPhotoPrefix(pathname: string): boolean {
+  return normalizeBlobPathname(pathname).startsWith(PHOTO_BLOB_PREFIX)
+}
+
+function isImageFile(file: File): boolean {
+  const name = file.name.toLowerCase()
+  const type = file.type.toLowerCase()
+  return (
+    type.startsWith('image/') ||
+    name.endsWith('.jpg') ||
+    name.endsWith('.jpeg') ||
+    name.endsWith('.png') ||
+    name.endsWith('.webp') ||
+    name.endsWith('.gif')
+  )
+}
+
+function imageContentType(file: File): string {
+  if (file.type && file.type.startsWith('image/')) return file.type
+  const name = file.name.toLowerCase()
+  if (name.endsWith('.png')) return 'image/png'
+  if (name.endsWith('.webp')) return 'image/webp'
+  if (name.endsWith('.gif')) return 'image/gif'
+  return 'image/jpeg'
+}
+
+function extensionForFile(file: File): string {
+  const name = file.name.toLowerCase()
+  const match = name.match(/\.(jpe?g|png|webp|gif)$/)
+  if (match) return match[1] === 'jpeg' ? 'jpg' : match[1]
+  const type = file.type.toLowerCase()
+  if (type.includes('png')) return 'png'
+  if (type.includes('webp')) return 'webp'
+  if (type.includes('gif')) return 'gif'
+  return 'jpg'
+}
+
+export async function createNonBdlEvent(input: {
+  name: string
+  eventDate: string
+  ballType?: string | null
+  division?: string | null
+  city?: string | null
+  hostOrgHomeLeague?: string | null
+  hostOrgName?: string | null
+  notes?: string | null
+}): Promise<NonBdlEventRecord> {
+  const db = getDb()
+  const name = input.name.trim()
+  if (!name) throw new Error('name is required')
+
+  const eventDate = parseEventDate(input.eventDate)
+  let ballType: BallType = 'foam'
+  if (input.ballType != null && input.ballType !== '') {
+    if (!isValidBallType(input.ballType)) throw new Error('Invalid ballType')
+    ballType = input.ballType
+  }
+
+  const { hostOrgHomeLeague, hostOrgName } = parseHostOrgForCreate({
+    hostOrgHomeLeague: input.hostOrgHomeLeague,
+    hostOrgName: input.hostOrgName,
+  })
+
+  const division = input.division?.trim() ? input.division.trim() : null
+  const city = input.city?.trim() ? input.city.trim() : null
+  const notes = input.notes?.trim() ? input.notes.trim() : null
+
+  const [created] = await db
+    .insert(nonBdlEvents)
+    .values({
+      name,
+      eventDate,
+      ballType,
+      division,
+      city,
+      hostOrgHomeLeague,
+      hostOrgName,
+      notes,
+    })
+    .returning()
+
+  return created
+}
+
+export async function updateNonBdlEvent(
+  id: string,
+  patch: {
+    name?: string
+    eventDate?: string
+    ballType?: string | null
+    division?: string | null
+    city?: string | null
+    hostOrgHomeLeague?: string | null
+    hostOrgName?: string | null
+    notes?: string | null
+  }
+): Promise<NonBdlEventRecord> {
+  const db = getDb()
+  const existing = await getNonBdlEvent(id)
+  if (!existing) throw new Error('Event not found')
+
+  const updates: {
+    name?: string
+    eventDate?: string
+    ballType?: string
+    division?: string | null
+    city?: string | null
+    hostOrgHomeLeague?: string | null
+    hostOrgName?: string | null
+    notes?: string | null
+    updatedAt: Date
+  } = { updatedAt: new Date() }
+
+  if (patch.name !== undefined) {
+    const name = patch.name.trim()
+    if (!name) throw new Error('name is required')
+    updates.name = name
+  }
+  if (patch.eventDate !== undefined) {
+    updates.eventDate = parseEventDate(patch.eventDate)
+  }
+  if (patch.ballType !== undefined) {
+    if (patch.ballType == null || patch.ballType === '') {
+      updates.ballType = 'foam'
+    } else if (!isValidBallType(patch.ballType)) {
+      throw new Error('Invalid ballType')
+    } else {
+      updates.ballType = patch.ballType
+    }
+  }
+  if (patch.division !== undefined) {
+    updates.division =
+      patch.division == null || patch.division.trim() === ''
+        ? null
+        : patch.division.trim()
+  }
+  if (patch.city !== undefined) {
+    updates.city =
+      patch.city == null || patch.city.trim() === '' ? null : patch.city.trim()
+  }
+  if (patch.notes !== undefined) {
+    updates.notes =
+      patch.notes == null || patch.notes.trim() === '' ? null : patch.notes.trim()
+  }
+
+  const hostPatch = parseHostOrgPatch(patch, {
+    hostOrgHomeLeague: existing.hostOrgHomeLeague,
+    hostOrgName: existing.hostOrgName,
+  })
+  if (hostPatch) {
+    updates.hostOrgHomeLeague = hostPatch.hostOrgHomeLeague
+    updates.hostOrgName = hostPatch.hostOrgName
+  }
+
+  const [updated] = await db
+    .update(nonBdlEvents)
+    .set(updates)
+    .where(eq(nonBdlEvents.id, id))
+    .returning()
+
+  if (!updated) throw new Error('Event not found')
+  return updated
+}
+
+export async function deleteNonBdlEvent(id: string): Promise<void> {
+  const db = getDb()
+  const photoRows = await db
+    .select({ pathname: nonBdlEventPhotos.pathname, blobUrl: nonBdlEventPhotos.blobUrl })
+    .from(nonBdlEventPhotos)
+    .where(eq(nonBdlEventPhotos.eventId, id))
+
+  const [deleted] = await db
+    .delete(nonBdlEvents)
+    .where(eq(nonBdlEvents.id, id))
+    .returning({ id: nonBdlEvents.id })
+  if (!deleted) throw new Error('Event not found')
+
+  for (const photo of photoRows) {
+    try {
+      if (isUnderPhotoPrefix(photo.pathname)) {
+        await del(photo.pathname)
+      } else if (photo.blobUrl) {
+        const parsed = new URL(photo.blobUrl)
+        if (isVercelBlobHost(parsed.hostname)) {
+          await del(photo.blobUrl)
+        }
+      }
+    } catch {
+      // Best-effort blob cleanup
+    }
+  }
+}
+
+export async function createNonBdlEventTeam(input: {
+  eventId: string
+  name: string
+  resultText?: string | null
+}): Promise<NonBdlEventTeamItem> {
+  const db = getDb()
+  const event = await getNonBdlEvent(input.eventId)
+  if (!event) throw new Error('Event not found')
+
+  const name = input.name.trim()
+  if (!name) throw new Error('name is required')
+  const resultText =
+    input.resultText == null || input.resultText.trim() === ''
+      ? null
+      : input.resultText.trim()
+
+  const [created] = await db
+    .insert(nonBdlEventTeams)
+    .values({ eventId: input.eventId, name, resultText })
+    .returning()
+  return created
+}
+
+export async function updateNonBdlEventTeam(
+  eventId: string,
+  teamId: string,
+  patch: { name?: string; resultText?: string | null }
+): Promise<NonBdlEventTeamItem> {
+  await assertTeamBelongsToEvent(eventId, teamId)
+  const db = getDb()
+  const updates: {
+    name?: string
+    resultText?: string | null
+    updatedAt: Date
+  } = { updatedAt: new Date() }
+
+  if (patch.name !== undefined) {
+    const name = patch.name.trim()
+    if (!name) throw new Error('name is required')
+    updates.name = name
+  }
+  if (patch.resultText !== undefined) {
+    updates.resultText =
+      patch.resultText == null || patch.resultText.trim() === ''
+        ? null
+        : patch.resultText.trim()
+  }
+
+  const [updated] = await db
+    .update(nonBdlEventTeams)
+    .set(updates)
+    .where(
+      and(eq(nonBdlEventTeams.id, teamId), eq(nonBdlEventTeams.eventId, eventId))
+    )
+    .returning()
+  if (!updated) throw new Error('Team not found')
+  return updated
+}
+
+export async function deleteNonBdlEventTeam(
+  eventId: string,
+  teamId: string
+): Promise<void> {
+  await assertTeamBelongsToEvent(eventId, teamId)
+  const db = getDb()
+  await db
+    .delete(nonBdlEventTeams)
+    .where(
+      and(eq(nonBdlEventTeams.id, teamId), eq(nonBdlEventTeams.eventId, eventId))
+    )
+}
+
+export async function addNonBdlEventAttendee(input: {
+  eventId: string
+  playerId: string
+  teamId?: string | null
+  notes?: string | null
+}): Promise<{ id: string; created: boolean }> {
+  const db = getDb()
+  const event = await getNonBdlEvent(input.eventId)
+  if (!event) throw new Error('Event not found')
+
+  const [player] = await db
+    .select({ id: players.id, isMerged: players.isMerged })
+    .from(players)
+    .where(eq(players.id, input.playerId))
+    .limit(1)
+  if (!player) throw new Error('Player not found')
+  if (player.isMerged) throw new Error('Cannot add a merged player')
+
+  if (input.teamId) {
+    await assertTeamBelongsToEvent(input.eventId, input.teamId)
+  }
+
+  const notes =
+    input.notes == null || input.notes.trim() === '' ? null : input.notes.trim()
+
+  const [existing] = await db
+    .select({ id: nonBdlEventAttendees.id })
+    .from(nonBdlEventAttendees)
+    .where(
+      and(
+        eq(nonBdlEventAttendees.eventId, input.eventId),
+        eq(nonBdlEventAttendees.playerId, input.playerId)
+      )
+    )
+    .limit(1)
+
+  if (existing) {
+    const updates: {
+      teamId?: string | null
+      notes?: string | null
+      updatedAt: Date
+    } = { updatedAt: new Date() }
+    if (input.teamId !== undefined) {
+      updates.teamId = input.teamId || null
+    }
+    if (input.notes !== undefined) {
+      updates.notes = notes
+    }
+    await db
+      .update(nonBdlEventAttendees)
+      .set(updates)
+      .where(eq(nonBdlEventAttendees.id, existing.id))
+    return { id: existing.id, created: false }
+  }
+
+  const [created] = await db
+    .insert(nonBdlEventAttendees)
+    .values({
+      eventId: input.eventId,
+      playerId: input.playerId,
+      teamId: input.teamId || null,
+      notes,
+    })
+    .returning({ id: nonBdlEventAttendees.id })
+
+  return { id: created.id, created: true }
+}
+
+export async function updateNonBdlEventAttendee(
+  eventId: string,
+  attendeeId: string,
+  patch: { teamId?: string | null; notes?: string | null }
+): Promise<void> {
+  const db = getDb()
+  const [existing] = await db
+    .select()
+    .from(nonBdlEventAttendees)
+    .where(
+      and(
+        eq(nonBdlEventAttendees.id, attendeeId),
+        eq(nonBdlEventAttendees.eventId, eventId)
+      )
+    )
+    .limit(1)
+  if (!existing) throw new Error('Attendee not found')
+
+  const updates: {
+    teamId?: string | null
+    notes?: string | null
+    updatedAt: Date
+  } = { updatedAt: new Date() }
+
+  if (patch.teamId !== undefined) {
+    if (patch.teamId) {
+      await assertTeamBelongsToEvent(eventId, patch.teamId)
+      updates.teamId = patch.teamId
+    } else {
+      updates.teamId = null
+    }
+  }
+  if (patch.notes !== undefined) {
+    updates.notes =
+      patch.notes == null || patch.notes.trim() === ''
+        ? null
+        : patch.notes.trim()
+  }
+
+  await db
+    .update(nonBdlEventAttendees)
+    .set(updates)
+    .where(eq(nonBdlEventAttendees.id, attendeeId))
+}
+
+export async function deleteNonBdlEventAttendee(
+  eventId: string,
+  attendeeId: string
+): Promise<void> {
+  const db = getDb()
+  const [deleted] = await db
+    .delete(nonBdlEventAttendees)
+    .where(
+      and(
+        eq(nonBdlEventAttendees.id, attendeeId),
+        eq(nonBdlEventAttendees.eventId, eventId)
+      )
+    )
+    .returning({ id: nonBdlEventAttendees.id })
+  if (!deleted) throw new Error('Attendee not found')
+}
+
+async function replaceStoryTags(
+  storyId: string,
+  eventId: string,
+  teamIds: string[],
+  playerIds: string[]
+): Promise<void> {
+  await assertTeamsBelongToEvent(eventId, teamIds)
+  await assertPlayersAttendEvent(eventId, playerIds)
+
+  const db = getDb()
+  await db
+    .delete(nonBdlEventStoryTeamTags)
+    .where(eq(nonBdlEventStoryTeamTags.storyId, storyId))
+  await db
+    .delete(nonBdlEventStoryPlayerTags)
+    .where(eq(nonBdlEventStoryPlayerTags.storyId, storyId))
+
+  const uniqueTeams = [...new Set(teamIds)]
+  const uniquePlayers = [...new Set(playerIds)]
+  if (uniqueTeams.length > 0) {
+    await db.insert(nonBdlEventStoryTeamTags).values(
+      uniqueTeams.map((teamId) => ({ storyId, teamId }))
+    )
+  }
+  if (uniquePlayers.length > 0) {
+    await db.insert(nonBdlEventStoryPlayerTags).values(
+      uniquePlayers.map((playerId) => ({ storyId, playerId }))
+    )
+  }
+}
+
+async function replacePhotoTags(
+  photoId: string,
+  eventId: string,
+  teamIds: string[],
+  playerIds: string[]
+): Promise<void> {
+  await assertTeamsBelongToEvent(eventId, teamIds)
+  await assertPlayersAttendEvent(eventId, playerIds)
+
+  const db = getDb()
+  await db
+    .delete(nonBdlEventPhotoTeamTags)
+    .where(eq(nonBdlEventPhotoTeamTags.photoId, photoId))
+  await db
+    .delete(nonBdlEventPhotoPlayerTags)
+    .where(eq(nonBdlEventPhotoPlayerTags.photoId, photoId))
+
+  const uniqueTeams = [...new Set(teamIds)]
+  const uniquePlayers = [...new Set(playerIds)]
+  if (uniqueTeams.length > 0) {
+    await db.insert(nonBdlEventPhotoTeamTags).values(
+      uniqueTeams.map((teamId) => ({ photoId, teamId }))
+    )
+  }
+  if (uniquePlayers.length > 0) {
+    await db.insert(nonBdlEventPhotoPlayerTags).values(
+      uniquePlayers.map((playerId) => ({ photoId, playerId }))
+    )
+  }
+}
+
+export async function createNonBdlEventStory(input: {
+  eventId: string
+  title?: string | null
+  body: string
+  sortOrder?: number
+  teamIds?: string[]
+  playerIds?: string[]
+}): Promise<NonBdlEventStoryItem> {
+  const db = getDb()
+  const event = await getNonBdlEvent(input.eventId)
+  if (!event) throw new Error('Event not found')
+
+  const body = input.body.trim()
+  if (!body) throw new Error('body is required')
+  const title =
+    input.title == null || input.title.trim() === '' ? null : input.title.trim()
+  const sortOrder =
+    typeof input.sortOrder === 'number' && Number.isFinite(input.sortOrder)
+      ? Math.trunc(input.sortOrder)
+      : 0
+  const teamIds = input.teamIds ?? []
+  const playerIds = input.playerIds ?? []
+
+  await assertTeamsBelongToEvent(input.eventId, teamIds)
+  await assertPlayersAttendEvent(input.eventId, playerIds)
+
+  const [created] = await db
+    .insert(nonBdlEventStories)
+    .values({
+      eventId: input.eventId,
+      title,
+      body,
+      sortOrder,
+    })
+    .returning()
+
+  await replaceStoryTags(created.id, input.eventId, teamIds, playerIds)
+
+  return {
+    ...created,
+    teamIds: [...new Set(teamIds)],
+    playerIds: [...new Set(playerIds)],
+  }
+}
+
+export async function updateNonBdlEventStory(
+  eventId: string,
+  storyId: string,
+  patch: {
+    title?: string | null
+    body?: string
+    sortOrder?: number
+    teamIds?: string[]
+    playerIds?: string[]
+  }
+): Promise<NonBdlEventStoryItem> {
+  const db = getDb()
+  const [existing] = await db
+    .select()
+    .from(nonBdlEventStories)
+    .where(
+      and(
+        eq(nonBdlEventStories.id, storyId),
+        eq(nonBdlEventStories.eventId, eventId)
+      )
+    )
+    .limit(1)
+  if (!existing) throw new Error('Story not found')
+
+  const updates: {
+    title?: string | null
+    body?: string
+    sortOrder?: number
+    updatedAt: Date
+  } = { updatedAt: new Date() }
+
+  if (patch.title !== undefined) {
+    updates.title =
+      patch.title == null || patch.title.trim() === ''
+        ? null
+        : patch.title.trim()
+  }
+  if (patch.body !== undefined) {
+    const body = patch.body.trim()
+    if (!body) throw new Error('body is required')
+    updates.body = body
+  }
+  if (patch.sortOrder !== undefined) {
+    if (!Number.isFinite(patch.sortOrder)) throw new Error('Invalid sortOrder')
+    updates.sortOrder = Math.trunc(patch.sortOrder)
+  }
+
+  const [updated] = await db
+    .update(nonBdlEventStories)
+    .set(updates)
+    .where(eq(nonBdlEventStories.id, storyId))
+    .returning()
+
+  let teamIds: string[]
+  let playerIds: string[]
+
+  if (patch.teamIds !== undefined || patch.playerIds !== undefined) {
+    const currentTeamTags = await db
+      .select({ teamId: nonBdlEventStoryTeamTags.teamId })
+      .from(nonBdlEventStoryTeamTags)
+      .where(eq(nonBdlEventStoryTeamTags.storyId, storyId))
+    const currentPlayerTags = await db
+      .select({ playerId: nonBdlEventStoryPlayerTags.playerId })
+      .from(nonBdlEventStoryPlayerTags)
+      .where(eq(nonBdlEventStoryPlayerTags.storyId, storyId))
+
+    teamIds = patch.teamIds ?? currentTeamTags.map((t) => t.teamId)
+    playerIds = patch.playerIds ?? currentPlayerTags.map((t) => t.playerId)
+    await replaceStoryTags(storyId, eventId, teamIds, playerIds)
+  } else {
+    const currentTeamTags = await db
+      .select({ teamId: nonBdlEventStoryTeamTags.teamId })
+      .from(nonBdlEventStoryTeamTags)
+      .where(eq(nonBdlEventStoryTeamTags.storyId, storyId))
+    const currentPlayerTags = await db
+      .select({ playerId: nonBdlEventStoryPlayerTags.playerId })
+      .from(nonBdlEventStoryPlayerTags)
+      .where(eq(nonBdlEventStoryPlayerTags.storyId, storyId))
+    teamIds = currentTeamTags.map((t) => t.teamId)
+    playerIds = currentPlayerTags.map((t) => t.playerId)
+  }
+
+  return {
+    ...updated,
+    teamIds,
+    playerIds,
+  }
+}
+
+export async function deleteNonBdlEventStory(
+  eventId: string,
+  storyId: string
+): Promise<void> {
+  const db = getDb()
+  const [deleted] = await db
+    .delete(nonBdlEventStories)
+    .where(
+      and(
+        eq(nonBdlEventStories.id, storyId),
+        eq(nonBdlEventStories.eventId, eventId)
+      )
+    )
+    .returning({ id: nonBdlEventStories.id })
+  if (!deleted) throw new Error('Story not found')
+}
+
+export async function uploadNonBdlEventPhoto(input: {
+  eventId: string
+  file: File
+  caption?: string | null
+  teamIds?: string[]
+  playerIds?: string[]
+}): Promise<NonBdlEventPhotoItem> {
+  const event = await getNonBdlEvent(input.eventId)
+  if (!event) throw new Error('Event not found')
+  if (!isImageFile(input.file)) {
+    throw new Error('Only image files are supported (jpg, png, webp, gif)')
+  }
+
+  const teamIds = input.teamIds ?? []
+  const playerIds = input.playerIds ?? []
+  await assertTeamsBelongToEvent(input.eventId, teamIds)
+  await assertPlayersAttendEvent(input.eventId, playerIds)
+
+  const ext = extensionForFile(input.file)
+  const pathname = `${PHOTO_BLOB_PREFIX}${input.eventId}/${crypto.randomUUID()}.${ext}`
+  const blob = await put(pathname, input.file, {
+    access: 'public',
+    addRandomSuffix: false,
+    contentType: imageContentType(input.file),
+  })
+
+  const caption =
+    input.caption == null || input.caption.trim() === ''
+      ? null
+      : input.caption.trim()
+
+  const db = getDb()
+  const existing = await db
+    .select({ sortOrder: nonBdlEventPhotos.sortOrder })
+    .from(nonBdlEventPhotos)
+    .where(eq(nonBdlEventPhotos.eventId, input.eventId))
+    .orderBy(desc(nonBdlEventPhotos.sortOrder))
+    .limit(1)
+  const sortOrder = (existing[0]?.sortOrder ?? -1) + 1
+
+  const [created] = await db
+    .insert(nonBdlEventPhotos)
+    .values({
+      eventId: input.eventId,
+      blobUrl: blob.url,
+      pathname: blob.pathname,
+      caption,
+      sortOrder,
+    })
+    .returning()
+
+  await replacePhotoTags(created.id, input.eventId, teamIds, playerIds)
+
+  return {
+    ...created,
+    teamIds: [...new Set(teamIds)],
+    playerIds: [...new Set(playerIds)],
+  }
+}
+
+export async function updateNonBdlEventPhoto(
+  eventId: string,
+  photoId: string,
+  patch: {
+    caption?: string | null
+    sortOrder?: number
+    teamIds?: string[]
+    playerIds?: string[]
+  }
+): Promise<NonBdlEventPhotoItem> {
+  const db = getDb()
+  const [existing] = await db
+    .select()
+    .from(nonBdlEventPhotos)
+    .where(
+      and(
+        eq(nonBdlEventPhotos.id, photoId),
+        eq(nonBdlEventPhotos.eventId, eventId)
+      )
+    )
+    .limit(1)
+  if (!existing) throw new Error('Photo not found')
+
+  const updates: {
+    caption?: string | null
+    sortOrder?: number
+    updatedAt: Date
+  } = { updatedAt: new Date() }
+
+  if (patch.caption !== undefined) {
+    updates.caption =
+      patch.caption == null || patch.caption.trim() === ''
+        ? null
+        : patch.caption.trim()
+  }
+  if (patch.sortOrder !== undefined) {
+    if (!Number.isFinite(patch.sortOrder)) throw new Error('Invalid sortOrder')
+    updates.sortOrder = Math.trunc(patch.sortOrder)
+  }
+
+  const [updated] = await db
+    .update(nonBdlEventPhotos)
+    .set(updates)
+    .where(eq(nonBdlEventPhotos.id, photoId))
+    .returning()
+
+  let teamIds: string[]
+  let playerIds: string[]
+
+  if (patch.teamIds !== undefined || patch.playerIds !== undefined) {
+    const currentTeamTags = await db
+      .select({ teamId: nonBdlEventPhotoTeamTags.teamId })
+      .from(nonBdlEventPhotoTeamTags)
+      .where(eq(nonBdlEventPhotoTeamTags.photoId, photoId))
+    const currentPlayerTags = await db
+      .select({ playerId: nonBdlEventPhotoPlayerTags.playerId })
+      .from(nonBdlEventPhotoPlayerTags)
+      .where(eq(nonBdlEventPhotoPlayerTags.photoId, photoId))
+
+    teamIds = patch.teamIds ?? currentTeamTags.map((t) => t.teamId)
+    playerIds = patch.playerIds ?? currentPlayerTags.map((t) => t.playerId)
+    await replacePhotoTags(photoId, eventId, teamIds, playerIds)
+  } else {
+    const currentTeamTags = await db
+      .select({ teamId: nonBdlEventPhotoTeamTags.teamId })
+      .from(nonBdlEventPhotoTeamTags)
+      .where(eq(nonBdlEventPhotoTeamTags.photoId, photoId))
+    const currentPlayerTags = await db
+      .select({ playerId: nonBdlEventPhotoPlayerTags.playerId })
+      .from(nonBdlEventPhotoPlayerTags)
+      .where(eq(nonBdlEventPhotoPlayerTags.photoId, photoId))
+    teamIds = currentTeamTags.map((t) => t.teamId)
+    playerIds = currentPlayerTags.map((t) => t.playerId)
+  }
+
+  return {
+    ...updated,
+    teamIds,
+    playerIds,
+  }
+}
+
+export async function deleteNonBdlEventPhoto(
+  eventId: string,
+  photoId: string
+): Promise<void> {
+  const db = getDb()
+  const [existing] = await db
+    .select()
+    .from(nonBdlEventPhotos)
+    .where(
+      and(
+        eq(nonBdlEventPhotos.id, photoId),
+        eq(nonBdlEventPhotos.eventId, eventId)
+      )
+    )
+    .limit(1)
+  if (!existing) throw new Error('Photo not found')
+
+  await db
+    .delete(nonBdlEventPhotos)
+    .where(eq(nonBdlEventPhotos.id, photoId))
+
+  try {
+    if (isUnderPhotoPrefix(existing.pathname)) {
+      await del(existing.pathname)
+    } else if (isVercelBlobHost(new URL(existing.blobUrl).hostname)) {
+      await del(existing.blobUrl)
+    }
+  } catch {
+    // Best-effort blob cleanup
+  }
+}
+
+export { PHOTO_BLOB_PREFIX }

--- a/app/lib/non-bdl-events/queries.ts
+++ b/app/lib/non-bdl-events/queries.ts
@@ -1,0 +1,328 @@
+import { and, asc, count, desc, eq, inArray, sql } from 'drizzle-orm'
+import { getDb } from '@/app/lib/db'
+import {
+  nonBdlEventAttendees,
+  nonBdlEventPhotoPlayerTags,
+  nonBdlEventPhotos,
+  nonBdlEventPhotoTeamTags,
+  nonBdlEvents,
+  nonBdlEventStories,
+  nonBdlEventStoryPlayerTags,
+  nonBdlEventStoryTeamTags,
+  nonBdlEventTeams,
+  players,
+} from '@/app/db/schema'
+import { resolveNickname } from '@/app/lib/players/skill'
+import {
+  ballTypeLabel,
+  hostOrgDisplayLabel,
+  type NonBdlEventAttendeeItem,
+  type NonBdlEventDetail,
+  type NonBdlEventListItem,
+  type NonBdlEventPhotoItem,
+  type NonBdlEventRecord,
+  type NonBdlEventStoryItem,
+  type NonBdlEventTeamItem,
+} from '@/app/lib/non-bdl-events/types'
+
+export async function listNonBdlEvents(): Promise<NonBdlEventListItem[]> {
+  const db = getDb()
+  const rows = await db
+    .select({
+      id: nonBdlEvents.id,
+      name: nonBdlEvents.name,
+      eventDate: nonBdlEvents.eventDate,
+      ballType: nonBdlEvents.ballType,
+      division: nonBdlEvents.division,
+      city: nonBdlEvents.city,
+      hostOrgHomeLeague: nonBdlEvents.hostOrgHomeLeague,
+      hostOrgName: nonBdlEvents.hostOrgName,
+      attendeeCount: count(nonBdlEventAttendees.id),
+    })
+    .from(nonBdlEvents)
+    .leftJoin(
+      nonBdlEventAttendees,
+      eq(nonBdlEventAttendees.eventId, nonBdlEvents.id)
+    )
+    .groupBy(
+      nonBdlEvents.id,
+      nonBdlEvents.name,
+      nonBdlEvents.eventDate,
+      nonBdlEvents.ballType,
+      nonBdlEvents.division,
+      nonBdlEvents.city,
+      nonBdlEvents.hostOrgHomeLeague,
+      nonBdlEvents.hostOrgName
+    )
+    .orderBy(desc(nonBdlEvents.eventDate), asc(nonBdlEvents.name))
+
+  return rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    eventDate: row.eventDate,
+    ballType: row.ballType,
+    ballTypeLabel: ballTypeLabel(row.ballType),
+    division: row.division,
+    city: row.city,
+    hostOrgLabel: hostOrgDisplayLabel(row.hostOrgHomeLeague, row.hostOrgName),
+    attendeeCount: Number(row.attendeeCount),
+  }))
+}
+
+export async function getNonBdlEvent(
+  id: string
+): Promise<NonBdlEventRecord | null> {
+  const db = getDb()
+  const [row] = await db
+    .select()
+    .from(nonBdlEvents)
+    .where(eq(nonBdlEvents.id, id))
+    .limit(1)
+  return row ?? null
+}
+
+export async function listNonBdlEventTeams(
+  eventId: string
+): Promise<NonBdlEventTeamItem[]> {
+  const db = getDb()
+  return db
+    .select()
+    .from(nonBdlEventTeams)
+    .where(eq(nonBdlEventTeams.eventId, eventId))
+    .orderBy(asc(nonBdlEventTeams.name))
+}
+
+export async function listNonBdlEventAttendees(
+  eventId: string
+): Promise<NonBdlEventAttendeeItem[]> {
+  const db = getDb()
+  const rows = await db
+    .select({
+      id: nonBdlEventAttendees.id,
+      eventId: nonBdlEventAttendees.eventId,
+      playerId: nonBdlEventAttendees.playerId,
+      teamId: nonBdlEventAttendees.teamId,
+      notes: nonBdlEventAttendees.notes,
+      createdAt: nonBdlEventAttendees.createdAt,
+      updatedAt: nonBdlEventAttendees.updatedAt,
+      firstName: players.firstName,
+      lastName: players.lastName,
+      rosterName: players.rosterName,
+      nickname: players.nickname,
+      teamName: nonBdlEventTeams.name,
+    })
+    .from(nonBdlEventAttendees)
+    .innerJoin(players, eq(players.id, nonBdlEventAttendees.playerId))
+    .leftJoin(nonBdlEventTeams, eq(nonBdlEventTeams.id, nonBdlEventAttendees.teamId))
+    .where(eq(nonBdlEventAttendees.eventId, eventId))
+    .orderBy(
+      sql`CASE WHEN ${nonBdlEventTeams.name} IS NULL THEN 1 ELSE 0 END`,
+      asc(nonBdlEventTeams.name),
+      asc(players.lastName),
+      asc(players.firstName)
+    )
+
+  return rows.map((row) => ({
+    id: row.id,
+    eventId: row.eventId,
+    playerId: row.playerId,
+    teamId: row.teamId,
+    teamName: row.teamName,
+    notes: row.notes,
+    firstName: row.firstName,
+    lastName: row.lastName,
+    rosterName: row.rosterName,
+    nickname: resolveNickname(row.nickname, row.firstName, row.lastName),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  }))
+}
+
+async function listStoriesWithTags(
+  eventId: string
+): Promise<NonBdlEventStoryItem[]> {
+  const db = getDb()
+  const stories = await db
+    .select()
+    .from(nonBdlEventStories)
+    .where(eq(nonBdlEventStories.eventId, eventId))
+    .orderBy(asc(nonBdlEventStories.sortOrder), asc(nonBdlEventStories.createdAt))
+
+  if (stories.length === 0) return []
+
+  const storyIds = stories.map((s) => s.id)
+  const [teamTags, playerTags] = await Promise.all([
+    db
+      .select()
+      .from(nonBdlEventStoryTeamTags)
+      .where(inArray(nonBdlEventStoryTeamTags.storyId, storyIds)),
+    db
+      .select()
+      .from(nonBdlEventStoryPlayerTags)
+      .where(inArray(nonBdlEventStoryPlayerTags.storyId, storyIds)),
+  ])
+
+  const teamsByStory = new Map<string, string[]>()
+  for (const tag of teamTags) {
+    const list = teamsByStory.get(tag.storyId) ?? []
+    list.push(tag.teamId)
+    teamsByStory.set(tag.storyId, list)
+  }
+  const playersByStory = new Map<string, string[]>()
+  for (const tag of playerTags) {
+    const list = playersByStory.get(tag.storyId) ?? []
+    list.push(tag.playerId)
+    playersByStory.set(tag.storyId, list)
+  }
+
+  return stories.map((s) => ({
+    id: s.id,
+    eventId: s.eventId,
+    title: s.title,
+    body: s.body,
+    sortOrder: s.sortOrder,
+    teamIds: teamsByStory.get(s.id) ?? [],
+    playerIds: playersByStory.get(s.id) ?? [],
+    createdAt: s.createdAt,
+    updatedAt: s.updatedAt,
+  }))
+}
+
+async function listPhotosWithTags(
+  eventId: string
+): Promise<NonBdlEventPhotoItem[]> {
+  const db = getDb()
+  const photos = await db
+    .select()
+    .from(nonBdlEventPhotos)
+    .where(eq(nonBdlEventPhotos.eventId, eventId))
+    .orderBy(asc(nonBdlEventPhotos.sortOrder), asc(nonBdlEventPhotos.createdAt))
+
+  if (photos.length === 0) return []
+
+  const photoIds = photos.map((p) => p.id)
+  const [teamTags, playerTags] = await Promise.all([
+    db
+      .select()
+      .from(nonBdlEventPhotoTeamTags)
+      .where(inArray(nonBdlEventPhotoTeamTags.photoId, photoIds)),
+    db
+      .select()
+      .from(nonBdlEventPhotoPlayerTags)
+      .where(inArray(nonBdlEventPhotoPlayerTags.photoId, photoIds)),
+  ])
+
+  const teamsByPhoto = new Map<string, string[]>()
+  for (const tag of teamTags) {
+    const list = teamsByPhoto.get(tag.photoId) ?? []
+    list.push(tag.teamId)
+    teamsByPhoto.set(tag.photoId, list)
+  }
+  const playersByPhoto = new Map<string, string[]>()
+  for (const tag of playerTags) {
+    const list = playersByPhoto.get(tag.photoId) ?? []
+    list.push(tag.playerId)
+    playersByPhoto.set(tag.photoId, list)
+  }
+
+  return photos.map((p) => ({
+    id: p.id,
+    eventId: p.eventId,
+    blobUrl: p.blobUrl,
+    pathname: p.pathname,
+    caption: p.caption,
+    sortOrder: p.sortOrder,
+    teamIds: teamsByPhoto.get(p.id) ?? [],
+    playerIds: playersByPhoto.get(p.id) ?? [],
+    createdAt: p.createdAt,
+    updatedAt: p.updatedAt,
+  }))
+}
+
+export async function getNonBdlEventDetail(
+  id: string
+): Promise<NonBdlEventDetail | null> {
+  const event = await getNonBdlEvent(id)
+  if (!event) return null
+
+  const [teams, attendees, stories, photos] = await Promise.all([
+    listNonBdlEventTeams(id),
+    listNonBdlEventAttendees(id),
+    listStoriesWithTags(id),
+    listPhotosWithTags(id),
+  ])
+
+  return {
+    event: {
+      ...event,
+      ballTypeLabel: ballTypeLabel(event.ballType),
+      hostOrgLabel: hostOrgDisplayLabel(
+        event.hostOrgHomeLeague,
+        event.hostOrgName
+      ),
+    },
+    teams,
+    attendees,
+    stories,
+    photos,
+  }
+}
+
+export async function getAttendeePlayerIds(eventId: string): Promise<Set<string>> {
+  const db = getDb()
+  const rows = await db
+    .select({ playerId: nonBdlEventAttendees.playerId })
+    .from(nonBdlEventAttendees)
+    .where(eq(nonBdlEventAttendees.eventId, eventId))
+  return new Set(rows.map((r) => r.playerId))
+}
+
+export async function assertTeamBelongsToEvent(
+  eventId: string,
+  teamId: string
+): Promise<void> {
+  const db = getDb()
+  const [row] = await db
+    .select({ id: nonBdlEventTeams.id })
+    .from(nonBdlEventTeams)
+    .where(
+      and(eq(nonBdlEventTeams.id, teamId), eq(nonBdlEventTeams.eventId, eventId))
+    )
+    .limit(1)
+  if (!row) throw new Error('Team not found for this event')
+}
+
+export async function assertTeamsBelongToEvent(
+  eventId: string,
+  teamIds: string[]
+): Promise<void> {
+  if (teamIds.length === 0) return
+  const unique = [...new Set(teamIds)]
+  const db = getDb()
+  const rows = await db
+    .select({ id: nonBdlEventTeams.id })
+    .from(nonBdlEventTeams)
+    .where(
+      and(
+        eq(nonBdlEventTeams.eventId, eventId),
+        inArray(nonBdlEventTeams.id, unique)
+      )
+    )
+  if (rows.length !== unique.length) {
+    throw new Error('One or more teams are not part of this event')
+  }
+}
+
+export async function assertPlayersAttendEvent(
+  eventId: string,
+  playerIds: string[]
+): Promise<void> {
+  if (playerIds.length === 0) return
+  const unique = [...new Set(playerIds)]
+  const attending = await getAttendeePlayerIds(eventId)
+  for (const id of unique) {
+    if (!attending.has(id)) {
+      throw new Error('One or more players are not attendees of this event')
+    }
+  }
+}

--- a/app/lib/non-bdl-events/types.ts
+++ b/app/lib/non-bdl-events/types.ts
@@ -1,0 +1,216 @@
+import {
+  HOME_LEAGUES,
+  homeLeagueLabel,
+  isValidHomeLeague,
+  type HomeLeague,
+} from '@/app/lib/players/home-league'
+
+export const BALL_TYPES = {
+  foam: 'Foam',
+  cloth: 'Cloth',
+} as const
+
+export type BallType = keyof typeof BALL_TYPES
+
+export function isValidBallType(value: unknown): value is BallType {
+  return value === 'foam' || value === 'cloth'
+}
+
+export function ballTypeLabel(type: string | null | undefined): string {
+  if (type && isValidBallType(type)) return BALL_TYPES[type]
+  return BALL_TYPES.foam
+}
+
+export type NonBdlEventRecord = {
+  id: string
+  name: string
+  eventDate: string
+  ballType: string
+  division: string | null
+  city: string | null
+  hostOrgHomeLeague: string | null
+  hostOrgName: string | null
+  notes: string | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+export type NonBdlEventListItem = {
+  id: string
+  name: string
+  eventDate: string
+  ballType: string
+  ballTypeLabel: string
+  division: string | null
+  city: string | null
+  hostOrgLabel: string
+  attendeeCount: number
+}
+
+export type NonBdlEventTeamItem = {
+  id: string
+  eventId: string
+  name: string
+  resultText: string | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+export type NonBdlEventAttendeeItem = {
+  id: string
+  eventId: string
+  playerId: string
+  teamId: string | null
+  teamName: string | null
+  notes: string | null
+  firstName: string
+  lastName: string
+  rosterName: string
+  nickname: string
+  createdAt: Date
+  updatedAt: Date
+}
+
+export type NonBdlEventStoryItem = {
+  id: string
+  eventId: string
+  title: string | null
+  body: string
+  sortOrder: number
+  teamIds: string[]
+  playerIds: string[]
+  createdAt: Date
+  updatedAt: Date
+}
+
+export type NonBdlEventPhotoItem = {
+  id: string
+  eventId: string
+  blobUrl: string
+  pathname: string
+  caption: string | null
+  sortOrder: number
+  teamIds: string[]
+  playerIds: string[]
+  createdAt: Date
+  updatedAt: Date
+}
+
+export type NonBdlEventDetail = {
+  event: NonBdlEventRecord & {
+    ballTypeLabel: string
+    hostOrgLabel: string
+  }
+  teams: NonBdlEventTeamItem[]
+  attendees: NonBdlEventAttendeeItem[]
+  stories: NonBdlEventStoryItem[]
+  photos: NonBdlEventPhotoItem[]
+}
+
+export function hostOrgDisplayLabel(
+  homeLeague: string | null | undefined,
+  name: string | null | undefined
+): string {
+  const fromLeague =
+    homeLeague && isValidHomeLeague(homeLeague)
+      ? homeLeagueLabel(homeLeague)
+      : null
+  const fromName = name?.trim() ? name.trim() : null
+  if (fromName && fromLeague && fromName !== fromLeague) {
+    return `${fromName} (${fromLeague})`
+  }
+  return fromName || fromLeague || '—'
+}
+
+export function parseHostOrg(input: {
+  hostOrgHomeLeague?: string | null
+  hostOrgName?: string | null
+}): { hostOrgHomeLeague: HomeLeague | null; hostOrgName: string | null } {
+  const rawLeague =
+    typeof input.hostOrgHomeLeague === 'string'
+      ? input.hostOrgHomeLeague.trim()
+      : input.hostOrgHomeLeague === null
+        ? null
+        : undefined
+  const rawName =
+    typeof input.hostOrgName === 'string'
+      ? input.hostOrgName.trim()
+      : input.hostOrgName === null
+        ? null
+        : undefined
+
+  let hostOrgHomeLeague: HomeLeague | null = null
+  if (rawLeague === null || rawLeague === '') {
+    hostOrgHomeLeague = null
+  } else if (rawLeague !== undefined) {
+    if (!isValidHomeLeague(rawLeague)) {
+      throw new Error('Invalid hostOrgHomeLeague')
+    }
+    hostOrgHomeLeague = rawLeague
+  }
+
+  const hostOrgName =
+    rawName === undefined ? null : rawName === null || rawName === '' ? null : rawName
+
+  // When called for create with both undefined, treat as missing.
+  if (rawLeague === undefined && rawName === undefined) {
+    throw new Error('host org is required (home league and/or name)')
+  }
+
+  // For create, at least one must be present. Callers that only patch one field
+  // should use parseHostOrgPatch instead.
+  if (hostOrgHomeLeague == null && hostOrgName == null) {
+    throw new Error('host org is required (home league and/or name)')
+  }
+
+  return { hostOrgHomeLeague, hostOrgName }
+}
+
+export function parseHostOrgForCreate(input: {
+  hostOrgHomeLeague?: string | null
+  hostOrgName?: string | null
+}): { hostOrgHomeLeague: HomeLeague | null; hostOrgName: string | null } {
+  return parseHostOrg(input)
+}
+
+export function parseHostOrgPatch(
+  patch: {
+    hostOrgHomeLeague?: string | null
+    hostOrgName?: string | null
+  },
+  current: {
+    hostOrgHomeLeague: string | null
+    hostOrgName: string | null
+  }
+): { hostOrgHomeLeague: string | null; hostOrgName: string | null } | null {
+  const hasLeague = Object.prototype.hasOwnProperty.call(patch, 'hostOrgHomeLeague')
+  const hasName = Object.prototype.hasOwnProperty.call(patch, 'hostOrgName')
+  if (!hasLeague && !hasName) return null
+
+  let hostOrgHomeLeague = current.hostOrgHomeLeague
+  let hostOrgName = current.hostOrgName
+
+  if (hasLeague) {
+    const raw = patch.hostOrgHomeLeague
+    if (raw == null || raw === '') {
+      hostOrgHomeLeague = null
+    } else if (!isValidHomeLeague(raw)) {
+      throw new Error('Invalid hostOrgHomeLeague')
+    } else {
+      hostOrgHomeLeague = raw
+    }
+  }
+
+  if (hasName) {
+    const raw = patch.hostOrgName
+    hostOrgName = raw == null || String(raw).trim() === '' ? null : String(raw).trim()
+  }
+
+  if (hostOrgHomeLeague == null && hostOrgName == null) {
+    throw new Error('host org is required (home league and/or name)')
+  }
+
+  return { hostOrgHomeLeague, hostOrgName }
+}
+
+export { HOME_LEAGUES }

--- a/app/non-bdl-events/[id]/page.tsx
+++ b/app/non-bdl-events/[id]/page.tsx
@@ -1,0 +1,1077 @@
+'use client'
+
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react'
+import { withDevMode } from '@/app/lib/devMode'
+import { useDevMode } from '@/app/hooks/useDevMode'
+import {
+  BALL_TYPES,
+  HOME_LEAGUES,
+  type NonBdlEventAttendeeItem,
+  type NonBdlEventPhotoItem,
+  type NonBdlEventStoryItem,
+  type NonBdlEventTeamItem,
+} from '@/app/lib/non-bdl-events/types'
+
+type EventDetail = {
+  id: string
+  name: string
+  eventDate: string
+  ballType: string
+  ballTypeLabel: string
+  division: string | null
+  city: string | null
+  hostOrgHomeLeague: string | null
+  hostOrgName: string | null
+  hostOrgLabel: string
+  notes: string | null
+}
+
+type PlayerSearchHit = {
+  id: string
+  firstName: string
+  lastName: string
+  nickname: string
+  rosterName: string
+}
+
+function TagChecklist({
+  label,
+  options,
+  selected,
+  onChange,
+}: {
+  label: string
+  options: { id: string; label: string }[]
+  selected: string[]
+  onChange: (ids: string[]) => void
+}) {
+  if (options.length === 0) {
+    return (
+      <p className="text-xs text-gray-500">
+        No {label.toLowerCase()} to tag yet.
+      </p>
+    )
+  }
+  return (
+    <fieldset className="space-y-1">
+      <legend className="text-xs font-medium text-gray-600">{label}</legend>
+      <div className="flex flex-wrap gap-2">
+        {options.map((opt) => {
+          const checked = selected.includes(opt.id)
+          return (
+            <label
+              key={opt.id}
+              className="inline-flex items-center gap-1 rounded border border-gray-200 px-2 py-1 text-xs"
+            >
+              <input
+                type="checkbox"
+                checked={checked}
+                onChange={() => {
+                  onChange(
+                    checked
+                      ? selected.filter((id) => id !== opt.id)
+                      : [...selected, opt.id]
+                  )
+                }}
+              />
+              {opt.label}
+            </label>
+          )
+        })}
+      </div>
+    </fieldset>
+  )
+}
+
+export default function NonBdlEventDetailPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="mx-auto max-w-5xl p-6 text-sm text-gray-600">Loading…</div>
+      }
+    >
+      <NonBdlEventDetailContent />
+    </Suspense>
+  )
+}
+
+function NonBdlEventDetailContent() {
+  const params = useParams()
+  const eventId = String(params.id)
+  const { devMode } = useDevMode()
+
+  const [event, setEvent] = useState<EventDetail | null>(null)
+  const [teams, setTeams] = useState<NonBdlEventTeamItem[]>([])
+  const [attendees, setAttendees] = useState<NonBdlEventAttendeeItem[]>([])
+  const [stories, setStories] = useState<NonBdlEventStoryItem[]>([])
+  const [photos, setPhotos] = useState<NonBdlEventPhotoItem[]>([])
+  const [goodLuckBlurb, setGoodLuckBlurb] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  // Event edit form
+  const [name, setName] = useState('')
+  const [eventDate, setEventDate] = useState('')
+  const [ballType, setBallType] = useState('foam')
+  const [division, setDivision] = useState('')
+  const [city, setCity] = useState('')
+  const [hostOrgHomeLeague, setHostOrgHomeLeague] = useState('')
+  const [hostOrgName, setHostOrgName] = useState('')
+  const [notes, setNotes] = useState('')
+
+  // Team form
+  const [newTeamName, setNewTeamName] = useState('')
+
+  // Player search
+  const [playerQuery, setPlayerQuery] = useState('')
+  const [playerHits, setPlayerHits] = useState<PlayerSearchHit[]>([])
+  const [searching, setSearching] = useState(false)
+  const [addTeamId, setAddTeamId] = useState('')
+
+  // Story form
+  const [storyTitle, setStoryTitle] = useState('')
+  const [storyBody, setStoryBody] = useState('')
+  const [storyTeamIds, setStoryTeamIds] = useState<string[]>([])
+  const [storyPlayerIds, setStoryPlayerIds] = useState<string[]>([])
+
+  // Photo form
+  const [photoCaption, setPhotoCaption] = useState('')
+  const [photoTeamIds, setPhotoTeamIds] = useState<string[]>([])
+  const [photoPlayerIds, setPhotoPlayerIds] = useState<string[]>([])
+  const [uploading, setUploading] = useState(false)
+
+  const loadDetail = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch(`/api/non-bdl-events/${eventId}`)
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to load event')
+      setEvent(data.event)
+      setTeams(data.teams)
+      setAttendees(data.attendees)
+      setStories(data.stories)
+      setPhotos(data.photos)
+      setGoodLuckBlurb(data.goodLuckBlurb ?? '')
+      setName(data.event.name)
+      setEventDate(data.event.eventDate)
+      setBallType(data.event.ballType)
+      setDivision(data.event.division ?? '')
+      setCity(data.event.city ?? '')
+      setHostOrgHomeLeague(data.event.hostOrgHomeLeague ?? '')
+      setHostOrgName(data.event.hostOrgName ?? '')
+      setNotes(data.event.notes ?? '')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load event')
+    } finally {
+      setLoading(false)
+    }
+  }, [eventId])
+
+  useEffect(() => {
+    void loadDetail()
+  }, [loadDetail])
+
+  useEffect(() => {
+    if (!playerQuery.trim()) {
+      setPlayerHits([])
+      return
+    }
+    const handle = window.setTimeout(() => {
+      void (async () => {
+        setSearching(true)
+        try {
+          const res = await fetch(
+            `/api/players?q=${encodeURIComponent(playerQuery.trim())}`
+          )
+          const data = await res.json()
+          if (!res.ok) throw new Error(data.error || 'Search failed')
+          const attending = new Set(attendees.map((a) => a.playerId))
+          setPlayerHits(
+            (data.players as PlayerSearchHit[])
+              .filter((p) => !attending.has(p.id))
+              .slice(0, 8)
+          )
+        } catch {
+          setPlayerHits([])
+        } finally {
+          setSearching(false)
+        }
+      })()
+    }, 250)
+    return () => window.clearTimeout(handle)
+  }, [playerQuery, attendees])
+
+  const teamOptions = useMemo(
+    () => teams.map((t) => ({ id: t.id, label: t.name })),
+    [teams]
+  )
+  const playerOptions = useMemo(
+    () => attendees.map((a) => ({ id: a.playerId, label: a.nickname })),
+    [attendees]
+  )
+
+  async function saveEvent() {
+    setSaving(true)
+    setActionError(null)
+    try {
+      const res = await fetch(`/api/non-bdl-events/${eventId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name,
+          eventDate,
+          ballType,
+          division: division.trim() || null,
+          city: city.trim() || null,
+          hostOrgHomeLeague: hostOrgHomeLeague || null,
+          hostOrgName: hostOrgName.trim() || null,
+          notes: notes.trim() || null,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to save')
+      await loadDetail()
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to save')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function deleteEvent() {
+    if (!window.confirm('Delete this travel event and all related content?')) {
+      return
+    }
+    setSaving(true)
+    setActionError(null)
+    try {
+      const res = await fetch(`/api/non-bdl-events/${eventId}`, {
+        method: 'DELETE',
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to delete')
+      window.location.href = withDevMode('/non-bdl-events', devMode)
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to delete')
+      setSaving(false)
+    }
+  }
+
+  async function addTeam() {
+    if (!newTeamName.trim()) return
+    setActionError(null)
+    try {
+      const res = await fetch(`/api/non-bdl-events/${eventId}/teams`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newTeamName }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to add team')
+      setNewTeamName('')
+      await loadDetail()
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to add team')
+    }
+  }
+
+  async function saveTeam(
+    teamId: string,
+    patch: { name?: string; resultText?: string | null }
+  ) {
+    setActionError(null)
+    try {
+      const res = await fetch(`/api/non-bdl-events/${eventId}/teams/${teamId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(patch),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to update team')
+      await loadDetail()
+    } catch (err) {
+      setActionError(
+        err instanceof Error ? err.message : 'Failed to update team'
+      )
+    }
+  }
+
+  async function removeTeam(teamId: string) {
+    if (!window.confirm('Delete this team? Players will be unassigned.')) return
+    setActionError(null)
+    try {
+      const res = await fetch(`/api/non-bdl-events/${eventId}/teams/${teamId}`, {
+        method: 'DELETE',
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to delete team')
+      await loadDetail()
+    } catch (err) {
+      setActionError(
+        err instanceof Error ? err.message : 'Failed to delete team'
+      )
+    }
+  }
+
+  async function addPlayer(playerId: string) {
+    setActionError(null)
+    try {
+      const res = await fetch(`/api/non-bdl-events/${eventId}/attendees`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          playerId,
+          teamId: addTeamId || null,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to add player')
+      setPlayerQuery('')
+      setPlayerHits([])
+      await loadDetail()
+    } catch (err) {
+      setActionError(
+        err instanceof Error ? err.message : 'Failed to add player'
+      )
+    }
+  }
+
+  async function updateAttendee(
+    attendeeId: string,
+    patch: { teamId?: string | null; notes?: string | null }
+  ) {
+    setActionError(null)
+    try {
+      const res = await fetch(
+        `/api/non-bdl-events/${eventId}/attendees/${attendeeId}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(patch),
+        }
+      )
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to update player')
+      await loadDetail()
+    } catch (err) {
+      setActionError(
+        err instanceof Error ? err.message : 'Failed to update player'
+      )
+    }
+  }
+
+  async function removeAttendee(attendeeId: string) {
+    setActionError(null)
+    try {
+      const res = await fetch(
+        `/api/non-bdl-events/${eventId}/attendees/${attendeeId}`,
+        { method: 'DELETE' }
+      )
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to remove player')
+      await loadDetail()
+    } catch (err) {
+      setActionError(
+        err instanceof Error ? err.message : 'Failed to remove player'
+      )
+    }
+  }
+
+  async function copyGoodLuck() {
+    try {
+      await navigator.clipboard.writeText(goodLuckBlurb)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 2000)
+    } catch {
+      setActionError('Could not copy to clipboard')
+    }
+  }
+
+  async function addStory() {
+    if (!storyBody.trim()) return
+    setActionError(null)
+    try {
+      const res = await fetch(`/api/non-bdl-events/${eventId}/stories`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: storyTitle.trim() || null,
+          body: storyBody,
+          teamIds: storyTeamIds,
+          playerIds: storyPlayerIds,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to add story')
+      setStoryTitle('')
+      setStoryBody('')
+      setStoryTeamIds([])
+      setStoryPlayerIds([])
+      await loadDetail()
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to add story')
+    }
+  }
+
+  async function saveStory(
+    storyId: string,
+    patch: {
+      title?: string | null
+      body?: string
+      teamIds?: string[]
+      playerIds?: string[]
+    }
+  ) {
+    setActionError(null)
+    try {
+      const res = await fetch(
+        `/api/non-bdl-events/${eventId}/stories/${storyId}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(patch),
+        }
+      )
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to update story')
+      await loadDetail()
+    } catch (err) {
+      setActionError(
+        err instanceof Error ? err.message : 'Failed to update story'
+      )
+    }
+  }
+
+  async function removeStory(storyId: string) {
+    if (!window.confirm('Delete this story?')) return
+    setActionError(null)
+    try {
+      const res = await fetch(
+        `/api/non-bdl-events/${eventId}/stories/${storyId}`,
+        { method: 'DELETE' }
+      )
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to delete story')
+      await loadDetail()
+    } catch (err) {
+      setActionError(
+        err instanceof Error ? err.message : 'Failed to delete story'
+      )
+    }
+  }
+
+  async function uploadPhoto(file: File) {
+    setUploading(true)
+    setActionError(null)
+    try {
+      const form = new FormData()
+      form.append('file', file)
+      if (photoCaption.trim()) form.append('caption', photoCaption.trim())
+      form.append('teamIds', JSON.stringify(photoTeamIds))
+      form.append('playerIds', JSON.stringify(photoPlayerIds))
+      const res = await fetch(`/api/non-bdl-events/${eventId}/photos/upload`, {
+        method: 'POST',
+        body: form,
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to upload photo')
+      setPhotoCaption('')
+      setPhotoTeamIds([])
+      setPhotoPlayerIds([])
+      await loadDetail()
+    } catch (err) {
+      setActionError(
+        err instanceof Error ? err.message : 'Failed to upload photo'
+      )
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  async function savePhoto(
+    photoId: string,
+    patch: {
+      caption?: string | null
+      teamIds?: string[]
+      playerIds?: string[]
+    }
+  ) {
+    setActionError(null)
+    try {
+      const res = await fetch(
+        `/api/non-bdl-events/${eventId}/photos/${photoId}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(patch),
+        }
+      )
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to update photo')
+      await loadDetail()
+    } catch (err) {
+      setActionError(
+        err instanceof Error ? err.message : 'Failed to update photo'
+      )
+    }
+  }
+
+  async function removePhoto(photoId: string) {
+    if (!window.confirm('Delete this photo?')) return
+    setActionError(null)
+    try {
+      const res = await fetch(
+        `/api/non-bdl-events/${eventId}/photos/${photoId}`,
+        { method: 'DELETE' }
+      )
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to delete photo')
+      await loadDetail()
+    } catch (err) {
+      setActionError(
+        err instanceof Error ? err.message : 'Failed to delete photo'
+      )
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-5xl p-6 text-sm text-gray-600">Loading…</div>
+    )
+  }
+
+  if (error || !event) {
+    return (
+      <div className="mx-auto max-w-5xl p-6 space-y-3">
+        <p className="text-sm text-red-600">{error || 'Event not found'}</p>
+        <Link
+          href={withDevMode('/non-bdl-events', devMode)}
+          className="text-sm text-blue-700 hover:underline"
+        >
+          ← Back to Non-BDL Events
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl p-6 space-y-8 text-gray-900">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <Link
+            href={withDevMode('/non-bdl-events', devMode)}
+            className="text-sm text-blue-700 hover:underline"
+          >
+            ← Non-BDL Events
+          </Link>
+          <h1 className="text-2xl font-semibold mt-1">{event.name}</h1>
+          <p className="text-sm text-gray-600">
+            {event.hostOrgLabel}
+            {event.city ? ` · ${event.city}` : ''}
+          </p>
+        </div>
+        <button
+          type="button"
+          className="rounded border border-red-300 px-3 py-2 text-sm text-red-700"
+          onClick={() => void deleteEvent()}
+          disabled={saving}
+        >
+          Delete event
+        </button>
+      </div>
+
+      {actionError ? <p className="text-sm text-red-600">{actionError}</p> : null}
+
+      {/* Event info */}
+      <section className="space-y-3 rounded border border-gray-200 p-4">
+        <h2 className="text-lg font-semibold">Event info</h2>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <label className="block text-sm sm:col-span-2">
+            <span className="text-gray-600">Name</span>
+            <input
+              className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-gray-600">Date</span>
+            <input
+              type="date"
+              className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+              value={eventDate}
+              onChange={(e) => setEventDate(e.target.value)}
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-gray-600">Ball</span>
+            <select
+              className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+              value={ballType}
+              onChange={(e) => setBallType(e.target.value)}
+            >
+              {Object.entries(BALL_TYPES).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block text-sm">
+            <span className="text-gray-600">Division</span>
+            <input
+              className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+              value={division}
+              onChange={(e) => setDivision(e.target.value)}
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-gray-600">City</span>
+            <input
+              className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+              value={city}
+              onChange={(e) => setCity(e.target.value)}
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-gray-600">Host org (known league)</span>
+            <select
+              className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+              value={hostOrgHomeLeague}
+              onChange={(e) => setHostOrgHomeLeague(e.target.value)}
+            >
+              <option value="">— None —</option>
+              {Object.entries(HOME_LEAGUES).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block text-sm">
+            <span className="text-gray-600">Host org (free text)</span>
+            <input
+              className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+              value={hostOrgName}
+              onChange={(e) => setHostOrgName(e.target.value)}
+            />
+          </label>
+          <label className="block text-sm sm:col-span-2">
+            <span className="text-gray-600">Notes</span>
+            <textarea
+              className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+              rows={2}
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+            />
+          </label>
+        </div>
+        <button
+          type="button"
+          className="rounded bg-blue-600 px-3 py-2 text-sm text-white disabled:opacity-50"
+          onClick={() => void saveEvent()}
+          disabled={saving}
+        >
+          {saving ? 'Saving…' : 'Save event info'}
+        </button>
+      </section>
+
+      {/* Teams */}
+      <section className="space-y-3 rounded border border-gray-200 p-4">
+        <h2 className="text-lg font-semibold">Teams</h2>
+        <div className="flex flex-wrap gap-2">
+          <input
+            className="rounded border border-gray-300 px-3 py-2 text-sm"
+            placeholder="External team name"
+            value={newTeamName}
+            onChange={(e) => setNewTeamName(e.target.value)}
+          />
+          <button
+            type="button"
+            className="rounded bg-blue-600 px-3 py-2 text-sm text-white"
+            onClick={() => void addTeam()}
+          >
+            Add team
+          </button>
+        </div>
+        {teams.length === 0 ? (
+          <p className="text-sm text-gray-600">No teams yet.</p>
+        ) : (
+          <ul className="space-y-3">
+            {teams.map((team) => (
+              <li
+                key={team.id}
+                className="rounded border border-gray-100 p-3 space-y-2"
+              >
+                <div className="flex flex-wrap gap-2 items-center">
+                  <input
+                    className="rounded border border-gray-300 px-2 py-1 text-sm font-medium"
+                    defaultValue={team.name}
+                    onBlur={(e) => {
+                      if (e.target.value.trim() !== team.name) {
+                        void saveTeam(team.id, { name: e.target.value })
+                      }
+                    }}
+                  />
+                  <button
+                    type="button"
+                    className="text-xs text-red-700 hover:underline"
+                    onClick={() => void removeTeam(team.id)}
+                  >
+                    Delete
+                  </button>
+                </div>
+                <label className="block text-sm">
+                  <span className="text-gray-600">How they did</span>
+                  <textarea
+                    className="mt-1 w-full rounded border border-gray-300 px-2 py-1 text-sm"
+                    rows={2}
+                    defaultValue={team.resultText ?? ''}
+                    onBlur={(e) => {
+                      const next = e.target.value.trim() || null
+                      if (next !== (team.resultText ?? null)) {
+                        void saveTeam(team.id, { resultText: next })
+                      }
+                    }}
+                    placeholder="Placement, notable wins…"
+                  />
+                </label>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Players */}
+      <section className="space-y-3 rounded border border-gray-200 p-4">
+        <h2 className="text-lg font-semibold">Players going</h2>
+        <div className="flex flex-wrap gap-2 items-end">
+          <label className="block text-sm grow min-w-[200px]">
+            <span className="text-gray-600">Search players</span>
+            <input
+              className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+              value={playerQuery}
+              onChange={(e) => setPlayerQuery(e.target.value)}
+              placeholder="Name…"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-gray-600">Assign to team</span>
+            <select
+              className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+              value={addTeamId}
+              onChange={(e) => setAddTeamId(e.target.value)}
+            >
+              <option value="">Unassigned</option>
+              {teams.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.name}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        {searching ? (
+          <p className="text-xs text-gray-500">Searching…</p>
+        ) : playerHits.length > 0 ? (
+          <ul className="rounded border border-gray-200 divide-y">
+            {playerHits.map((p) => (
+              <li
+                key={p.id}
+                className="flex items-center justify-between px-3 py-2 text-sm"
+              >
+                <span>
+                  {p.nickname}{' '}
+                  <span className="text-gray-500">
+                    ({p.firstName} {p.lastName})
+                  </span>
+                </span>
+                <button
+                  type="button"
+                  className="text-blue-700 hover:underline"
+                  onClick={() => void addPlayer(p.id)}
+                >
+                  Add
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+
+        {attendees.length === 0 ? (
+          <p className="text-sm text-gray-600">No players added yet.</p>
+        ) : (
+          <div className="overflow-x-auto rounded border border-gray-200">
+            <table className="min-w-full text-sm">
+              <thead className="bg-gray-50 text-left">
+                <tr>
+                  <th className="px-3 py-2 font-medium">Player</th>
+                  <th className="px-3 py-2 font-medium">Team</th>
+                  <th className="px-3 py-2 font-medium">Notes</th>
+                  <th className="px-3 py-2 font-medium" />
+                </tr>
+              </thead>
+              <tbody>
+                {attendees.map((a) => (
+                  <tr key={a.id} className="border-t border-gray-100">
+                    <td className="px-3 py-2 whitespace-nowrap">{a.nickname}</td>
+                    <td className="px-3 py-2">
+                      <select
+                        className="rounded border border-gray-300 px-2 py-1"
+                        value={a.teamId ?? ''}
+                        onChange={(e) =>
+                          void updateAttendee(a.id, {
+                            teamId: e.target.value || null,
+                          })
+                        }
+                      >
+                        <option value="">Unassigned</option>
+                        {teams.map((t) => (
+                          <option key={t.id} value={t.id}>
+                            {t.name}
+                          </option>
+                        ))}
+                      </select>
+                    </td>
+                    <td className="px-3 py-2 min-w-[180px]">
+                      <input
+                        className="w-full rounded border border-gray-300 px-2 py-1"
+                        defaultValue={a.notes ?? ''}
+                        onBlur={(e) => {
+                          const next = e.target.value.trim() || null
+                          if (next !== (a.notes ?? null)) {
+                            void updateAttendee(a.id, { notes: next })
+                          }
+                        }}
+                        placeholder="Optional notes / story seed"
+                      />
+                    </td>
+                    <td className="px-3 py-2 text-right">
+                      <button
+                        type="button"
+                        className="text-xs text-red-700 hover:underline"
+                        onClick={() => void removeAttendee(a.id)}
+                      >
+                        Remove
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {/* Good luck */}
+      <section className="space-y-3 rounded border border-gray-200 p-4">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h2 className="text-lg font-semibold">Good luck blurb</h2>
+          <button
+            type="button"
+            className="rounded border px-3 py-1.5 text-sm"
+            onClick={() => void copyGoodLuck()}
+          >
+            {copied ? 'Copied!' : 'Copy'}
+          </button>
+        </div>
+        <pre className="whitespace-pre-wrap rounded bg-gray-50 p-3 text-sm border border-gray-100">
+          {goodLuckBlurb}
+        </pre>
+      </section>
+
+      {/* Stories */}
+      <section className="space-y-3 rounded border border-gray-200 p-4">
+        <h2 className="text-lg font-semibold">Stories</h2>
+        <div className="space-y-2 rounded border border-dashed border-gray-300 p-3">
+          <input
+            className="w-full rounded border border-gray-300 px-3 py-2 text-sm"
+            placeholder="Title (optional)"
+            value={storyTitle}
+            onChange={(e) => setStoryTitle(e.target.value)}
+          />
+          <textarea
+            className="w-full rounded border border-gray-300 px-3 py-2 text-sm"
+            rows={4}
+            placeholder="Story draft for the website…"
+            value={storyBody}
+            onChange={(e) => setStoryBody(e.target.value)}
+          />
+          <TagChecklist
+            label="Tag teams"
+            options={teamOptions}
+            selected={storyTeamIds}
+            onChange={setStoryTeamIds}
+          />
+          <TagChecklist
+            label="Tag players"
+            options={playerOptions}
+            selected={storyPlayerIds}
+            onChange={setStoryPlayerIds}
+          />
+          <button
+            type="button"
+            className="rounded bg-blue-600 px-3 py-2 text-sm text-white disabled:opacity-50"
+            disabled={!storyBody.trim()}
+            onClick={() => void addStory()}
+          >
+            Add story
+          </button>
+        </div>
+        {stories.length === 0 ? (
+          <p className="text-sm text-gray-600">No stories yet.</p>
+        ) : (
+          <ul className="space-y-3">
+            {stories.map((story) => (
+              <li
+                key={story.id}
+                className="rounded border border-gray-100 p-3 space-y-2"
+              >
+                <input
+                  className="w-full rounded border border-gray-300 px-2 py-1 text-sm font-medium"
+                  defaultValue={story.title ?? ''}
+                  placeholder="Untitled"
+                  onBlur={(e) => {
+                    const next = e.target.value.trim() || null
+                    if (next !== (story.title ?? null)) {
+                      void saveStory(story.id, { title: next })
+                    }
+                  }}
+                />
+                <textarea
+                  className="w-full rounded border border-gray-300 px-2 py-1 text-sm"
+                  rows={4}
+                  defaultValue={story.body}
+                  onBlur={(e) => {
+                    if (e.target.value.trim() !== story.body) {
+                      void saveStory(story.id, { body: e.target.value })
+                    }
+                  }}
+                />
+                <TagChecklist
+                  label="Tag teams"
+                  options={teamOptions}
+                  selected={story.teamIds}
+                  onChange={(ids) => void saveStory(story.id, { teamIds: ids })}
+                />
+                <TagChecklist
+                  label="Tag players"
+                  options={playerOptions}
+                  selected={story.playerIds}
+                  onChange={(ids) =>
+                    void saveStory(story.id, { playerIds: ids })
+                  }
+                />
+                <button
+                  type="button"
+                  className="text-xs text-red-700 hover:underline"
+                  onClick={() => void removeStory(story.id)}
+                >
+                  Delete story
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Photos */}
+      <section className="space-y-3 rounded border border-gray-200 p-4">
+        <h2 className="text-lg font-semibold">Photos</h2>
+        <div className="space-y-2 rounded border border-dashed border-gray-300 p-3">
+          <input
+            className="w-full rounded border border-gray-300 px-3 py-2 text-sm"
+            placeholder="Caption (optional)"
+            value={photoCaption}
+            onChange={(e) => setPhotoCaption(e.target.value)}
+          />
+          <TagChecklist
+            label="Tag teams"
+            options={teamOptions}
+            selected={photoTeamIds}
+            onChange={setPhotoTeamIds}
+          />
+          <TagChecklist
+            label="Tag players"
+            options={playerOptions}
+            selected={photoPlayerIds}
+            onChange={setPhotoPlayerIds}
+          />
+          <label className="inline-flex items-center gap-2 text-sm">
+            <span className="rounded bg-blue-600 px-3 py-2 text-white cursor-pointer">
+              {uploading ? 'Uploading…' : 'Upload photo'}
+            </span>
+            <input
+              type="file"
+              accept="image/*"
+              className="hidden"
+              disabled={uploading}
+              onChange={(e) => {
+                const file = e.target.files?.[0]
+                e.target.value = ''
+                if (file) void uploadPhoto(file)
+              }}
+            />
+          </label>
+        </div>
+        {photos.length === 0 ? (
+          <p className="text-sm text-gray-600">No photos yet.</p>
+        ) : (
+          <ul className="grid gap-4 sm:grid-cols-2">
+            {photos.map((photo) => (
+              <li
+                key={photo.id}
+                className="rounded border border-gray-100 p-3 space-y-2"
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={photo.blobUrl}
+                  alt={photo.caption || 'Event photo'}
+                  className="w-full max-h-56 object-cover rounded"
+                />
+                <input
+                  className="w-full rounded border border-gray-300 px-2 py-1 text-sm"
+                  defaultValue={photo.caption ?? ''}
+                  placeholder="Caption"
+                  onBlur={(e) => {
+                    const next = e.target.value.trim() || null
+                    if (next !== (photo.caption ?? null)) {
+                      void savePhoto(photo.id, { caption: next })
+                    }
+                  }}
+                />
+                <TagChecklist
+                  label="Tag teams"
+                  options={teamOptions}
+                  selected={photo.teamIds}
+                  onChange={(ids) => void savePhoto(photo.id, { teamIds: ids })}
+                />
+                <TagChecklist
+                  label="Tag players"
+                  options={playerOptions}
+                  selected={photo.playerIds}
+                  onChange={(ids) =>
+                    void savePhoto(photo.id, { playerIds: ids })
+                  }
+                />
+                <button
+                  type="button"
+                  className="text-xs text-red-700 hover:underline"
+                  onClick={() => void removePhoto(photo.id)}
+                >
+                  Delete photo
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/app/non-bdl-events/page.tsx
+++ b/app/non-bdl-events/page.tsx
@@ -1,0 +1,298 @@
+'use client'
+
+import Link from 'next/link'
+import { Suspense, useCallback, useEffect, useState } from 'react'
+import { withDevMode } from '@/app/lib/devMode'
+import { useDevMode } from '@/app/hooks/useDevMode'
+import {
+  BALL_TYPES,
+  HOME_LEAGUES,
+  type NonBdlEventListItem,
+} from '@/app/lib/non-bdl-events/types'
+
+function formatDisplayDate(isoDate: string): string {
+  const d = new Date(`${isoDate}T12:00:00`)
+  if (Number.isNaN(d.getTime())) return isoDate
+  return d.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+export default function NonBdlEventsPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="mx-auto max-w-5xl p-6 text-sm text-gray-600">Loading…</div>
+      }
+    >
+      <NonBdlEventsPageContent />
+    </Suspense>
+  )
+}
+
+function NonBdlEventsPageContent() {
+  const { devMode } = useDevMode()
+  const [events, setEvents] = useState<NonBdlEventListItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [createOpen, setCreateOpen] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [formError, setFormError] = useState<string | null>(null)
+  const [name, setName] = useState('')
+  const [eventDate, setEventDate] = useState('')
+  const [ballType, setBallType] = useState('foam')
+  const [division, setDivision] = useState('')
+  const [city, setCity] = useState('')
+  const [hostOrgHomeLeague, setHostOrgHomeLeague] = useState('')
+  const [hostOrgName, setHostOrgName] = useState('')
+  const [notes, setNotes] = useState('')
+
+  const loadEvents = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/non-bdl-events')
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to load events')
+      setEvents(data.events)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load events')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadEvents()
+  }, [loadEvents])
+
+  function resetForm() {
+    setName('')
+    setEventDate('')
+    setBallType('foam')
+    setDivision('')
+    setCity('')
+    setHostOrgHomeLeague('')
+    setHostOrgName('')
+    setNotes('')
+  }
+
+  async function createEvent() {
+    setSaving(true)
+    setFormError(null)
+    try {
+      const res = await fetch('/api/non-bdl-events', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name,
+          eventDate,
+          ballType,
+          division: division.trim() || null,
+          city: city.trim() || null,
+          hostOrgHomeLeague: hostOrgHomeLeague || null,
+          hostOrgName: hostOrgName.trim() || null,
+          notes: notes.trim() || null,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to create event')
+      setCreateOpen(false)
+      resetForm()
+      await loadEvents()
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Failed to create event')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl p-6 space-y-6 text-gray-900">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold">Non-BDL Events</h1>
+          <p className="text-sm text-gray-600 mt-1">
+            Track travel tournaments — who&apos;s going, which teams, results, and
+            website story drafts.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="rounded bg-blue-600 px-3 py-2 text-sm text-white"
+          onClick={() => {
+            setCreateOpen(true)
+            setFormError(null)
+          }}
+        >
+          New travel event
+        </button>
+      </div>
+
+      {error ? <p className="text-sm text-red-600">{error}</p> : null}
+
+      {loading ? (
+        <p className="text-sm text-gray-600">Loading…</p>
+      ) : events.length === 0 ? (
+        <p className="text-sm text-gray-600">
+          No travel events yet. Add one to track players heading to another
+          league&apos;s tournament.
+        </p>
+      ) : (
+        <div className="overflow-x-auto rounded border border-gray-200">
+          <table className="min-w-full text-sm">
+            <thead className="bg-gray-50 text-left">
+              <tr>
+                <th className="px-3 py-2 font-medium">Date</th>
+                <th className="px-3 py-2 font-medium">Name</th>
+                <th className="px-3 py-2 font-medium">City</th>
+                <th className="px-3 py-2 font-medium">Host</th>
+                <th className="px-3 py-2 font-medium">Ball</th>
+                <th className="px-3 py-2 font-medium">Players</th>
+              </tr>
+            </thead>
+            <tbody>
+              {events.map((event) => (
+                <tr
+                  key={event.id}
+                  className="border-t border-gray-100 hover:bg-gray-50"
+                >
+                  <td className="px-3 py-2 whitespace-nowrap">
+                    {formatDisplayDate(event.eventDate)}
+                  </td>
+                  <td className="px-3 py-2">
+                    <Link
+                      href={withDevMode(`/non-bdl-events/${event.id}`, devMode)}
+                      className="text-blue-700 hover:underline font-medium"
+                    >
+                      {event.name}
+                    </Link>
+                  </td>
+                  <td className="px-3 py-2">{event.city || '—'}</td>
+                  <td className="px-3 py-2">{event.hostOrgLabel}</td>
+                  <td className="px-3 py-2">{event.ballTypeLabel}</td>
+                  <td className="px-3 py-2">{event.attendeeCount}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {createOpen ? (
+        <div className="fixed inset-0 z-40 bg-black/40 flex items-center justify-center p-4">
+          <div className="bg-white rounded-lg shadow-xl max-w-lg w-full p-6 space-y-4 max-h-[90vh] overflow-y-auto">
+            <h2 className="text-lg font-semibold">New travel event</h2>
+            <label className="block text-sm">
+              <span className="text-gray-600">Name</span>
+              <input
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Philly Foam Classic"
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="text-gray-600">Date</span>
+              <input
+                type="date"
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+                value={eventDate}
+                onChange={(e) => setEventDate(e.target.value)}
+              />
+            </label>
+            <div className="grid grid-cols-2 gap-3">
+              <label className="block text-sm">
+                <span className="text-gray-600">Ball</span>
+                <select
+                  className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+                  value={ballType}
+                  onChange={(e) => setBallType(e.target.value)}
+                >
+                  {Object.entries(BALL_TYPES).map(([value, label]) => (
+                    <option key={value} value={value}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="block text-sm">
+                <span className="text-gray-600">Division</span>
+                <input
+                  className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+                  value={division}
+                  onChange={(e) => setDivision(e.target.value)}
+                  placeholder="Open, Mixed…"
+                />
+              </label>
+            </div>
+            <label className="block text-sm">
+              <span className="text-gray-600">City</span>
+              <input
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+                value={city}
+                onChange={(e) => setCity(e.target.value)}
+                placeholder="Philadelphia"
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="text-gray-600">Host org (known league)</span>
+              <select
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+                value={hostOrgHomeLeague}
+                onChange={(e) => setHostOrgHomeLeague(e.target.value)}
+              >
+                <option value="">— None / use free text —</option>
+                {Object.entries(HOME_LEAGUES).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="block text-sm">
+              <span className="text-gray-600">Host org (free text)</span>
+              <input
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+                value={hostOrgName}
+                onChange={(e) => setHostOrgName(e.target.value)}
+                placeholder="Required if no known league selected"
+              />
+            </label>
+            <label className="block text-sm">
+              <span className="text-gray-600">Notes (optional)</span>
+              <textarea
+                className="mt-1 w-full rounded border border-gray-300 px-3 py-2"
+                rows={2}
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+              />
+            </label>
+            {formError ? <p className="text-sm text-red-600">{formError}</p> : null}
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                className="rounded border px-3 py-2 text-sm"
+                onClick={() => setCreateOpen(false)}
+                disabled={saving}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="rounded bg-blue-600 px-3 py-2 text-sm text-white disabled:opacity-50"
+                onClick={() => void createEvent()}
+                disabled={saving || !name.trim() || !eventDate}
+              >
+                {saving ? 'Saving…' : 'Create'}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/drizzle/0013_non_bdl_events.sql
+++ b/drizzle/0013_non_bdl_events.sql
@@ -1,0 +1,193 @@
+CREATE TABLE IF NOT EXISTS "non_bdl_events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"event_date" date NOT NULL,
+	"ball_type" text DEFAULT 'foam' NOT NULL,
+	"division" text,
+	"city" text,
+	"host_org_home_league" text,
+	"host_org_name" text,
+	"notes" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "non_bdl_event_teams" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"event_id" uuid NOT NULL,
+	"name" text NOT NULL,
+	"result_text" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "non_bdl_event_attendees" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"event_id" uuid NOT NULL,
+	"player_id" uuid NOT NULL,
+	"team_id" uuid,
+	"notes" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "non_bdl_event_stories" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"event_id" uuid NOT NULL,
+	"title" text,
+	"body" text NOT NULL,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "non_bdl_event_story_team_tags" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"story_id" uuid NOT NULL,
+	"team_id" uuid NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "non_bdl_event_story_player_tags" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"story_id" uuid NOT NULL,
+	"player_id" uuid NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "non_bdl_event_photos" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"event_id" uuid NOT NULL,
+	"blob_url" text NOT NULL,
+	"pathname" text NOT NULL,
+	"caption" text,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "non_bdl_event_photo_team_tags" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"photo_id" uuid NOT NULL,
+	"team_id" uuid NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "non_bdl_event_photo_player_tags" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"photo_id" uuid NOT NULL,
+	"player_id" uuid NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "non_bdl_event_teams" ADD CONSTRAINT "non_bdl_event_teams_event_id_non_bdl_events_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."non_bdl_events"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "non_bdl_event_attendees" ADD CONSTRAINT "non_bdl_event_attendees_event_id_non_bdl_events_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."non_bdl_events"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "non_bdl_event_attendees" ADD CONSTRAINT "non_bdl_event_attendees_player_id_players_id_fk" FOREIGN KEY ("player_id") REFERENCES "public"."players"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "non_bdl_event_attendees" ADD CONSTRAINT "non_bdl_event_attendees_team_id_non_bdl_event_teams_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."non_bdl_event_teams"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "non_bdl_event_stories" ADD CONSTRAINT "non_bdl_event_stories_event_id_non_bdl_events_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."non_bdl_events"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "non_bdl_event_story_team_tags" ADD CONSTRAINT "non_bdl_event_story_team_tags_story_id_non_bdl_event_stories_id_fk" FOREIGN KEY ("story_id") REFERENCES "public"."non_bdl_event_stories"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "non_bdl_event_story_team_tags" ADD CONSTRAINT "non_bdl_event_story_team_tags_team_id_non_bdl_event_teams_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."non_bdl_event_teams"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "non_bdl_event_story_player_tags" ADD CONSTRAINT "non_bdl_event_story_player_tags_story_id_non_bdl_event_stories_id_fk" FOREIGN KEY ("story_id") REFERENCES "public"."non_bdl_event_stories"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "non_bdl_event_story_player_tags" ADD CONSTRAINT "non_bdl_event_story_player_tags_player_id_players_id_fk" FOREIGN KEY ("player_id") REFERENCES "public"."players"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "non_bdl_event_photos" ADD CONSTRAINT "non_bdl_event_photos_event_id_non_bdl_events_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."non_bdl_events"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "non_bdl_event_photo_team_tags" ADD CONSTRAINT "non_bdl_event_photo_team_tags_photo_id_non_bdl_event_photos_id_fk" FOREIGN KEY ("photo_id") REFERENCES "public"."non_bdl_event_photos"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "non_bdl_event_photo_team_tags" ADD CONSTRAINT "non_bdl_event_photo_team_tags_team_id_non_bdl_event_teams_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."non_bdl_event_teams"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "non_bdl_event_photo_player_tags" ADD CONSTRAINT "non_bdl_event_photo_player_tags_photo_id_non_bdl_event_photos_id_fk" FOREIGN KEY ("photo_id") REFERENCES "public"."non_bdl_event_photos"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "non_bdl_event_photo_player_tags" ADD CONSTRAINT "non_bdl_event_photo_player_tags_player_id_players_id_fk" FOREIGN KEY ("player_id") REFERENCES "public"."players"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "non_bdl_events_event_date_idx" ON "non_bdl_events" USING btree ("event_date");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "non_bdl_event_teams_event_id_idx" ON "non_bdl_event_teams" USING btree ("event_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "non_bdl_event_attendees_event_player_uidx" ON "non_bdl_event_attendees" USING btree ("event_id","player_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "non_bdl_event_attendees_event_id_idx" ON "non_bdl_event_attendees" USING btree ("event_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "non_bdl_event_attendees_player_id_idx" ON "non_bdl_event_attendees" USING btree ("player_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "non_bdl_event_attendees_team_id_idx" ON "non_bdl_event_attendees" USING btree ("team_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "non_bdl_event_stories_event_id_idx" ON "non_bdl_event_stories" USING btree ("event_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "non_bdl_event_story_team_tags_uidx" ON "non_bdl_event_story_team_tags" USING btree ("story_id","team_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "non_bdl_event_story_team_tags_story_id_idx" ON "non_bdl_event_story_team_tags" USING btree ("story_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "non_bdl_event_story_player_tags_uidx" ON "non_bdl_event_story_player_tags" USING btree ("story_id","player_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "non_bdl_event_story_player_tags_story_id_idx" ON "non_bdl_event_story_player_tags" USING btree ("story_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "non_bdl_event_photos_event_id_idx" ON "non_bdl_event_photos" USING btree ("event_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "non_bdl_event_photo_team_tags_uidx" ON "non_bdl_event_photo_team_tags" USING btree ("photo_id","team_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "non_bdl_event_photo_team_tags_photo_id_idx" ON "non_bdl_event_photo_team_tags" USING btree ("photo_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "non_bdl_event_photo_player_tags_uidx" ON "non_bdl_event_photo_player_tags" USING btree ("photo_id","player_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "non_bdl_event_photo_player_tags_photo_id_idx" ON "non_bdl_event_photo_player_tags" USING btree ("photo_id");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1753301000000,
       "tag": "0012_event_ball_type_gender",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1753302000000,
+      "tag": "0013_non_bdl_events",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a separate **Non-BDL Events** domain (distinct from BDL draft/registration events) so staff can track travel tournaments and draft website content.

### Event fields
- Name, date, ball type (foam/cloth), division, city
- Host org: known home-league pick and/or free text
- Notes

### Related content
- External **teams** with free-text results (“how they did”)
- **Attendees** (BDL players) assigned to a team, with optional per-player notes
- **Stories** and **photos** attached to the event, each taggable to any number of teams and/or players
- Photos upload to Vercel Blob under `non-bdl-event-photos/{eventId}/…`
- Generated **good luck blurb** with copy-to-clipboard

### Admin UI
- TopNav: **Non-BDL Events**
- List + detail pages at `/non-bdl-events` and `/non-bdl-events/[id]`

### Data
- Migration `0013_non_bdl_events.sql`
- REST API under `/api/non-bdl-events/...`

Out of scope (as planned): publishing to the public website; structured W/L tables.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1205302a-9fae-40a4-a2f2-c59f1f457e90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1205302a-9fae-40a4-a2f2-c59f1f457e90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

