### PR TITLE
Default Cursor agent PRs to preview branch

### DIFF
--- a/.cursor/git-pr-workflow.md
+++ b/.cursor/git-pr-workflow.md
@@ -33,6 +33,10 @@ update_pr: base_branch = "preview"  # when retargeting a mis-aimed PR
 
 Only set `base_branch: "main"` when opening the production promotion PR (`preview` → `main`).
 
+## Cloud Agents dashboard
+
+Set **Base branch** to `preview` in [Cloud Agents → Default settings](https://cursor.com/dashboard/cloud-agents) for this repo. When blank, Cursor uses the GitHub repository default branch.
+
 ## Related files
 
 - [.github/pull_request_template.md](../.github/pull_request_template.md) — PR checklist

--- a/.cursor/git-pr-workflow.md
+++ b/.cursor/git-pr-workflow.md
@@ -1,0 +1,41 @@
+# Git branches and pull requests
+
+Use this when opening PRs, choosing a base branch, or promoting to production.
+
+## Default: target `preview`
+
+| PR type | Head branch | Base branch |
+|---------|-------------|-------------|
+| Feature / fix | `cursor/<name>-4208` or your topic branch | **`preview`** |
+| Production promote | `preview` | `main` |
+
+**Do not** open feature PRs against `main`. CI **Main merge gate** rejects any PR into `main` whose head is not `preview`.
+
+## Deploy flow
+
+1. Branch from `preview` (or merge latest `preview` into your branch).
+2. Open PR **into `preview`**.
+3. Merge → Vercel deploys [admin-preview](https://admin-preview.bostondodgeballleague.com).
+4. CI **Preview smoke** checks `/login`, `/players`, `/events` (or run `npm run smoke:preview` locally).
+5. When preview is good, open **`preview` → `main`**.
+6. Merge to `main` → production at [admin](https://admin.bostondodgeballleague.com).
+
+If `preview` is behind `main`, fast-forward or merge `main` into `preview` before new feature work.
+
+## Agent / Cloud instructions
+
+When using `ManagePullRequest`:
+
+```text
+create_pr: base_branch = "preview"   # default for feature/fix work
+update_pr: base_branch = "preview"  # when retargeting a mis-aimed PR
+```
+
+Only set `base_branch: "main"` when opening the production promotion PR (`preview` → `main`).
+
+## Related files
+
+- [.github/pull_request_template.md](../.github/pull_request_template.md) — PR checklist
+- [.github/workflows/main-merge-gate.yml](../.github/workflows/main-merge-gate.yml) — enforces preview-only merges to main
+- [.github/workflows/preview-smoke.yml](../.github/workflows/preview-smoke.yml) — post-merge preview health check
+- [.cursor/players-and-auth-runbook.md](./players-and-auth-runbook.md) — environment hosts and auth

--- a/.cursor/rules/git-pr-workflow.mdc
+++ b/.cursor/rules/git-pr-workflow.mdc
@@ -1,0 +1,15 @@
+---
+description: Pull request base branch and preview-to-main deploy promotion flow
+alwaysApply: true
+---
+
+# Pull requests and deploy flow
+
+**Default base branch for new PRs is `preview`, not `main`.**
+
+- Open feature and fix PRs against **`preview`**. Merge there first; Vercel deploys `admin-preview.bostondodgeballleague.com`.
+- When creating or updating PRs (`ManagePullRequest`, `gh pr create`, etc.), pass **`base_branch: "preview"`** unless you are explicitly promoting preview to production.
+- **Production promote only:** open **`preview` → `main`** after preview deploy and Preview smoke are healthy. The **Main merge gate** requires the head branch to be exactly `preview`; any other head into `main` fails CI.
+- If `preview` has fallen behind `main`, merge or fast-forward `main` into `preview` before landing new work.
+
+Full details: [.cursor/git-pr-workflow.md](.cursor/git-pr-workflow.md), [.github/pull_request_template.md](.github/pull_request_template.md).

--- a/.cursor/rules/git-pr-workflow.mdc
+++ b/.cursor/rules/git-pr-workflow.mdc
@@ -12,4 +12,6 @@ alwaysApply: true
 - **Production promote only:** open **`preview` → `main`** after preview deploy and Preview smoke are healthy. The **Main merge gate** requires the head branch to be exactly `preview`; any other head into `main` fails CI.
 - If `preview` has fallen behind `main`, merge or fast-forward `main` into `preview` before landing new work.
 
-Full details: [.cursor/git-pr-workflow.md](.cursor/git-pr-workflow.md), [.github/pull_request_template.md](.github/pull_request_template.md).
+**Cloud Agents dashboard:** In [Cloud Agents → Default settings](https://cursor.com/dashboard/cloud-agents), set **Base branch** to `preview` for this repository (or leave blank if the GitHub default branch is `preview`).
+
+Full details: [.cursor/git-pr-workflow.md](.cursor/git-pr-workflow.md), [.github/pull_request_template.md](.github/pull_request_template.md), [AGENTS.md](AGENTS.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Agent instructions
+
+## Cursor Cloud specific instructions
+
+This repo uses a **preview-first** deploy flow. Production merges go `preview` → `main` only after preview is verified.
+
+### Pull requests (required)
+
+- **Default base branch for new PRs: `preview`** (not `main`).
+- When creating or updating pull requests (`ManagePullRequest`, `gh pr create`, etc.), always pass **`base_branch: "preview"`** unless you are explicitly opening a production promotion PR (`preview` → `main`).
+- Feature and fix branches should merge into `preview` first. CI **Main merge gate** fails if a PR into `main` has any head branch other than `preview`.
+
+### Branches
+
+- Integration / preview deploy: `preview` → `admin-preview.bostondodgeballleague.com`
+- Production: `main` → `admin.bostondodgeballleague.com`
+- Cloud agent feature branches: `cursor/<descriptive-name>-4208` (or your topic branch), opened against **`preview`**.
+
+### More detail
+
+- [.cursor/git-pr-workflow.md](.cursor/git-pr-workflow.md)
+- [.github/pull_request_template.md](.github/pull_request_template.md)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Configures Cursor agents to default new pull requests to the `preview` branch instead of `main`, matching the repo's deploy flow and avoiding Main merge gate failures.

## Changes

- **`.cursor/rules/git-pr-workflow.mdc`** — always-applied rule: feature/fix PRs target `preview`; only `preview` → `main` for production promote
- **`.cursor/git-pr-workflow.md`** — detailed runbook with branch table, deploy steps, and dashboard link
- **`AGENTS.md`** — Cursor Cloud instructions: default PR base branch is `preview`, with explicit `ManagePullRequest` guidance

## Manual step (repo admin)

Cloud Agents **Base branch** is a dashboard setting Cursor cannot change from the repo. In [Cloud Agents → Default settings](https://cursor.com/dashboard/cloud-agents), set **Base branch** to `preview` for `bdl-admin`. Optionally set GitHub's default branch to `preview` so blank dashboard settings also resolve correctly.

## Context

PR #116 failed Main merge gate because it targeted `main` directly. This PR adds in-repo agent instructions; the dashboard change completes the fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14cf1991-ef9b-46d0-9272-1dc8ea274208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14cf1991-ef9b-46d0-9272-1dc8ea274208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

