### PR TITLE
Rename Linear skill to Normal and add modal field visibility

### DIFF
--- a/.cursor/players-and-auth-runbook.md
+++ b/.cursor/players-and-auth-runbook.md
@@ -82,10 +82,10 @@ Sign in at `/login`. TopNav shows the signed-in email and Log out.
 - UI: `/players`
 - Import TeamLinkt CSV (dry run → commit). Matching: email, then first+last name.
 - Skill systems (independent per player):
-  - **Linear** (`skill_level`): 1–100 with anchors at 20 Beginner, 40 Intermediate, 60 Advanced, 80 Worlds level (`null` = Unset). Midpoints (e.g. 30, 50) are allowed. Legacy 1–4 values were migrated ×20.
+  - **Normal** (`skill_level`): 1–100 with anchors at 20 Beginner, 40 Intermediate, 60 Advanced, 80 Worlds level (`null` = Unset). Midpoints (e.g. 30, 50) are allowed. Legacy 1–4 values were migrated ×20.
   - **Fibonacci** (`skill_level_fib`): one of `1, 2, 3, 5, 8, 13, 21, 34, 55, 89` (or unset).
-  - **Skill areas** (`skill_areas` jsonb): offense, defense, staying alive, court presence/play calling — each on the linear scale; blank fields fall back to the main linear skill. Effective score = average of the four resolved values.
-- Players and event pages share a **Skill view** toggle (`localStorage` key `bdl-admin.skillViewMode`) so display, matrix, sorting, and draft balancing follow Linear / Fibonacci / Skill areas.
+  - **Skill areas** (`skill_areas` jsonb): offense, defense, staying alive, court presence/play calling — each on the normal scale; blank fields fall back to the main normal skill. Effective score = average of the four resolved values.
+- Players and event pages share a **Skill view** toggle (`localStorage` key `bdl-admin.skillViewMode`) so display, matrix, sorting, and draft balancing follow Normal / Fibonacci / Skill areas.
 - Gender: male / female / nonbinary / other (imported from TeamLinkt Gender column). List sorts female/nonbinary/other together for drafting. Birthdate from TeamLinkt is not stored or shown.
 - Import fills **linear** skill when the CSV has a Skill / Skill Level column (`2`/`Intermediate` → 40, `3`/`Advanced` → 60, etc.). Creates get the value; updates only set skill when the existing player is unset. Fibonacci and skill areas are not invented by import.
 - All writes audit to `player_changes` with `actor` = Google email and `source` = `admin` or `import`.

--- a/app/components/players/SkillFieldsEditor.tsx
+++ b/app/components/players/SkillFieldsEditor.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import {
   FIB_SKILL_LEVELS,
   LINEAR_SKILL_MAX,
@@ -81,6 +82,11 @@ export function skillFieldsToPatch(fields: SkillFieldsValue): {
   return { skillLevel, skillLevelFib, skillAreas }
 }
 
+function hasAlternateSkillData(value: SkillFieldsValue): boolean {
+  if (value.skillLevelFib !== '') return true
+  return SKILL_AREA_KEYS.some((key) => value.skillAreas[key] !== '')
+}
+
 export function SkillFieldsEditor(props: {
   value: SkillFieldsValue
   onChange: (next: SkillFieldsValue) => void
@@ -89,7 +95,14 @@ export function SkillFieldsEditor(props: {
 }) {
   const { value, onChange, disabled, idPrefix = 'skill' } = props
   const mainHint =
-    value.skillLevel !== '' ? value.skillLevel : 'main linear skill'
+    value.skillLevel !== '' ? value.skillLevel : 'main normal skill'
+  const [moreSystemsOpen, setMoreSystemsOpen] = useState(() =>
+    hasAlternateSkillData(value)
+  )
+
+  useEffect(() => {
+    if (hasAlternateSkillData(value)) setMoreSystemsOpen(true)
+  }, [value])
 
   return (
     <div className="space-y-3">
@@ -98,9 +111,9 @@ export function SkillFieldsEditor(props: {
           htmlFor={`${idPrefix}-linear`}
           className="mb-1 inline-flex items-center gap-1.5 text-sm font-medium text-gray-700"
         >
-          Linear skill (1–100)
+          Normal skill (1–100)
           <Tooltip
-            label="About linear skill"
+            label="About normal skill"
             content="Primary 1–100 rating used for drafting and filters. Presets map common labels (e.g. Intermediate) to a number."
           />
         </label>
@@ -121,7 +134,7 @@ export function SkillFieldsEditor(props: {
             className="rounded border border-gray-300 px-2 py-1.5 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
             value=""
             disabled={disabled}
-            aria-label="Set linear skill preset"
+            aria-label="Set normal skill preset"
             onChange={(e) => {
               if (!e.target.value) return
               onChange({ ...value, skillLevel: e.target.value })
@@ -140,71 +153,82 @@ export function SkillFieldsEditor(props: {
         </FieldHelp>
       </div>
 
-      <div>
-        <label
-          htmlFor={`${idPrefix}-fib`}
-          className="mb-1 inline-flex items-center gap-1.5 text-sm font-medium text-gray-700"
-        >
-          Fibonacci skill
-          <Tooltip
-            label="About Fibonacci skill"
-            content="Optional coarser skill scale (Fibonacci numbers). Used when Skill view is set to Fibonacci."
-          />
-        </label>
-        <select
-          id={`${idPrefix}-fib`}
-          className="rounded border border-gray-300 px-2 py-1.5 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
-          value={value.skillLevelFib}
-          disabled={disabled}
-          aria-describedby={`${idPrefix}-fib-help`}
-          onChange={(e) => onChange({ ...value, skillLevelFib: e.target.value })}
-        >
-          <option value="">Unset</option>
-          {FIB_SKILL_LEVELS.map((v) => (
-            <option key={v} value={v}>
-              {v}
-            </option>
-          ))}
-        </select>
-        <FieldHelp id={`${idPrefix}-fib-help`}>
-          Leave unset if you only track linear skill.
-        </FieldHelp>
-      </div>
-
-      <fieldset className="rounded border border-gray-200 p-3">
-        <legend className="inline-flex items-center gap-1.5 px-1 text-sm font-medium text-gray-700">
-          Skill areas
-          <Tooltip
-            label="About skill areas"
-            content="Break out offense, defense, staying alive, and court presence. Blank areas fall back to the main linear skill."
-          />
-        </legend>
-        <FieldHelp className="mb-2 mt-0">
-          Leave blank to use the main linear skill ({mainHint}).
-        </FieldHelp>
-        <div className="grid gap-2 sm:grid-cols-2">
-          {SKILL_AREA_KEYS.map((key) => (
-            <label key={key} className="block text-sm text-gray-700">
-              <span className="mb-1 block">{SKILL_AREA_LABELS[key]}</span>
-              <input
-                type="number"
-                min={LINEAR_SKILL_MIN}
-                max={LINEAR_SKILL_MAX}
-                className="w-full rounded border border-gray-300 px-2 py-1.5 text-sm"
-                value={value.skillAreas[key]}
-                disabled={disabled}
-                placeholder={`Default: ${mainHint}`}
-                onChange={(e) =>
-                  onChange({
-                    ...value,
-                    skillAreas: { ...value.skillAreas, [key]: e.target.value },
-                  })
-                }
+      <details
+        open={moreSystemsOpen}
+        onToggle={(e) => setMoreSystemsOpen(e.currentTarget.open)}
+        className="rounded border border-gray-200"
+      >
+        <summary className="cursor-pointer px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50">
+          More skill systems
+        </summary>
+        <div className="space-y-3 border-t border-gray-200 px-3 py-3">
+          <div>
+            <label
+              htmlFor={`${idPrefix}-fib`}
+              className="mb-1 inline-flex items-center gap-1.5 text-sm font-medium text-gray-700"
+            >
+              Fibonacci skill
+              <Tooltip
+                label="About Fibonacci skill"
+                content="Optional coarser skill scale (Fibonacci numbers). Used when Skill view is set to Fibonacci."
               />
             </label>
-          ))}
+            <select
+              id={`${idPrefix}-fib`}
+              className="rounded border border-gray-300 px-2 py-1.5 text-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+              value={value.skillLevelFib}
+              disabled={disabled}
+              aria-describedby={`${idPrefix}-fib-help`}
+              onChange={(e) => onChange({ ...value, skillLevelFib: e.target.value })}
+            >
+              <option value="">Unset</option>
+              {FIB_SKILL_LEVELS.map((v) => (
+                <option key={v} value={v}>
+                  {v}
+                </option>
+              ))}
+            </select>
+            <FieldHelp id={`${idPrefix}-fib-help`}>
+              Leave unset if you only track normal skill.
+            </FieldHelp>
+          </div>
+
+          <fieldset className="rounded border border-gray-200 p-3">
+            <legend className="inline-flex items-center gap-1.5 px-1 text-sm font-medium text-gray-700">
+              Skill areas
+              <Tooltip
+                label="About skill areas"
+                content="Break out offense, defense, staying alive, and court presence. Blank areas fall back to the main normal skill."
+              />
+            </legend>
+            <FieldHelp className="mb-2 mt-0">
+              Leave blank to use the main normal skill ({mainHint}).
+            </FieldHelp>
+            <div className="grid gap-2 sm:grid-cols-2">
+              {SKILL_AREA_KEYS.map((key) => (
+                <label key={key} className="block text-sm text-gray-700">
+                  <span className="mb-1 block">{SKILL_AREA_LABELS[key]}</span>
+                  <input
+                    type="number"
+                    min={LINEAR_SKILL_MIN}
+                    max={LINEAR_SKILL_MAX}
+                    className="w-full rounded border border-gray-300 px-2 py-1.5 text-sm"
+                    value={value.skillAreas[key]}
+                    disabled={disabled}
+                    placeholder={`Default: ${mainHint}`}
+                    onChange={(e) =>
+                      onChange({
+                        ...value,
+                        skillAreas: { ...value.skillAreas, [key]: e.target.value },
+                      })
+                    }
+                  />
+                </label>
+              ))}
+            </div>
+          </fieldset>
         </div>
-      </fieldset>
+      </details>
     </div>
   )
 }

--- a/app/hooks/useSkillViewMode.tsx
+++ b/app/hooks/useSkillViewMode.tsx
@@ -53,7 +53,7 @@ export function SkillViewModeToggle(props: {
         Skill view
         <Tooltip
           label="About skill view"
-          content="Controls how skill is shown in lists and drafts: Linear (1–100), Fibonacci, or by skill area when set."
+          content="Controls how skill is shown in lists and drafts: Normal (1–100), Fibonacci, or by skill area when set."
         />
       </span>
       <select

--- a/app/lib/players/skill.ts
+++ b/app/lib/players/skill.ts
@@ -46,7 +46,7 @@ export const SKILL_VIEW_MODES: readonly SkillViewMode[] = [
 ] as const
 
 export const SKILL_VIEW_MODE_LABELS: Record<SkillViewMode, string> = {
-  linear: 'Linear',
+  linear: 'Normal',
   fibonacci: 'Fibonacci',
   areas: 'Skill areas',
 }

--- a/app/players/__tests__/page.test.tsx
+++ b/app/players/__tests__/page.test.tsx
@@ -445,7 +445,9 @@ describe('PlayersPage home leagues', () => {
 
     await screen.findByText('1 player')
     await userEvent.click(screen.getByRole('button', { name: 'Edit' }))
-    expect(screen.getByText('Home leagues')).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: 'Fields' }))
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Home leagues' }))
+    expect(screen.getByRole('heading', { name: 'Home leagues' })).toBeInTheDocument()
 
     await userEvent.selectOptions(
       screen.getByDisplayValue('Select home league'),

--- a/app/players/page.tsx
+++ b/app/players/page.tsx
@@ -331,6 +331,55 @@ function loadVisibleColumns(): Record<ColumnKey, boolean> {
   }
 }
 
+type ModalFieldKey =
+  | 'skill'
+  | 'roster'
+  | 'photo'
+  | 'name'
+  | 'flags'
+  | 'emails'
+  | 'aliases'
+  | 'homeLeagues'
+
+const MODAL_FIELD_OPTIONS: { key: ModalFieldKey; label: string }[] = [
+  { key: 'skill', label: 'Skill systems' },
+  { key: 'roster', label: 'Roster' },
+  { key: 'photo', label: 'Photo' },
+  { key: 'name', label: 'Name' },
+  { key: 'flags', label: 'Flags' },
+  { key: 'emails', label: 'Emails' },
+  { key: 'aliases', label: 'Alternate names' },
+  { key: 'homeLeagues', label: 'Home leagues' },
+]
+
+const DEFAULT_VISIBLE_MODAL_FIELDS: Record<ModalFieldKey, boolean> = {
+  skill: true,
+  roster: true,
+  photo: false,
+  name: true,
+  flags: true,
+  emails: true,
+  aliases: false,
+  homeLeagues: false,
+}
+
+const MODAL_FIELDS_STORAGE_KEY = 'bdl-admin.players.visibleModalFields'
+
+function loadVisibleModalFields(): Record<ModalFieldKey, boolean> {
+  if (typeof window === 'undefined') return { ...DEFAULT_VISIBLE_MODAL_FIELDS }
+  try {
+    const raw = window.localStorage.getItem(MODAL_FIELDS_STORAGE_KEY)
+    if (!raw) return { ...DEFAULT_VISIBLE_MODAL_FIELDS }
+    const parsed = JSON.parse(raw) as Partial<Record<ModalFieldKey, boolean>>
+    return {
+      ...DEFAULT_VISIBLE_MODAL_FIELDS,
+      ...parsed,
+    }
+  } catch {
+    return { ...DEFAULT_VISIBLE_MODAL_FIELDS }
+  }
+}
+
 function compareByLastName(a: PlayerListItem, b: PlayerListItem): number {
   const last = a.lastName.localeCompare(b.lastName, undefined, { sensitivity: 'base' })
   if (last !== 0) return last
@@ -2230,6 +2279,26 @@ function EditPanel(props: {
   const [newEmail, setNewEmail] = useState('')
   const [newAlias, setNewAlias] = useState('')
   const [newHomeLeague, setNewHomeLeague] = useState('')
+  const [visibleFields, setVisibleFields] = useState<Record<ModalFieldKey, boolean>>(
+    DEFAULT_VISIBLE_MODAL_FIELDS
+  )
+  const [fieldsOpen, setFieldsOpen] = useState(false)
+
+  useEffect(() => {
+    setVisibleFields(loadVisibleModalFields())
+  }, [])
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(MODAL_FIELDS_STORAGE_KEY, JSON.stringify(visibleFields))
+    } catch {
+      // ignore storage errors
+    }
+  }, [visibleFields])
+
+  function toggleModalField(key: ModalFieldKey) {
+    setVisibleFields((prev) => ({ ...prev, [key]: !prev[key] }))
+  }
 
   useEffect(() => {
     setFirstName(p.firstName)
@@ -2265,7 +2334,40 @@ function EditPanel(props: {
   return (
     <Dialog open onClose={props.onClose} title="Edit player" className="max-w-xl">
       <div className="space-y-4 text-gray-900">
-        <div className="flex justify-end">
+        <div className="flex items-center justify-between gap-4">
+          <div className="relative">
+            <button
+              type="button"
+              onClick={() => setFieldsOpen((open) => !open)}
+              className="rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-800 hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+            >
+              Fields
+            </button>
+            {fieldsOpen ? (
+              <div className="absolute left-0 top-full z-20 mt-1 w-52 rounded border border-gray-200 bg-white p-2 shadow-lg">
+                {MODAL_FIELD_OPTIONS.map((field) => (
+                  <label
+                    key={field.key}
+                    className="flex items-center gap-2 rounded px-1 py-1 text-sm text-gray-900 hover:bg-gray-50"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={visibleFields[field.key]}
+                      onChange={() => toggleModalField(field.key)}
+                    />
+                    {field.label}
+                  </label>
+                ))}
+                <button
+                  type="button"
+                  className="mt-1 w-full rounded px-1 py-1 text-left text-xs text-blue-700 hover:bg-blue-50"
+                  onClick={() => setVisibleFields({ ...DEFAULT_VISIBLE_MODAL_FIELDS })}
+                >
+                  Reset defaults
+                </button>
+              </div>
+            ) : null}
+          </div>
           <button
             type="button"
             className="text-sm text-gray-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
@@ -2306,6 +2408,7 @@ function EditPanel(props: {
           </div>
         ) : null}
 
+        {visibleFields.skill ? (
         <div className="space-y-2">
           <h3 className="font-medium text-sm">Skill systems</h3>
           <SkillFieldsEditor
@@ -2315,7 +2418,9 @@ function EditPanel(props: {
             idPrefix="edit-skill"
           />
         </div>
+        ) : null}
 
+        {visibleFields.roster ? (
         <div className="space-y-2">
           <h3 className="font-medium text-sm">Roster</h3>
           <div className="grid grid-cols-2 gap-3">
@@ -2362,7 +2467,9 @@ function EditPanel(props: {
             </label>
           </div>
         </div>
+        ) : null}
 
+        {visibleFields.photo ? (
         <div className="border-t pt-4 space-y-2">
           <h3 className="font-medium text-sm">Photo</h3>
           <div className="flex items-center gap-4">
@@ -2399,7 +2506,9 @@ function EditPanel(props: {
             </div>
           </div>
         </div>
+        ) : null}
 
+        {visibleFields.name ? (
         <div className="border-t pt-4 space-y-2">
           <h3 className="font-medium text-sm">Name</h3>
           <div className="grid grid-cols-2 gap-3">
@@ -2448,7 +2557,9 @@ function EditPanel(props: {
             </label>
           </div>
         </div>
+        ) : null}
 
+        {visibleFields.flags ? (
         <div className="border-t pt-4 space-y-2">
           <h3 className="font-medium text-sm">Flags</h3>
           <div className="rounded border border-amber-200 bg-amber-50/50 px-3 py-2">
@@ -2495,6 +2606,7 @@ function EditPanel(props: {
             </label>
           ) : null}
         </div>
+        ) : null}
 
         {!p.isMerged ? (
           <button
@@ -2523,6 +2635,7 @@ function EditPanel(props: {
           </button>
         ) : null}
 
+        {visibleFields.emails ? (
         <div className="border-t pt-4 space-y-2">
           <h3 className="font-medium text-sm">Emails</h3>
           <ul className="space-y-1 text-sm">
@@ -2579,7 +2692,9 @@ function EditPanel(props: {
             </div>
           ) : null}
         </div>
+        ) : null}
 
+        {visibleFields.aliases ? (
         <div className="border-t pt-4 space-y-2">
           <h3 className="font-medium text-sm">Alternate names</h3>
           <ul className="space-y-1 text-sm">
@@ -2623,7 +2738,9 @@ function EditPanel(props: {
             </div>
           ) : null}
         </div>
+        ) : null}
 
+        {visibleFields.homeLeagues ? (
         <div className="border-t pt-4 space-y-2">
           <h3 className="font-medium text-sm">Home leagues</h3>
           <FieldHelp id="edit-home-leagues-help">
@@ -2706,9 +2823,10 @@ function EditPanel(props: {
             </div>
           ) : null}
         </div>
+        ) : null}
 
         <p className="text-xs text-gray-500">
-          Linear: {effectiveSkillLabel(p, 'linear')} · Fib:{' '}
+          Normal: {effectiveSkillLabel(p, 'linear')} · Fib:{' '}
           {effectiveSkillLabel(p, 'fibonacci')} · Areas:{' '}
           {effectiveSkillLabel(p, 'areas')}
         </p>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Renames user-facing "Linear" skill labels to "Normal" while keeping the internal `linear` value and database column unchanged. Collapses Fibonacci and skill areas behind an expandable disclosure in the player form. Adds a Fields control to the edit player modal so sections can be shown or hidden, with preferences persisted in localStorage.

## Changes

- **Normal skill naming**: Skill view dropdown, editor labels, tooltips, edit modal footer, and runbook now say "Normal" instead of "Linear"
- **Collapsed skill systems**: `SkillFieldsEditor` shows Normal skill by default; Fibonacci and skill areas are behind a "More skill systems" disclosure that auto-opens when alternate data exists
- **Modal field visibility**: Edit player modal has a Fields dropdown (mirroring the list Columns control) with toggles for skill, roster, photo, name, flags, emails, aliases, and home leagues; defaults hide photo, aliases, and home leagues

## Test plan

- [x] Player page tests pass, including updated home leagues test that enables the field via Fields
- [ ] Open edit player modal and verify Fields dropdown toggles sections
- [ ] Confirm Fibonacci/areas disclosure auto-opens for players with those values set
- [ ] Confirm Skill view dropdown shows "Normal" instead of "Linear"
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14cf1991-ef9b-46d0-9272-1dc8ea274208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14cf1991-ef9b-46d0-9272-1dc8ea274208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

