### PR TITLE
Promote preview to main: Team Video Tools

### DIFF
--- a/.cursor/video-tools-runbook.md
+++ b/.cursor/video-tools-runbook.md
@@ -1,0 +1,21 @@
+# Video Tools (bdl-admin)
+
+Team UI for concurrent GoPro upload sets (e.g. Court 1 + Court 2) and cloud merge.
+
+## App env (Vercel / `.env.local`)
+
+| Variable | Purpose |
+|----------|---------|
+| `BLOB_READ_WRITE_TOKEN` | Already used for player/event photos; required for client video uploads |
+| `VIDEO_WORKER_SECRET` | Shared bearer secret for `/api/video-tools/worker/*` |
+
+## Worker env
+
+See [`workers/video-merge/README.md`](../workers/video-merge/README.md).
+
+## Flow
+
+1. **Video Tools** → New upload set (event name, date, label)
+2. Upload MP4s (multipart client → Vercel Blob)
+3. **Start merge** → status `queued`
+4. Worker claims job → ffmpeg concat → uploads `_untrimmed.MP4` → `complete`

--- a/app/api/video-tools/sets/[id]/cancel-upload/route.ts
+++ b/app/api/video-tools/sets/[id]/cancel-upload/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import { cancelPendingClipUpload } from '@/app/lib/video-tools/mutations'
+import { getVideoUploadSet } from '@/app/lib/video-tools/queries'
+
+type RouteContext = { params: Promise<{ id: string }> }
+
+/**
+ * Decrement pending_upload_count after an abandoned/failed client upload.
+ * Safe to call more than once (floors at 0).
+ */
+export async function POST(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id: setId } = await context.params
+    const set = await getVideoUploadSet(setId)
+    if (!set) {
+      return NextResponse.json({ error: 'Upload set not found' }, { status: 404 })
+    }
+
+    await cancelPendingClipUpload(setId)
+    const refreshed = await getVideoUploadSet(setId)
+    return NextResponse.json({ set: refreshed })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to cancel pending upload'
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+}

--- a/app/api/video-tools/sets/[id]/clips/route.ts
+++ b/app/api/video-tools/sets/[id]/clips/route.ts
@@ -6,6 +6,7 @@ import {
 import { recordUploadedClip } from '@/app/lib/video-tools/mutations'
 import { getVideoUploadSet } from '@/app/lib/video-tools/queries'
 import { VIDEO_TOOLS_BLOB_PREFIX } from '@/app/lib/video-tools/naming'
+import { assertSafeVideoClipBlobUrl } from '@/app/lib/video-tools/blob-url'
 
 type RouteContext = { params: Promise<{ id: string }> }
 
@@ -42,6 +43,14 @@ export async function POST(request: NextRequest, context: RouteContext) {
       return NextResponse.json({ error: 'Invalid pathname for this set' }, { status: 400 })
     }
 
+    let safeBlobUrl: string
+    try {
+      safeBlobUrl = assertSafeVideoClipBlobUrl(body.blobUrl, body.pathname)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Invalid blobUrl'
+      return NextResponse.json({ error: message }, { status: 400 })
+    }
+
     const set = await getVideoUploadSet(setId)
     if (!set) {
       return NextResponse.json({ error: 'Upload set not found' }, { status: 404 })
@@ -51,7 +60,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
     const clip = await recordUploadedClip({
       setId,
       originalFilename: body.originalFilename,
-      blobUrl: body.blobUrl,
+      blobUrl: safeBlobUrl,
       pathname: body.pathname,
       sizeBytes: body.sizeBytes ?? 0,
     })

--- a/app/api/video-tools/sets/[id]/clips/route.ts
+++ b/app/api/video-tools/sets/[id]/clips/route.ts
@@ -45,7 +45,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
 
     let safeBlobUrl: string
     try {
-      safeBlobUrl = assertSafeVideoClipBlobUrl(body.blobUrl, body.pathname)
+      safeBlobUrl = assertSafeVideoClipBlobUrl(body.blobUrl, body.pathname, setId)
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Invalid blobUrl'
       return NextResponse.json({ error: message }, { status: 400 })

--- a/app/api/video-tools/sets/[id]/clips/route.ts
+++ b/app/api/video-tools/sets/[id]/clips/route.ts
@@ -6,9 +6,6 @@ import {
 import { recordUploadedClip } from '@/app/lib/video-tools/mutations'
 import { getVideoUploadSet } from '@/app/lib/video-tools/queries'
 import { VIDEO_TOOLS_BLOB_PREFIX } from '@/app/lib/video-tools/naming'
-import { getDb } from '@/app/lib/db'
-import { videoUploadClips } from '@/app/db/schema'
-import { eq } from 'drizzle-orm'
 
 type RouteContext = { params: Promise<{ id: string }> }
 
@@ -50,18 +47,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
       return NextResponse.json({ error: 'Upload set not found' }, { status: 404 })
     }
 
-    const db = getDb()
-    const [existing] = await db
-      .select()
-      .from(videoUploadClips)
-      .where(eq(videoUploadClips.pathname, body.pathname))
-      .limit(1)
-
-    if (existing) {
-      const refreshed = await getVideoUploadSet(setId)
-      return NextResponse.json({ set: refreshed, clipId: existing.id })
-    }
-
+    // recordUploadedClip is idempotent on pathname (client + Blob webhook race).
     const clip = await recordUploadedClip({
       setId,
       originalFilename: body.originalFilename,

--- a/app/api/video-tools/sets/[id]/clips/route.ts
+++ b/app/api/video-tools/sets/[id]/clips/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import { recordUploadedClip } from '@/app/lib/video-tools/mutations'
+import { getVideoUploadSet } from '@/app/lib/video-tools/queries'
+import { VIDEO_TOOLS_BLOB_PREFIX } from '@/app/lib/video-tools/naming'
+import { getDb } from '@/app/lib/db'
+import { videoUploadClips } from '@/app/db/schema'
+import { eq } from 'drizzle-orm'
+
+type RouteContext = { params: Promise<{ id: string }> }
+
+/**
+ * Register a clip after a client Blob upload completes.
+ * Needed on localhost (Blob onUploadCompleted webhook does not fire locally)
+ * and as an idempotent fallback in production.
+ */
+export async function POST(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id: setId } = await context.params
+    const body = (await request.json()) as {
+      originalFilename?: string
+      blobUrl?: string
+      pathname?: string
+      sizeBytes?: number
+    }
+
+    if (!body.originalFilename?.trim()) {
+      return NextResponse.json({ error: 'originalFilename is required' }, { status: 400 })
+    }
+    if (!body.blobUrl?.trim()) {
+      return NextResponse.json({ error: 'blobUrl is required' }, { status: 400 })
+    }
+    if (!body.pathname?.trim()) {
+      return NextResponse.json({ error: 'pathname is required' }, { status: 400 })
+    }
+
+    const expectedPrefix = `${VIDEO_TOOLS_BLOB_PREFIX}${setId}/clips/`
+    if (!body.pathname.startsWith(expectedPrefix)) {
+      return NextResponse.json({ error: 'Invalid pathname for this set' }, { status: 400 })
+    }
+
+    const set = await getVideoUploadSet(setId)
+    if (!set) {
+      return NextResponse.json({ error: 'Upload set not found' }, { status: 404 })
+    }
+
+    const db = getDb()
+    const [existing] = await db
+      .select()
+      .from(videoUploadClips)
+      .where(eq(videoUploadClips.pathname, body.pathname))
+      .limit(1)
+
+    if (existing) {
+      const refreshed = await getVideoUploadSet(setId)
+      return NextResponse.json({ set: refreshed, clipId: existing.id })
+    }
+
+    const clip = await recordUploadedClip({
+      setId,
+      originalFilename: body.originalFilename,
+      blobUrl: body.blobUrl,
+      pathname: body.pathname,
+      sizeBytes: body.sizeBytes ?? 0,
+    })
+
+    const refreshed = await getVideoUploadSet(setId)
+    return NextResponse.json({ set: refreshed, clipId: clip.id }, { status: 201 })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to register clip'
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+}

--- a/app/api/video-tools/sets/[id]/enqueue/route.ts
+++ b/app/api/video-tools/sets/[id]/enqueue/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import { enqueueVideoUploadSet } from '@/app/lib/video-tools/mutations'
+import { getVideoUploadSet } from '@/app/lib/video-tools/queries'
+
+type RouteContext = { params: Promise<{ id: string }> }
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id } = await context.params
+    await enqueueVideoUploadSet(id)
+    const set = await getVideoUploadSet(id)
+    return NextResponse.json({ set })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to enqueue upload set'
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+}

--- a/app/api/video-tools/sets/[id]/route.ts
+++ b/app/api/video-tools/sets/[id]/route.ts
@@ -3,7 +3,7 @@ import {
   adminUnauthorizedResponse,
   getAdminSessionFromRequest,
 } from '@/app/lib/admin-auth'
-import { markSetReady } from '@/app/lib/video-tools/mutations'
+import { markSetReady, resetPendingUploads } from '@/app/lib/video-tools/mutations'
 import { getVideoUploadSet } from '@/app/lib/video-tools/queries'
 
 type RouteContext = { params: Promise<{ id: string }> }
@@ -35,6 +35,12 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
 
     if (body.action === 'mark_ready') {
       const updated = await markSetReady(id)
+      const set = await getVideoUploadSet(updated.id)
+      return NextResponse.json({ set })
+    }
+
+    if (body.action === 'reset_pending_uploads') {
+      const updated = await resetPendingUploads(id)
       const set = await getVideoUploadSet(updated.id)
       return NextResponse.json({ set })
     }

--- a/app/api/video-tools/sets/[id]/route.ts
+++ b/app/api/video-tools/sets/[id]/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import { markSetReady } from '@/app/lib/video-tools/mutations'
+import { getVideoUploadSet } from '@/app/lib/video-tools/queries'
+
+type RouteContext = { params: Promise<{ id: string }> }
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id } = await context.params
+    const set = await getVideoUploadSet(id)
+    if (!set) {
+      return NextResponse.json({ error: 'Upload set not found' }, { status: 404 })
+    }
+    return NextResponse.json({ set })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to load upload set'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id } = await context.params
+    const body = (await request.json()) as { action?: string }
+
+    if (body.action === 'mark_ready') {
+      const updated = await markSetReady(id)
+      const set = await getVideoUploadSet(updated.id)
+      return NextResponse.json({ set })
+    }
+
+    return NextResponse.json({ error: 'Unknown action' }, { status: 400 })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to update upload set'
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+}

--- a/app/api/video-tools/sets/route.ts
+++ b/app/api/video-tools/sets/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import { createVideoUploadSet } from '@/app/lib/video-tools/mutations'
+import { listVideoUploadSets } from '@/app/lib/video-tools/queries'
+
+export async function GET(request: NextRequest) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const sets = await listVideoUploadSets()
+    return NextResponse.json({ sets })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to list upload sets'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const body = (await request.json()) as {
+      eventName?: string
+      label?: string
+      eventDate?: string
+    }
+
+    if (!body.eventName?.trim()) {
+      return NextResponse.json({ error: 'eventName is required' }, { status: 400 })
+    }
+    if (!body.label?.trim()) {
+      return NextResponse.json({ error: 'label is required' }, { status: 400 })
+    }
+    if (!body.eventDate?.trim()) {
+      return NextResponse.json({ error: 'eventDate is required' }, { status: 400 })
+    }
+
+    const set = await createVideoUploadSet({
+      eventName: body.eventName,
+      label: body.label,
+      eventDate: body.eventDate,
+      createdByEmail: session.email,
+    })
+
+    return NextResponse.json({ set }, { status: 201 })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to create upload set'
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+}

--- a/app/api/video-tools/upload/route.ts
+++ b/app/api/video-tools/upload/route.ts
@@ -1,0 +1,102 @@
+import { handleUpload, type HandleUploadBody } from '@vercel/blob/client'
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import { recordUploadedClip } from '@/app/lib/video-tools/mutations'
+import { getVideoUploadSet } from '@/app/lib/video-tools/queries'
+import { VIDEO_TOOLS_BLOB_PREFIX } from '@/app/lib/video-tools/naming'
+
+/**
+ * Client upload token exchange + completion webhook for video clips.
+ * Auth is enforced in onBeforeGenerateToken (admin session).
+ * Middleware allows this path so Vercel Blob completion callbacks can land.
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const body = (await request.json()) as HandleUploadBody
+
+  try {
+    const jsonResponse = await handleUpload({
+      body,
+      request,
+      onBeforeGenerateToken: async (pathname, clientPayload) => {
+        const session = getAdminSessionFromRequest(request)
+        if (!session) {
+          throw new Error('Unauthorized')
+        }
+
+        let setId: string | null = null
+        let originalFilename: string | null = null
+        try {
+          const payload = clientPayload
+            ? (JSON.parse(clientPayload) as {
+                setId?: string
+                originalFilename?: string
+              })
+            : {}
+          setId = payload.setId?.trim() || null
+          originalFilename = payload.originalFilename?.trim() || null
+        } catch {
+          throw new Error('Invalid client payload')
+        }
+
+        if (!setId) throw new Error('setId is required')
+        if (!originalFilename) throw new Error('originalFilename is required')
+
+        const set = await getVideoUploadSet(setId)
+        if (!set) throw new Error('Upload set not found')
+        if (['queued', 'processing', 'complete'].includes(set.status)) {
+          throw new Error(`Cannot upload clips while set is ${set.status}`)
+        }
+
+        const expectedPrefix = `${VIDEO_TOOLS_BLOB_PREFIX}${setId}/clips/`
+        if (!pathname.startsWith(expectedPrefix)) {
+          throw new Error('Invalid upload pathname')
+        }
+
+        return {
+          allowedContentTypes: [
+            'video/mp4',
+            'video/quicktime',
+            'application/octet-stream',
+          ],
+          maximumSizeInBytes: 20 * 1024 * 1024 * 1024, // 20 GB per clip
+          tokenPayload: JSON.stringify({
+            setId,
+            originalFilename,
+            actor: session.email,
+          }),
+          addRandomSuffix: false,
+        }
+      },
+      onUploadCompleted: async ({ blob, tokenPayload }) => {
+        const payload = tokenPayload
+          ? (JSON.parse(tokenPayload) as {
+              setId?: string
+              originalFilename?: string
+            })
+          : {}
+        if (!payload.setId || !payload.originalFilename) {
+          throw new Error('Missing token payload for clip record')
+        }
+
+        await recordUploadedClip({
+          setId: payload.setId,
+          originalFilename: payload.originalFilename,
+          blobUrl: blob.url,
+          pathname: blob.pathname,
+          sizeBytes: 0,
+        })
+      },
+    })
+
+    return NextResponse.json(jsonResponse)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Upload failed'
+    if (message === 'Unauthorized') {
+      return adminUnauthorizedResponse()
+    }
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+}

--- a/app/api/video-tools/upload/route.ts
+++ b/app/api/video-tools/upload/route.ts
@@ -4,7 +4,7 @@ import {
   adminUnauthorizedResponse,
   getAdminSessionFromRequest,
 } from '@/app/lib/admin-auth'
-import { beginPendingClipUpload, recordUploadedClip } from '@/app/lib/video-tools/mutations'
+import { beginPendingClipUpload, cancelPendingClipUpload, recordUploadedClip } from '@/app/lib/video-tools/mutations'
 import { getVideoUploadSet } from '@/app/lib/video-tools/queries'
 import { VIDEO_TOOLS_BLOB_PREFIX } from '@/app/lib/video-tools/naming'
 
@@ -46,9 +46,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
         const set = await getVideoUploadSet(setId)
         if (!set) throw new Error('Upload set not found')
-        // New tokens only while collecting clips. In-flight completions may still
-        // land via onUploadCompleted / /clips after Mark ready.
-        if (!['draft', 'uploading', 'failed'].includes(set.status)) {
+        // New tokens while collecting clips (including demoting ready → uploading).
+        if (!['draft', 'uploading', 'failed', 'ready'].includes(set.status)) {
           throw new Error(`Cannot upload clips while set is ${set.status}`)
         }
 
@@ -85,13 +84,20 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
           throw new Error('Missing token payload for clip record')
         }
 
-        await recordUploadedClip({
-          setId: payload.setId,
-          originalFilename: payload.originalFilename,
-          blobUrl: blob.url,
-          pathname: blob.pathname,
-          sizeBytes: 0,
-        })
+        try {
+          await recordUploadedClip({
+            setId: payload.setId,
+            originalFilename: payload.originalFilename,
+            blobUrl: blob.url,
+            pathname: blob.pathname,
+            sizeBytes: 0,
+          })
+        } catch (err) {
+          // Token mint already incremented pending; release if registration failed
+          // before the insert path could decrement.
+          await cancelPendingClipUpload(payload.setId).catch(() => {})
+          throw err
+        }
       },
     })
 

--- a/app/api/video-tools/upload/route.ts
+++ b/app/api/video-tools/upload/route.ts
@@ -4,7 +4,7 @@ import {
   adminUnauthorizedResponse,
   getAdminSessionFromRequest,
 } from '@/app/lib/admin-auth'
-import { recordUploadedClip } from '@/app/lib/video-tools/mutations'
+import { beginPendingClipUpload, recordUploadedClip } from '@/app/lib/video-tools/mutations'
 import { getVideoUploadSet } from '@/app/lib/video-tools/queries'
 import { VIDEO_TOOLS_BLOB_PREFIX } from '@/app/lib/video-tools/naming'
 
@@ -46,9 +46,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
         const set = await getVideoUploadSet(setId)
         if (!set) throw new Error('Upload set not found')
-        // Block new tokens once merge has started or finished. Queued still
-        // allows in-flight multipart completions via onUploadCompleted.
-        if (['processing', 'complete'].includes(set.status)) {
+        // New tokens only while collecting clips. In-flight completions may still
+        // land via onUploadCompleted / /clips after Mark ready.
+        if (!['draft', 'uploading', 'failed'].includes(set.status)) {
           throw new Error(`Cannot upload clips while set is ${set.status}`)
         }
 
@@ -56,6 +56,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         if (!pathname.startsWith(expectedPrefix)) {
           throw new Error('Invalid upload pathname')
         }
+
+        await beginPendingClipUpload(setId)
 
         return {
           allowedContentTypes: [

--- a/app/api/video-tools/upload/route.ts
+++ b/app/api/video-tools/upload/route.ts
@@ -4,7 +4,7 @@ import {
   adminUnauthorizedResponse,
   getAdminSessionFromRequest,
 } from '@/app/lib/admin-auth'
-import { beginPendingClipUpload, cancelPendingClipUpload, recordUploadedClip } from '@/app/lib/video-tools/mutations'
+import { beginPendingClipUpload, recordUploadedClip } from '@/app/lib/video-tools/mutations'
 import { getVideoUploadSet } from '@/app/lib/video-tools/queries'
 import { VIDEO_TOOLS_BLOB_PREFIX } from '@/app/lib/video-tools/naming'
 
@@ -84,20 +84,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
           throw new Error('Missing token payload for clip record')
         }
 
-        try {
-          await recordUploadedClip({
-            setId: payload.setId,
-            originalFilename: payload.originalFilename,
-            blobUrl: blob.url,
-            pathname: blob.pathname,
-            sizeBytes: 0,
-          })
-        } catch (err) {
-          // Token mint already incremented pending; release if registration failed
-          // before the insert path could decrement.
-          await cancelPendingClipUpload(payload.setId).catch(() => {})
-          throw err
-        }
+        await recordUploadedClip({
+          setId: payload.setId,
+          originalFilename: payload.originalFilename,
+          blobUrl: blob.url,
+          pathname: blob.pathname,
+          sizeBytes: 0,
+        })
       },
     })
 

--- a/app/api/video-tools/upload/route.ts
+++ b/app/api/video-tools/upload/route.ts
@@ -46,7 +46,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
         const set = await getVideoUploadSet(setId)
         if (!set) throw new Error('Upload set not found')
-        if (['queued', 'processing', 'complete'].includes(set.status)) {
+        // Block new tokens once merge has started or finished. Queued still
+        // allows in-flight multipart completions via onUploadCompleted.
+        if (['processing', 'complete'].includes(set.status)) {
           throw new Error(`Cannot upload clips while set is ${set.status}`)
         }
 

--- a/app/api/video-tools/worker/claim/route.ts
+++ b/app/api/video-tools/worker/claim/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { claimNextQueuedSet } from '@/app/lib/video-tools/mutations'
+import {
+  verifyVideoWorkerRequest,
+  workerUnauthorizedResponse,
+} from '@/app/lib/video-tools/worker-auth'
+
+export async function POST(request: NextRequest) {
+  if (!verifyVideoWorkerRequest(request)) {
+    return workerUnauthorizedResponse()
+  }
+
+  try {
+    const job = await claimNextQueuedSet()
+    if (!job) {
+      return NextResponse.json({ job: null })
+    }
+    return NextResponse.json({ job })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to claim job'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/api/video-tools/worker/complete/route.ts
+++ b/app/api/video-tools/worker/complete/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { completeVideoUploadSet } from '@/app/lib/video-tools/mutations'
+import {
+  verifyVideoWorkerRequest,
+  workerUnauthorizedResponse,
+} from '@/app/lib/video-tools/worker-auth'
+
+export async function POST(request: NextRequest) {
+  if (!verifyVideoWorkerRequest(request)) {
+    return workerUnauthorizedResponse()
+  }
+
+  try {
+    const body = (await request.json()) as {
+      setId?: string
+      mergedBlobUrl?: string
+      mergedBlobPathname?: string
+      outputFilename?: string
+    }
+
+    if (!body.setId?.trim()) {
+      return NextResponse.json({ error: 'setId is required' }, { status: 400 })
+    }
+    if (!body.mergedBlobUrl?.trim()) {
+      return NextResponse.json({ error: 'mergedBlobUrl is required' }, { status: 400 })
+    }
+    if (!body.mergedBlobPathname?.trim()) {
+      return NextResponse.json(
+        { error: 'mergedBlobPathname is required' },
+        { status: 400 }
+      )
+    }
+
+    const set = await completeVideoUploadSet({
+      setId: body.setId,
+      mergedBlobUrl: body.mergedBlobUrl,
+      mergedBlobPathname: body.mergedBlobPathname,
+      outputFilename: body.outputFilename,
+    })
+
+    return NextResponse.json({ set })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to complete job'
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+}

--- a/app/api/video-tools/worker/complete/route.ts
+++ b/app/api/video-tools/worker/complete/route.ts
@@ -13,6 +13,7 @@ export async function POST(request: NextRequest) {
   try {
     const body = (await request.json()) as {
       setId?: string
+      claimToken?: string
       mergedBlobUrl?: string
       mergedBlobPathname?: string
       outputFilename?: string
@@ -20,6 +21,9 @@ export async function POST(request: NextRequest) {
 
     if (!body.setId?.trim()) {
       return NextResponse.json({ error: 'setId is required' }, { status: 400 })
+    }
+    if (!body.claimToken?.trim()) {
+      return NextResponse.json({ error: 'claimToken is required' }, { status: 400 })
     }
     if (!body.mergedBlobUrl?.trim()) {
       return NextResponse.json({ error: 'mergedBlobUrl is required' }, { status: 400 })
@@ -33,6 +37,7 @@ export async function POST(request: NextRequest) {
 
     const set = await completeVideoUploadSet({
       setId: body.setId,
+      claimToken: body.claimToken,
       mergedBlobUrl: body.mergedBlobUrl,
       mergedBlobPathname: body.mergedBlobPathname,
       outputFilename: body.outputFilename,

--- a/app/api/video-tools/worker/fail/route.ts
+++ b/app/api/video-tools/worker/fail/route.ts
@@ -13,11 +13,15 @@ export async function POST(request: NextRequest) {
   try {
     const body = (await request.json()) as {
       setId?: string
+      claimToken?: string
       errorMessage?: string
     }
 
     if (!body.setId?.trim()) {
       return NextResponse.json({ error: 'setId is required' }, { status: 400 })
+    }
+    if (!body.claimToken?.trim()) {
+      return NextResponse.json({ error: 'claimToken is required' }, { status: 400 })
     }
     if (!body.errorMessage?.trim()) {
       return NextResponse.json({ error: 'errorMessage is required' }, { status: 400 })
@@ -25,6 +29,7 @@ export async function POST(request: NextRequest) {
 
     const set = await failVideoUploadSet({
       setId: body.setId,
+      claimToken: body.claimToken,
       errorMessage: body.errorMessage,
     })
 

--- a/app/api/video-tools/worker/fail/route.ts
+++ b/app/api/video-tools/worker/fail/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { failVideoUploadSet } from '@/app/lib/video-tools/mutations'
+import {
+  verifyVideoWorkerRequest,
+  workerUnauthorizedResponse,
+} from '@/app/lib/video-tools/worker-auth'
+
+export async function POST(request: NextRequest) {
+  if (!verifyVideoWorkerRequest(request)) {
+    return workerUnauthorizedResponse()
+  }
+
+  try {
+    const body = (await request.json()) as {
+      setId?: string
+      errorMessage?: string
+    }
+
+    if (!body.setId?.trim()) {
+      return NextResponse.json({ error: 'setId is required' }, { status: 400 })
+    }
+    if (!body.errorMessage?.trim()) {
+      return NextResponse.json({ error: 'errorMessage is required' }, { status: 400 })
+    }
+
+    const set = await failVideoUploadSet({
+      setId: body.setId,
+      errorMessage: body.errorMessage,
+    })
+
+    return NextResponse.json({ set })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to fail job'
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+}

--- a/app/components/TopNav.tsx
+++ b/app/components/TopNav.tsx
@@ -128,6 +128,12 @@ export default function TopNav() {
           Events
         </Link>
         <Link
+          href={withDevMode('/video-tools', devMode)}
+          className="hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+        >
+          Video Tools
+        </Link>
+        <Link
           href={withDevMode('/non-bdl-events', devMode)}
           className="hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
         >

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -378,3 +378,51 @@ export const nonBdlEventPhotoPlayerTags = pgTable(
     index('non_bdl_event_photo_player_tags_photo_id_idx').on(table.photoId),
   ]
 )
+
+/**
+ * Concurrent GoPro upload/merge jobs for Video Tools.
+ * Status: draft | uploading | ready | queued | processing | complete | failed
+ */
+export const videoUploadSets = pgTable(
+  'video_upload_sets',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    eventName: text('event_name').notNull(),
+    label: text('label').notNull(),
+    eventDate: date('event_date').notNull(),
+    status: text('status').notNull().default('draft'),
+    createdByEmail: text('created_by_email').notNull(),
+    errorMessage: text('error_message'),
+    mergedBlobUrl: text('merged_blob_url'),
+    mergedBlobPathname: text('merged_blob_pathname'),
+    outputFilename: text('output_filename'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index('video_upload_sets_status_idx').on(table.status),
+    index('video_upload_sets_event_date_idx').on(table.eventDate),
+    index('video_upload_sets_created_at_idx').on(table.createdAt),
+  ]
+)
+
+export const videoUploadClips = pgTable(
+  'video_upload_clips',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    setId: uuid('set_id')
+      .notNull()
+      .references(() => videoUploadSets.id, { onDelete: 'cascade' }),
+    originalFilename: text('original_filename').notNull(),
+    blobUrl: text('blob_url').notNull(),
+    pathname: text('pathname').notNull(),
+    sizeBytes: integer('size_bytes').notNull().default(0),
+    sortIndex: integer('sort_index'),
+    uploadComplete: boolean('upload_complete').notNull().default(true),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index('video_upload_clips_set_id_idx').on(table.setId),
+    uniqueIndex('video_upload_clips_pathname_uidx').on(table.pathname),
+  ]
+)

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -396,6 +396,8 @@ export const videoUploadSets = pgTable(
     mergedBlobUrl: text('merged_blob_url'),
     mergedBlobPathname: text('merged_blob_pathname'),
     outputFilename: text('output_filename'),
+    /** Rotated on each worker claim; invalidates stale complete/fail after retry. */
+    claimToken: uuid('claim_token'),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -398,6 +398,8 @@ export const videoUploadSets = pgTable(
     outputFilename: text('output_filename'),
     /** Rotated on each worker claim; invalidates stale complete/fail after retry. */
     claimToken: uuid('claim_token'),
+    /** In-flight Blob upload tokens; Mark ready / enqueue require zero. */
+    pendingUploadCount: integer('pending_upload_count').notNull().default(0),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },

--- a/app/lib/video-tools/__tests__/blob-url.test.ts
+++ b/app/lib/video-tools/__tests__/blob-url.test.ts
@@ -1,20 +1,25 @@
 import { describe, expect, it } from 'vitest'
-import { assertSafeVideoClipBlobUrl } from '@/app/lib/video-tools/blob-url'
+import {
+  assertSafeVideoClipBlobUrl,
+  assertSafeVideoMergedBlobUrl,
+} from '@/app/lib/video-tools/blob-url'
+
+const setId = '11111111-1111-1111-1111-111111111111'
 
 describe('assertSafeVideoClipBlobUrl', () => {
-  const pathname =
-    'video-tools/11111111-1111-1111-1111-111111111111/clips/abc-GX010100.MP4'
+  const pathname = `video-tools/${setId}/clips/abc-GX010100.MP4`
 
   it('accepts matching Vercel Blob https URLs', () => {
     const url = `https://abc123.public.blob.vercel-storage.com/${pathname}`
-    expect(assertSafeVideoClipBlobUrl(url, pathname)).toBe(url)
+    expect(assertSafeVideoClipBlobUrl(url, pathname, setId)).toBe(url)
   })
 
   it('rejects non-blob hosts (SSRF)', () => {
     expect(() =>
       assertSafeVideoClipBlobUrl(
         `https://169.254.169.254/${pathname}`,
-        pathname
+        pathname,
+        setId
       )
     ).toThrow(/Vercel Blob/)
   })
@@ -23,7 +28,8 @@ describe('assertSafeVideoClipBlobUrl', () => {
     expect(() =>
       assertSafeVideoClipBlobUrl(
         `http://abc123.public.blob.vercel-storage.com/${pathname}`,
-        pathname
+        pathname,
+        setId
       )
     ).toThrow(/https/)
   })
@@ -32,8 +38,58 @@ describe('assertSafeVideoClipBlobUrl', () => {
     expect(() =>
       assertSafeVideoClipBlobUrl(
         `https://abc123.public.blob.vercel-storage.com/${pathname}`,
-        'video-tools/other/clips/x.MP4'
+        'video-tools/other/clips/x.MP4',
+        setId
       )
     ).toThrow(/must match/)
+  })
+
+  it('rejects clips for a different set when setId is provided', () => {
+    const otherPath =
+      'video-tools/22222222-2222-2222-2222-222222222222/clips/abc-GX010100.MP4'
+    const url = `https://abc123.public.blob.vercel-storage.com/${otherPath}`
+    expect(() => assertSafeVideoClipBlobUrl(url, otherPath, setId)).toThrow(
+      /must start with/
+    )
+  })
+})
+
+describe('assertSafeVideoMergedBlobUrl', () => {
+  const outputFilename = 'Summer_Remix_2026-07-12_Court_1_untrimmed.MP4'
+  const pathname = `video-tools/${setId}/merged/${outputFilename}`
+
+  it('accepts matching merged Blob URLs', () => {
+    const url = `https://abc123.public.blob.vercel-storage.com/${pathname}`
+    expect(
+      assertSafeVideoMergedBlobUrl({
+        blobUrl: url,
+        pathname,
+        setId,
+        outputFilename,
+      })
+    ).toBe(url)
+  })
+
+  it('rejects non-blob hosts', () => {
+    expect(() =>
+      assertSafeVideoMergedBlobUrl({
+        blobUrl: `https://evil.example/${pathname}`,
+        pathname,
+        setId,
+        outputFilename,
+      })
+    ).toThrow(/Vercel Blob/)
+  })
+
+  it('rejects wrong output filename path', () => {
+    const wrong = `video-tools/${setId}/merged/other_untrimmed.MP4`
+    expect(() =>
+      assertSafeVideoMergedBlobUrl({
+        blobUrl: `https://abc123.public.blob.vercel-storage.com/${wrong}`,
+        pathname: wrong,
+        setId,
+        outputFilename,
+      })
+    ).toThrow(/output filename/)
   })
 })

--- a/app/lib/video-tools/__tests__/blob-url.test.ts
+++ b/app/lib/video-tools/__tests__/blob-url.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { assertSafeVideoClipBlobUrl } from '@/app/lib/video-tools/blob-url'
+
+describe('assertSafeVideoClipBlobUrl', () => {
+  const pathname =
+    'video-tools/11111111-1111-1111-1111-111111111111/clips/abc-GX010100.MP4'
+
+  it('accepts matching Vercel Blob https URLs', () => {
+    const url = `https://abc123.public.blob.vercel-storage.com/${pathname}`
+    expect(assertSafeVideoClipBlobUrl(url, pathname)).toBe(url)
+  })
+
+  it('rejects non-blob hosts (SSRF)', () => {
+    expect(() =>
+      assertSafeVideoClipBlobUrl(
+        `https://169.254.169.254/${pathname}`,
+        pathname
+      )
+    ).toThrow(/Vercel Blob/)
+  })
+
+  it('rejects http', () => {
+    expect(() =>
+      assertSafeVideoClipBlobUrl(
+        `http://abc123.public.blob.vercel-storage.com/${pathname}`,
+        pathname
+      )
+    ).toThrow(/https/)
+  })
+
+  it('rejects pathname mismatch', () => {
+    expect(() =>
+      assertSafeVideoClipBlobUrl(
+        `https://abc123.public.blob.vercel-storage.com/${pathname}`,
+        'video-tools/other/clips/x.MP4'
+      )
+    ).toThrow(/must match/)
+  })
+})

--- a/app/lib/video-tools/__tests__/concurrent-sets.smoke.test.ts
+++ b/app/lib/video-tools/__tests__/concurrent-sets.smoke.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { orderClipsForMerge } from '@/app/lib/video-tools/gopro-order'
+import {
+  buildUntrimmedOutputFilename,
+  displayTitle,
+} from '@/app/lib/video-tools/naming'
+
+/**
+ * Smoke-style checks for concurrent Court 1 / Court 2 upload sets:
+ * independent titles, distinct merge outputs, shared GoPro ordering rules.
+ */
+describe('concurrent court upload sets (smoke)', () => {
+  const eventName = 'BDL Season 7: Summer Remix'
+  const eventDate = '2026-07-12'
+
+  it('builds distinct titles and filenames for Court 1 and Court 2', () => {
+    const court1 = {
+      eventName,
+      eventDate,
+      label: 'Court 1',
+    }
+    const court2 = {
+      eventName,
+      eventDate,
+      label: 'Court 2',
+    }
+
+    expect(displayTitle(court1.eventName, court1.label)).toBe(
+      'BDL Season 7: Summer Remix · Court 1'
+    )
+    expect(displayTitle(court2.eventName, court2.label)).toBe(
+      'BDL Season 7: Summer Remix · Court 2'
+    )
+
+    const out1 = buildUntrimmedOutputFilename(court1)
+    const out2 = buildUntrimmedOutputFilename(court2)
+    expect(out1).toBe(
+      'BDL_Season_7_Summer_Remix_2026-07-12_Court_1_untrimmed.MP4'
+    )
+    expect(out2).toBe(
+      'BDL_Season_7_Summer_Remix_2026-07-12_Court_2_untrimmed.MP4'
+    )
+    expect(out1).not.toBe(out2)
+  })
+
+  it('orders each court set independently', () => {
+    const court1Clips = [
+      { originalFilename: 'GX020100.MP4', set: 'court1' },
+      { originalFilename: 'GX010100.MP4', set: 'court1' },
+    ]
+    const court2Clips = [
+      { originalFilename: 'GX010200.MP4', set: 'court2' },
+      { originalFilename: 'GOPR0200.MP4', set: 'court2' },
+    ]
+
+    const ordered1 = orderClipsForMerge(court1Clips).map((c) => c.originalFilename)
+    const ordered2 = orderClipsForMerge(court2Clips).map((c) => c.originalFilename)
+
+    expect(ordered1).toEqual(['GX010100.MP4', 'GX020100.MP4'])
+    expect(ordered2).toEqual(['GOPR0200.MP4', 'GX010200.MP4'])
+  })
+})

--- a/app/lib/video-tools/__tests__/gopro-order.test.ts
+++ b/app/lib/video-tools/__tests__/gopro-order.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import {
+  extractGoProSessionId,
+  orderClipsForMerge,
+} from '@/app/lib/video-tools/gopro-order'
+import {
+  buildUntrimmedOutputFilename,
+  displayTitle,
+  slugifyForFilename,
+} from '@/app/lib/video-tools/naming'
+
+describe('slugifyForFilename', () => {
+  it('replaces spaces and strips unsafe characters', () => {
+    expect(slugifyForFilename('BDL Season 7: Summer Remix')).toBe(
+      'BDL_Season_7_Summer_Remix'
+    )
+  })
+})
+
+describe('buildUntrimmedOutputFilename', () => {
+  it('follows Event_date_Label_untrimmed.MP4', () => {
+    expect(
+      buildUntrimmedOutputFilename({
+        eventName: 'SheThey League',
+        eventDate: '2026-03-29',
+        label: 'Court 1',
+      })
+    ).toBe('SheThey_League_2026-03-29_Court_1_untrimmed.MP4')
+  })
+})
+
+describe('displayTitle', () => {
+  it('joins event and label', () => {
+    expect(displayTitle('Summer Remix', 'Court 2')).toBe('Summer Remix · Court 2')
+  })
+})
+
+describe('orderClipsForMerge', () => {
+  it('orders GoPro chapters by session then GOPR/GP/GX', () => {
+    const clips = [
+      { originalFilename: 'GX020010.MP4' },
+      { originalFilename: 'GX010010.MP4' },
+      { originalFilename: 'GOPR0010.MP4' },
+      { originalFilename: 'GX010020.MP4' },
+      { originalFilename: 'random_clip.mp4' },
+    ]
+    const ordered = orderClipsForMerge(clips).map((c) => c.originalFilename)
+    expect(ordered).toEqual([
+      'GOPR0010.MP4',
+      'GX010010.MP4',
+      'GX020010.MP4',
+      'GX010020.MP4',
+      'random_clip.mp4',
+    ])
+  })
+
+  it('extracts session ids', () => {
+    expect(extractGoProSessionId('GX010554.MP4')).toBe('0554')
+    expect(extractGoProSessionId('GOPR0554.MP4')).toBe('0554')
+    expect(extractGoProSessionId('other.mp4')).toBeNull()
+  })
+})

--- a/app/lib/video-tools/__tests__/gopro-order.test.ts
+++ b/app/lib/video-tools/__tests__/gopro-order.test.ts
@@ -54,9 +54,26 @@ describe('orderClipsForMerge', () => {
     ])
   })
 
+  it('orders GoPro chapters for .mov the same as .mp4', () => {
+    const clips = [
+      { originalFilename: 'GX020010.MOV' },
+      { originalFilename: 'GX010010.mov' },
+      { originalFilename: 'GOPR0010.MOV' },
+      { originalFilename: 'random_clip.mov' },
+    ]
+    const ordered = orderClipsForMerge(clips).map((c) => c.originalFilename)
+    expect(ordered).toEqual([
+      'GOPR0010.MOV',
+      'GX010010.mov',
+      'GX020010.MOV',
+      'random_clip.mov',
+    ])
+  })
+
   it('extracts session ids', () => {
     expect(extractGoProSessionId('GX010554.MP4')).toBe('0554')
     expect(extractGoProSessionId('GOPR0554.MP4')).toBe('0554')
+    expect(extractGoProSessionId('GX010554.MOV')).toBe('0554')
     expect(extractGoProSessionId('other.mp4')).toBeNull()
   })
 })

--- a/app/lib/video-tools/__tests__/status-transitions.test.ts
+++ b/app/lib/video-tools/__tests__/status-transitions.test.ts
@@ -3,6 +3,7 @@ import {
   CLIP_LOCKED_STATUSES,
   ENQUEUE_ALLOWED_STATUSES,
   READY_ALLOWED_STATUSES,
+  UPLOAD_TOKEN_ALLOWED_STATUSES,
 } from '@/app/lib/video-tools/mutations'
 import { VIDEO_SET_STATUSES } from '@/app/lib/video-tools/types'
 
@@ -37,6 +38,14 @@ describe('video tools status transition policy', () => {
     expect(ENQUEUE_ALLOWED_STATUSES).not.toContain('uploading')
     expect(ENQUEUE_ALLOWED_STATUSES).not.toContain('draft')
     expect(READY_ALLOWED_STATUSES).toContain('uploading')
+  })
+
+  it('only mints upload tokens while collecting clips', () => {
+    expect([...UPLOAD_TOKEN_ALLOWED_STATUSES]).toEqual([
+      'draft',
+      'uploading',
+      'failed',
+    ])
   })
 
   it('documents claim-token invalidation on retry', () => {

--- a/app/lib/video-tools/__tests__/status-transitions.test.ts
+++ b/app/lib/video-tools/__tests__/status-transitions.test.ts
@@ -33,6 +33,11 @@ describe('video tools status transition policy', () => {
     }
   })
 
+  it('documents claim-token invalidation on retry', () => {
+    // enqueue clears claimToken; complete/fail require matching token + processing.
+    expect(ENQUEUE_ALLOWED_STATUSES).toContain('processing')
+  })
+
   it('covers every set status in at least one transition list', () => {
     const covered = new Set<string>([
       ...READY_ALLOWED_STATUSES,

--- a/app/lib/video-tools/__tests__/status-transitions.test.ts
+++ b/app/lib/video-tools/__tests__/status-transitions.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CLIP_LOCKED_STATUSES,
+  ENQUEUE_ALLOWED_STATUSES,
+  READY_ALLOWED_STATUSES,
+} from '@/app/lib/video-tools/mutations'
+import { VIDEO_SET_STATUSES } from '@/app/lib/video-tools/types'
+
+describe('video tools status transition policy', () => {
+  it('blocks mark_ready once merge is queued or running', () => {
+    expect([...READY_ALLOWED_STATUSES]).toEqual([
+      'draft',
+      'uploading',
+      'ready',
+      'failed',
+    ])
+    for (const status of ['queued', 'processing', 'complete'] as const) {
+      expect(READY_ALLOWED_STATUSES).not.toContain(status)
+    }
+  })
+
+  it('locks new clips only after claim or completion (queued still allowed)', () => {
+    expect([...CLIP_LOCKED_STATUSES]).toEqual(['processing', 'complete'])
+    expect(CLIP_LOCKED_STATUSES).not.toContain('queued')
+  })
+
+  it('allows re-enqueue from processing for stuck-worker recovery', () => {
+    expect(ENQUEUE_ALLOWED_STATUSES).toContain('processing')
+    expect(ENQUEUE_ALLOWED_STATUSES).toContain('failed')
+    expect(ENQUEUE_ALLOWED_STATUSES).toContain('ready')
+    for (const status of ['draft', 'uploading', 'queued', 'complete'] as const) {
+      expect(ENQUEUE_ALLOWED_STATUSES).not.toContain(status)
+    }
+  })
+
+  it('covers every set status in at least one transition list', () => {
+    const covered = new Set<string>([
+      ...READY_ALLOWED_STATUSES,
+      ...CLIP_LOCKED_STATUSES,
+      ...ENQUEUE_ALLOWED_STATUSES,
+      'queued', // claim target
+      'complete', // completeVideoUploadSet terminal
+    ])
+    for (const status of VIDEO_SET_STATUSES) {
+      expect(covered.has(status)).toBe(true)
+    }
+  })
+})

--- a/app/lib/video-tools/__tests__/status-transitions.test.ts
+++ b/app/lib/video-tools/__tests__/status-transitions.test.ts
@@ -45,6 +45,7 @@ describe('video tools status transition policy', () => {
       'draft',
       'uploading',
       'failed',
+      'ready',
     ])
   })
 

--- a/app/lib/video-tools/__tests__/status-transitions.test.ts
+++ b/app/lib/video-tools/__tests__/status-transitions.test.ts
@@ -33,6 +33,12 @@ describe('video tools status transition policy', () => {
     }
   })
 
+  it('requires ready before enqueue (no merge while still uploading)', () => {
+    expect(ENQUEUE_ALLOWED_STATUSES).not.toContain('uploading')
+    expect(ENQUEUE_ALLOWED_STATUSES).not.toContain('draft')
+    expect(READY_ALLOWED_STATUSES).toContain('uploading')
+  })
+
   it('documents claim-token invalidation on retry', () => {
     // enqueue clears claimToken; complete/fail require matching token + processing.
     expect(ENQUEUE_ALLOWED_STATUSES).toContain('processing')

--- a/app/lib/video-tools/blob-url.ts
+++ b/app/lib/video-tools/blob-url.ts
@@ -1,4 +1,7 @@
-import { VIDEO_TOOLS_BLOB_PREFIX } from '@/app/lib/video-tools/naming'
+import {
+  VIDEO_TOOLS_BLOB_PREFIX,
+  mergedBlobPathname,
+} from '@/app/lib/video-tools/naming'
 
 const ALLOWED_BLOB_HOST_SUFFIXES = ['.blob.vercel-storage.com']
 
@@ -12,13 +15,10 @@ function normalizeBlobPathname(pathname: string): string {
   return pathname.startsWith('/') ? pathname.slice(1) : pathname
 }
 
-/**
- * Ensure clip blobUrl is a Vercel Blob HTTPS URL whose path matches the
- * trusted pathname for this set (prevents SSRF via the merge worker fetch).
- */
-export function assertSafeVideoClipBlobUrl(
+function assertSafeVideoToolsBlobUrl(
   blobUrl: string,
-  pathname: string
+  pathname: string,
+  requiredPrefix: string
 ): string {
   let parsed: URL
   try {
@@ -37,11 +37,53 @@ export function assertSafeVideoClipBlobUrl(
   const urlPath = normalizeBlobPathname(decodeURIComponent(parsed.pathname))
   const expectedPath = normalizeBlobPathname(pathname)
   if (urlPath !== expectedPath) {
-    throw new Error('blobUrl pathname must match the clip pathname')
+    throw new Error('blobUrl pathname must match the stored pathname')
+  }
+  if (!expectedPath.startsWith(requiredPrefix)) {
+    throw new Error(`pathname must start with ${requiredPrefix}`)
   }
   if (!expectedPath.startsWith(VIDEO_TOOLS_BLOB_PREFIX)) {
     throw new Error('pathname must be under video-tools/')
   }
 
   return blobUrl.trim()
+}
+
+/**
+ * Ensure clip blobUrl is a Vercel Blob HTTPS URL whose path matches the
+ * trusted pathname for this set (prevents SSRF via the merge worker fetch).
+ */
+export function assertSafeVideoClipBlobUrl(
+  blobUrl: string,
+  pathname: string,
+  setId?: string
+): string {
+  const prefix = setId
+    ? `${VIDEO_TOOLS_BLOB_PREFIX}${setId}/clips/`
+    : `${VIDEO_TOOLS_BLOB_PREFIX}`
+  return assertSafeVideoToolsBlobUrl(blobUrl, pathname, prefix)
+}
+
+/**
+ * Ensure merged deliverable URL is a Vercel Blob HTTPS URL under this set's
+ * merged/ prefix (download link shown in the admin UI).
+ */
+export function assertSafeVideoMergedBlobUrl(input: {
+  blobUrl: string
+  pathname: string
+  setId: string
+  outputFilename?: string | null
+}): string {
+  const expectedPrefix = `${VIDEO_TOOLS_BLOB_PREFIX}${input.setId}/merged/`
+  if (input.outputFilename) {
+    const expected = mergedBlobPathname(input.setId, input.outputFilename)
+    if (normalizeBlobPathname(input.pathname) !== normalizeBlobPathname(expected)) {
+      throw new Error('mergedBlobPathname must match the set output filename')
+    }
+  }
+  return assertSafeVideoToolsBlobUrl(
+    input.blobUrl,
+    input.pathname,
+    expectedPrefix
+  )
 }

--- a/app/lib/video-tools/blob-url.ts
+++ b/app/lib/video-tools/blob-url.ts
@@ -1,0 +1,47 @@
+import { VIDEO_TOOLS_BLOB_PREFIX } from '@/app/lib/video-tools/naming'
+
+const ALLOWED_BLOB_HOST_SUFFIXES = ['.blob.vercel-storage.com']
+
+function isVercelBlobHost(hostname: string): boolean {
+  return ALLOWED_BLOB_HOST_SUFFIXES.some(
+    (suffix) => hostname === suffix.slice(1) || hostname.endsWith(suffix)
+  )
+}
+
+function normalizeBlobPathname(pathname: string): string {
+  return pathname.startsWith('/') ? pathname.slice(1) : pathname
+}
+
+/**
+ * Ensure clip blobUrl is a Vercel Blob HTTPS URL whose path matches the
+ * trusted pathname for this set (prevents SSRF via the merge worker fetch).
+ */
+export function assertSafeVideoClipBlobUrl(
+  blobUrl: string,
+  pathname: string
+): string {
+  let parsed: URL
+  try {
+    parsed = new URL(blobUrl)
+  } catch {
+    throw new Error('blobUrl is not a valid URL')
+  }
+
+  if (parsed.protocol !== 'https:') {
+    throw new Error('blobUrl must be https')
+  }
+  if (!isVercelBlobHost(parsed.hostname)) {
+    throw new Error('blobUrl must be a Vercel Blob storage URL')
+  }
+
+  const urlPath = normalizeBlobPathname(decodeURIComponent(parsed.pathname))
+  const expectedPath = normalizeBlobPathname(pathname)
+  if (urlPath !== expectedPath) {
+    throw new Error('blobUrl pathname must match the clip pathname')
+  }
+  if (!expectedPath.startsWith(VIDEO_TOOLS_BLOB_PREFIX)) {
+    throw new Error('pathname must be under video-tools/')
+  }
+
+  return blobUrl.trim()
+}

--- a/app/lib/video-tools/gopro-order.ts
+++ b/app/lib/video-tools/gopro-order.ts
@@ -1,0 +1,97 @@
+/**
+ * GoPro-aware clip ordering (ported from combine_week_courts.sh / combine_gopro_videos.sh).
+ *
+ * - Session id = last 4 digits of GXnnSSSS / GPnnSSSS / GOPRSSSS
+ * - Sessions sorted numerically
+ * - Within a session: GOPR → GP → GX, then by full basename (chapter order)
+ * - Non-GoPro files: lexicographic basename, after all GoPro sessions
+ */
+
+export type OrderedClip = {
+  originalFilename: string
+  basename: string
+}
+
+type GoProParsed = {
+  kind: 'GOPR' | 'GP' | 'GX'
+  sessionId: string
+  basename: string
+}
+
+const GOPR_RE = /^GOPR(\d{4})\.(mp4|MP4)$/
+const GP_RE = /^GP(\d{2})(\d{4})\.(mp4|MP4)$/
+const GX_RE = /^GX(\d{2})(\d{4})\.(mp4|MP4)$/
+
+function basenameOf(filename: string): string {
+  const parts = filename.replace(/\\/g, '/').split('/')
+  return parts[parts.length - 1] || filename
+}
+
+function parseGoPro(basename: string): GoProParsed | null {
+  let m = basename.match(GOPR_RE)
+  if (m) {
+    return { kind: 'GOPR', sessionId: m[1], basename }
+  }
+  m = basename.match(GP_RE)
+  if (m) {
+    return { kind: 'GP', sessionId: m[2], basename }
+  }
+  m = basename.match(GX_RE)
+  if (m) {
+    return { kind: 'GX', sessionId: m[2], basename }
+  }
+  return null
+}
+
+const KIND_ORDER: Record<GoProParsed['kind'], number> = {
+  GOPR: 0,
+  GP: 1,
+  GX: 2,
+}
+
+function compareGoPro(a: GoProParsed, b: GoProParsed): number {
+  if (a.sessionId !== b.sessionId) {
+    return a.sessionId.localeCompare(b.sessionId, undefined, { numeric: true })
+  }
+  const kindDiff = KIND_ORDER[a.kind] - KIND_ORDER[b.kind]
+  if (kindDiff !== 0) return kindDiff
+  return a.basename.localeCompare(b.basename, undefined, {
+    numeric: true,
+    sensitivity: 'base',
+  })
+}
+
+/** Return clips sorted in concat order. Preserves object identity / extra fields. */
+export function orderClipsForMerge<T extends { originalFilename: string }>(
+  clips: T[]
+): T[] {
+  const withMeta = clips.map((clip, index) => {
+    const basename = basenameOf(clip.originalFilename)
+    const gopro = parseGoPro(basename)
+    return { clip, index, basename, gopro }
+  })
+
+  const goproItems = withMeta.filter((x) => x.gopro)
+  const otherItems = withMeta.filter((x) => !x.gopro)
+
+  goproItems.sort((a, b) => {
+    const cmp = compareGoPro(a.gopro!, b.gopro!)
+    if (cmp !== 0) return cmp
+    return a.index - b.index
+  })
+
+  otherItems.sort((a, b) => {
+    const cmp = a.basename.localeCompare(b.basename, undefined, {
+      numeric: true,
+      sensitivity: 'base',
+    })
+    if (cmp !== 0) return cmp
+    return a.index - b.index
+  })
+
+  return [...goproItems, ...otherItems].map((x) => x.clip)
+}
+
+export function extractGoProSessionId(filename: string): string | null {
+  return parseGoPro(basenameOf(filename))?.sessionId ?? null
+}

--- a/app/lib/video-tools/gopro-order.ts
+++ b/app/lib/video-tools/gopro-order.ts
@@ -18,9 +18,9 @@ type GoProParsed = {
   basename: string
 }
 
-const GOPR_RE = /^GOPR(\d{4})\.(mp4|MP4)$/
-const GP_RE = /^GP(\d{2})(\d{4})\.(mp4|MP4)$/
-const GX_RE = /^GX(\d{2})(\d{4})\.(mp4|MP4)$/
+const GOPR_RE = /^GOPR(\d{4})\.(mp4|mov)$/i
+const GP_RE = /^GP(\d{2})(\d{4})\.(mp4|mov)$/i
+const GX_RE = /^GX(\d{2})(\d{4})\.(mp4|mov)$/i
 
 function basenameOf(filename: string): string {
   const parts = filename.replace(/\\/g, '/').split('/')

--- a/app/lib/video-tools/mutations.ts
+++ b/app/lib/video-tools/mutations.ts
@@ -186,6 +186,20 @@ export async function cancelPendingClipUpload(setId: string): Promise<void> {
   await releasePendingClipUpload(setId)
 }
 
+/** Operator recovery when pending_upload_count is stuck after abandoned uploads. */
+export async function resetPendingUploads(
+  setId: string
+): Promise<VideoUploadSetRecord> {
+  const db = getDb()
+  const [updated] = await db
+    .update(videoUploadSets)
+    .set({ pendingUploadCount: 0, updatedAt: new Date() })
+    .where(eq(videoUploadSets.id, setId))
+    .returning()
+  if (!updated) throw new Error('Upload set not found')
+  return mapSet(updated)
+}
+
 export async function recordUploadedClip(input: {
   setId: string
   originalFilename: string

--- a/app/lib/video-tools/mutations.ts
+++ b/app/lib/video-tools/mutations.ts
@@ -227,28 +227,36 @@ export async function recordUploadedClip(input: {
     return reconcileExisting(raced)
   }
 
-  // Do not demote queued sets; late in-flight uploads may land before the worker claims.
-  // Demote ready → uploading if another clip arrives after Mark ready.
-  if (set.status === 'queued') {
-    await db
-      .update(videoUploadSets)
-      .set({ updatedAt: new Date() })
-      .where(eq(videoUploadSets.id, input.setId))
-  } else {
-    await db
-      .update(videoUploadSets)
-      .set({
-        status:
-          set.status === 'draft' ||
-          set.status === 'failed' ||
-          set.status === 'ready'
-            ? 'uploading'
-            : set.status,
-        updatedAt: new Date(),
-        errorMessage: null,
-      })
-      .where(eq(videoUploadSets.id, input.setId))
-  }
+  // Conditional updates only — never clobber queued/processing/complete if the
+  // set advanced between the initial read and this write (Start merge race).
+  await db
+    .update(videoUploadSets)
+    .set({ updatedAt: new Date() })
+    .where(
+      and(
+        eq(videoUploadSets.id, input.setId),
+        eq(videoUploadSets.status, 'queued')
+      )
+    )
+
+  await db
+    .update(videoUploadSets)
+    .set({
+      status: 'uploading',
+      updatedAt: new Date(),
+      errorMessage: null,
+    })
+    .where(
+      and(
+        eq(videoUploadSets.id, input.setId),
+        inArray(videoUploadSets.status, [
+          'draft',
+          'failed',
+          'ready',
+          'uploading',
+        ])
+      )
+    )
 
   return mapClip(clip)
 }

--- a/app/lib/video-tools/mutations.ts
+++ b/app/lib/video-tools/mutations.ts
@@ -275,8 +275,6 @@ export async function recordUploadedClip(input: {
     return reconcileExisting(raced)
   }
 
-  await releasePendingClipUpload(input.setId)
-
   // Conditional updates only — never clobber queued/processing/complete if the
   // set advanced between the initial read and this write (Start merge race).
   await db
@@ -310,6 +308,10 @@ export async function recordUploadedClip(input: {
         inArray(videoUploadSets.status, [...demoteFrom])
       )
     )
+
+  // Release after status writes so a later throw doesn't leave us needing a
+  // second decrement in the upload webhook catch handler.
+  await releasePendingClipUpload(input.setId)
 
   return mapClip(clip)
 }

--- a/app/lib/video-tools/mutations.ts
+++ b/app/lib/video-tools/mutations.ts
@@ -1,0 +1,353 @@
+import { and, asc, eq } from 'drizzle-orm'
+import { getDb } from '@/app/lib/db'
+import { videoUploadClips, videoUploadSets } from '@/app/db/schema'
+import { orderClipsForMerge } from '@/app/lib/video-tools/gopro-order'
+import {
+  buildUntrimmedOutputFilename,
+  displayTitle,
+} from '@/app/lib/video-tools/naming'
+import { listClipsForSet } from '@/app/lib/video-tools/queries'
+import type {
+  VideoSetStatus,
+  VideoUploadClipRecord,
+  VideoUploadSetDetail,
+  VideoUploadSetRecord,
+  WorkerClaimPayload,
+} from '@/app/lib/video-tools/types'
+import { isValidVideoSetStatus } from '@/app/lib/video-tools/types'
+
+function parseEventDate(value: string): string {
+  const trimmed = value.trim()
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    throw new Error('eventDate must be YYYY-MM-DD')
+  }
+  const d = new Date(`${trimmed}T00:00:00.000Z`)
+  if (Number.isNaN(d.getTime())) {
+    throw new Error('eventDate is not a valid date')
+  }
+  if (d.toISOString().slice(0, 10) !== trimmed) {
+    throw new Error('eventDate is not a valid date')
+  }
+  return trimmed
+}
+
+function mapSet(row: typeof videoUploadSets.$inferSelect): VideoUploadSetRecord {
+  return {
+    id: row.id,
+    eventName: row.eventName,
+    label: row.label,
+    eventDate: row.eventDate,
+    status: row.status,
+    createdByEmail: row.createdByEmail,
+    errorMessage: row.errorMessage,
+    mergedBlobUrl: row.mergedBlobUrl,
+    mergedBlobPathname: row.mergedBlobPathname,
+    outputFilename: row.outputFilename,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  }
+}
+
+function mapClip(row: typeof videoUploadClips.$inferSelect): VideoUploadClipRecord {
+  return {
+    id: row.id,
+    setId: row.setId,
+    originalFilename: row.originalFilename,
+    blobUrl: row.blobUrl,
+    pathname: row.pathname,
+    sizeBytes: row.sizeBytes,
+    sortIndex: row.sortIndex,
+    uploadComplete: row.uploadComplete,
+    createdAt: row.createdAt,
+  }
+}
+
+export async function createVideoUploadSet(input: {
+  eventName: string
+  label: string
+  eventDate: string
+  createdByEmail: string
+}): Promise<VideoUploadSetDetail> {
+  const eventName = input.eventName.trim()
+  const label = input.label.trim()
+  if (!eventName) throw new Error('eventName is required')
+  if (!label) throw new Error('label is required')
+  const eventDate = parseEventDate(input.eventDate)
+  const createdByEmail = input.createdByEmail.trim().toLowerCase()
+  if (!createdByEmail) throw new Error('createdByEmail is required')
+
+  const db = getDb()
+  const outputFilename = buildUntrimmedOutputFilename({
+    eventName,
+    eventDate,
+    label,
+  })
+
+  const [created] = await db
+    .insert(videoUploadSets)
+    .values({
+      eventName,
+      label,
+      eventDate,
+      status: 'draft',
+      createdByEmail,
+      outputFilename,
+    })
+    .returning()
+
+  const mapped = mapSet(created)
+  return {
+    ...mapped,
+    displayTitle: displayTitle(mapped.eventName, mapped.label),
+    clips: [],
+  }
+}
+
+export async function markSetUploading(setId: string): Promise<void> {
+  const db = getDb()
+  await db
+    .update(videoUploadSets)
+    .set({ status: 'uploading', updatedAt: new Date(), errorMessage: null })
+    .where(
+      and(
+        eq(videoUploadSets.id, setId),
+        eq(videoUploadSets.status, 'draft')
+      )
+    )
+}
+
+export async function recordUploadedClip(input: {
+  setId: string
+  originalFilename: string
+  blobUrl: string
+  pathname: string
+  sizeBytes?: number
+}): Promise<VideoUploadClipRecord> {
+  const db = getDb()
+  const [set] = await db
+    .select()
+    .from(videoUploadSets)
+    .where(eq(videoUploadSets.id, input.setId))
+    .limit(1)
+  if (!set) throw new Error('Upload set not found')
+  if (['queued', 'processing', 'complete'].includes(set.status)) {
+    throw new Error(`Cannot add clips while set is ${set.status}`)
+  }
+
+  const [clip] = await db
+    .insert(videoUploadClips)
+    .values({
+      setId: input.setId,
+      originalFilename: input.originalFilename,
+      blobUrl: input.blobUrl,
+      pathname: input.pathname,
+      sizeBytes: input.sizeBytes ?? 0,
+      uploadComplete: true,
+    })
+    .returning()
+
+  await db
+    .update(videoUploadSets)
+    .set({
+      status: set.status === 'draft' ? 'uploading' : set.status === 'failed' ? 'uploading' : set.status,
+      updatedAt: new Date(),
+      errorMessage: null,
+    })
+    .where(eq(videoUploadSets.id, input.setId))
+
+  return mapClip(clip)
+}
+
+export async function markSetReady(setId: string): Promise<VideoUploadSetRecord> {
+  const db = getDb()
+  const clips = await listClipsForSet(setId)
+  if (clips.length === 0) {
+    throw new Error('Add at least one clip before marking ready')
+  }
+
+  const ordered = orderClipsForMerge(clips)
+  for (let i = 0; i < ordered.length; i++) {
+    await db
+      .update(videoUploadClips)
+      .set({ sortIndex: i })
+      .where(eq(videoUploadClips.id, ordered[i].id))
+  }
+
+  const [updated] = await db
+    .update(videoUploadSets)
+    .set({
+      status: 'ready',
+      updatedAt: new Date(),
+      errorMessage: null,
+    })
+    .where(eq(videoUploadSets.id, setId))
+    .returning()
+
+  if (!updated) throw new Error('Upload set not found')
+  return mapSet(updated)
+}
+
+export async function enqueueVideoUploadSet(
+  setId: string
+): Promise<VideoUploadSetRecord> {
+  const db = getDb()
+  const [set] = await db
+    .select()
+    .from(videoUploadSets)
+    .where(eq(videoUploadSets.id, setId))
+    .limit(1)
+  if (!set) throw new Error('Upload set not found')
+
+  if (!['ready', 'failed'].includes(set.status)) {
+    throw new Error(`Cannot enqueue set in status ${set.status}`)
+  }
+
+  const clips = await listClipsForSet(setId)
+  if (clips.length === 0) {
+    throw new Error('Cannot enqueue a set with no clips')
+  }
+
+  // Refresh GoPro order before queueing
+  const ordered = orderClipsForMerge(clips)
+  for (let i = 0; i < ordered.length; i++) {
+    await db
+      .update(videoUploadClips)
+      .set({ sortIndex: i })
+      .where(eq(videoUploadClips.id, ordered[i].id))
+  }
+
+  const outputFilename =
+    set.outputFilename ||
+    buildUntrimmedOutputFilename({
+      eventName: set.eventName,
+      eventDate: set.eventDate,
+      label: set.label,
+    })
+
+  const [updated] = await db
+    .update(videoUploadSets)
+    .set({
+      status: 'queued',
+      updatedAt: new Date(),
+      errorMessage: null,
+      outputFilename,
+      mergedBlobUrl: null,
+      mergedBlobPathname: null,
+    })
+    .where(eq(videoUploadSets.id, setId))
+    .returning()
+
+  if (!updated) throw new Error('Upload set not found')
+  return mapSet(updated)
+}
+
+/** Optimistic claim of the oldest queued set. */
+export async function claimNextQueuedSet(): Promise<WorkerClaimPayload | null> {
+  const db = getDb()
+  const [next] = await db
+    .select()
+    .from(videoUploadSets)
+    .where(eq(videoUploadSets.status, 'queued'))
+    .orderBy(asc(videoUploadSets.createdAt))
+    .limit(1)
+
+  if (!next) return null
+
+  const [claimed] = await db
+    .update(videoUploadSets)
+    .set({ status: 'processing', updatedAt: new Date(), errorMessage: null })
+    .where(
+      and(
+        eq(videoUploadSets.id, next.id),
+        eq(videoUploadSets.status, 'queued')
+      )
+    )
+    .returning()
+
+  if (!claimed) return null
+
+  const clips = await listClipsForSet(claimed.id)
+  const ordered = orderClipsForMerge(clips)
+  const outputFilename =
+    claimed.outputFilename ||
+    buildUntrimmedOutputFilename({
+      eventName: claimed.eventName,
+      eventDate: claimed.eventDate,
+      label: claimed.label,
+    })
+
+  return {
+    set: mapSet(claimed),
+    clips: ordered,
+    outputFilename,
+  }
+}
+
+export async function completeVideoUploadSet(input: {
+  setId: string
+  mergedBlobUrl: string
+  mergedBlobPathname: string
+  outputFilename?: string
+}): Promise<VideoUploadSetRecord> {
+  const db = getDb()
+  const [updated] = await db
+    .update(videoUploadSets)
+    .set({
+      status: 'complete',
+      updatedAt: new Date(),
+      errorMessage: null,
+      mergedBlobUrl: input.mergedBlobUrl,
+      mergedBlobPathname: input.mergedBlobPathname,
+      ...(input.outputFilename
+        ? { outputFilename: input.outputFilename }
+        : {}),
+    })
+    .where(
+      and(
+        eq(videoUploadSets.id, input.setId),
+        eq(videoUploadSets.status, 'processing')
+      )
+    )
+    .returning()
+
+  if (!updated) {
+    throw new Error('Set not found or not processing')
+  }
+  return mapSet(updated)
+}
+
+export async function failVideoUploadSet(input: {
+  setId: string
+  errorMessage: string
+}): Promise<VideoUploadSetRecord> {
+  const db = getDb()
+  const [updated] = await db
+    .update(videoUploadSets)
+    .set({
+      status: 'failed',
+      updatedAt: new Date(),
+      errorMessage: input.errorMessage.slice(0, 2000),
+    })
+    .where(eq(videoUploadSets.id, input.setId))
+    .returning()
+
+  if (!updated) throw new Error('Upload set not found')
+  return mapSet(updated)
+}
+
+export async function updateVideoUploadSetStatus(
+  setId: string,
+  status: VideoSetStatus
+): Promise<VideoUploadSetRecord> {
+  if (!isValidVideoSetStatus(status)) {
+    throw new Error('Invalid status')
+  }
+  const db = getDb()
+  const [updated] = await db
+    .update(videoUploadSets)
+    .set({ status, updatedAt: new Date() })
+    .where(eq(videoUploadSets.id, setId))
+    .returning()
+  if (!updated) throw new Error('Upload set not found')
+  return mapSet(updated)
+}

--- a/app/lib/video-tools/mutations.ts
+++ b/app/lib/video-tools/mutations.ts
@@ -2,7 +2,10 @@ import { and, asc, eq, inArray } from 'drizzle-orm'
 import { randomUUID } from 'node:crypto'
 import { getDb } from '@/app/lib/db'
 import { videoUploadClips, videoUploadSets } from '@/app/db/schema'
-import { assertSafeVideoClipBlobUrl } from '@/app/lib/video-tools/blob-url'
+import {
+  assertSafeVideoClipBlobUrl,
+  assertSafeVideoMergedBlobUrl,
+} from '@/app/lib/video-tools/blob-url'
 import { orderClipsForMerge } from '@/app/lib/video-tools/gopro-order'
 import {
   buildUntrimmedOutputFilename,
@@ -143,7 +146,39 @@ export async function recordUploadedClip(input: {
   sizeBytes?: number
 }): Promise<VideoUploadClipRecord> {
   const db = getDb()
-  const safeBlobUrl = assertSafeVideoClipBlobUrl(input.blobUrl, input.pathname)
+  const safeBlobUrl = assertSafeVideoClipBlobUrl(
+    input.blobUrl,
+    input.pathname,
+    input.setId
+  )
+  const incomingSize =
+    typeof input.sizeBytes === 'number' && input.sizeBytes > 0
+      ? Math.floor(input.sizeBytes)
+      : 0
+
+  async function reconcileExisting(
+    existing: typeof videoUploadClips.$inferSelect
+  ): Promise<VideoUploadClipRecord> {
+    if (existing.setId !== input.setId) {
+      throw new Error('Clip pathname already belongs to another upload set')
+    }
+    const nextSize = Math.max(existing.sizeBytes, incomingSize)
+    const needsUrl = existing.blobUrl !== safeBlobUrl
+    const needsSize = nextSize > existing.sizeBytes
+    if (!needsUrl && !needsSize) {
+      return mapClip(existing)
+    }
+    const [updated] = await db
+      .update(videoUploadClips)
+      .set({
+        ...(needsUrl ? { blobUrl: safeBlobUrl } : {}),
+        ...(needsSize ? { sizeBytes: nextSize } : {}),
+        uploadComplete: true,
+      })
+      .where(eq(videoUploadClips.id, existing.id))
+      .returning()
+    return mapClip(updated)
+  }
 
   const [existing] = await db
     .select()
@@ -151,20 +186,7 @@ export async function recordUploadedClip(input: {
     .where(eq(videoUploadClips.pathname, input.pathname))
     .limit(1)
   if (existing) {
-    if (existing.setId !== input.setId) {
-      throw new Error('Clip pathname already belongs to another upload set')
-    }
-    if (existing.blobUrl === safeBlobUrl) {
-      return mapClip(existing)
-    }
-    // Replace a mismatched / previously unvalidated URL so the worker never
-    // fetches an attacker-controlled address after an idempotent re-register.
-    const [updated] = await db
-      .update(videoUploadClips)
-      .set({ blobUrl: safeBlobUrl, uploadComplete: true })
-      .where(eq(videoUploadClips.id, existing.id))
-      .returning()
-    return mapClip(updated)
+    return reconcileExisting(existing)
   }
 
   const [set] = await db
@@ -186,7 +208,7 @@ export async function recordUploadedClip(input: {
         originalFilename: input.originalFilename,
         blobUrl: safeBlobUrl,
         pathname: input.pathname,
-        sizeBytes: input.sizeBytes ?? 0,
+        sizeBytes: incomingSize,
         uploadComplete: true,
       })
       .returning()
@@ -198,14 +220,8 @@ export async function recordUploadedClip(input: {
       .from(videoUploadClips)
       .where(eq(videoUploadClips.pathname, input.pathname))
       .limit(1)
-    if (!raced || raced.setId !== input.setId) throw err
-    if (raced.blobUrl === safeBlobUrl) return mapClip(raced)
-    const [updated] = await db
-      .update(videoUploadClips)
-      .set({ blobUrl: safeBlobUrl, uploadComplete: true })
-      .where(eq(videoUploadClips.id, raced.id))
-      .returning()
-    return mapClip(updated)
+    if (!raced) throw err
+    return reconcileExisting(raced)
   }
 
   // Do not demote queued sets; late in-flight uploads may land before the worker claims.
@@ -401,17 +417,38 @@ export async function completeVideoUploadSet(input: {
   if (!claimToken) throw new Error('claimToken is required')
 
   const db = getDb()
+  const [current] = await db
+    .select()
+    .from(videoUploadSets)
+    .where(eq(videoUploadSets.id, input.setId))
+    .limit(1)
+  if (!current) throw new Error('Upload set not found')
+
+  const outputFilename =
+    input.outputFilename?.trim() ||
+    current.outputFilename ||
+    buildUntrimmedOutputFilename({
+      eventName: current.eventName,
+      eventDate: current.eventDate,
+      label: current.label,
+    })
+
+  const safeMergedUrl = assertSafeVideoMergedBlobUrl({
+    blobUrl: input.mergedBlobUrl,
+    pathname: input.mergedBlobPathname,
+    setId: input.setId,
+    outputFilename,
+  })
+
   const [updated] = await db
     .update(videoUploadSets)
     .set({
       status: 'complete',
       updatedAt: new Date(),
       errorMessage: null,
-      mergedBlobUrl: input.mergedBlobUrl,
-      mergedBlobPathname: input.mergedBlobPathname,
-      ...(input.outputFilename
-        ? { outputFilename: input.outputFilename }
-        : {}),
+      mergedBlobUrl: safeMergedUrl,
+      mergedBlobPathname: input.mergedBlobPathname.trim(),
+      outputFilename,
     })
     .where(
       and(

--- a/app/lib/video-tools/mutations.ts
+++ b/app/lib/video-tools/mutations.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq } from 'drizzle-orm'
+import { and, asc, eq, inArray } from 'drizzle-orm'
 import { getDb } from '@/app/lib/db'
 import { videoUploadClips, videoUploadSets } from '@/app/db/schema'
 import { orderClipsForMerge } from '@/app/lib/video-tools/gopro-order'
@@ -116,6 +116,23 @@ export async function markSetUploading(setId: string): Promise<void> {
     )
 }
 
+export const READY_ALLOWED_STATUSES = ['draft', 'uploading', 'ready', 'failed'] as const
+/** Allow clip registration while queued so in-flight multipart uploads can finish before claim. */
+export const CLIP_LOCKED_STATUSES = ['processing', 'complete'] as const
+/** ready = normal; failed/processing = operator retry for stuck or failed merges. */
+export const ENQUEUE_ALLOWED_STATUSES = ['ready', 'failed', 'processing'] as const
+
+function isUniquePathnameError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  const code = 'code' in err ? String(err.code) : ''
+  const message = 'message' in err ? String(err.message) : ''
+  return (
+    code === '23505' ||
+    message.includes('video_upload_clips_pathname_uidx') ||
+    message.toLowerCase().includes('unique')
+  )
+}
+
 export async function recordUploadedClip(input: {
   setId: string
   originalFilename: string
@@ -124,42 +141,89 @@ export async function recordUploadedClip(input: {
   sizeBytes?: number
 }): Promise<VideoUploadClipRecord> {
   const db = getDb()
+
+  const [existing] = await db
+    .select()
+    .from(videoUploadClips)
+    .where(eq(videoUploadClips.pathname, input.pathname))
+    .limit(1)
+  if (existing) {
+    if (existing.setId !== input.setId) {
+      throw new Error('Clip pathname already belongs to another upload set')
+    }
+    return mapClip(existing)
+  }
+
   const [set] = await db
     .select()
     .from(videoUploadSets)
     .where(eq(videoUploadSets.id, input.setId))
     .limit(1)
   if (!set) throw new Error('Upload set not found')
-  if (['queued', 'processing', 'complete'].includes(set.status)) {
+  if ((CLIP_LOCKED_STATUSES as readonly string[]).includes(set.status)) {
     throw new Error(`Cannot add clips while set is ${set.status}`)
   }
 
-  const [clip] = await db
-    .insert(videoUploadClips)
-    .values({
-      setId: input.setId,
-      originalFilename: input.originalFilename,
-      blobUrl: input.blobUrl,
-      pathname: input.pathname,
-      sizeBytes: input.sizeBytes ?? 0,
-      uploadComplete: true,
-    })
-    .returning()
+  let clip: typeof videoUploadClips.$inferSelect
+  try {
+    const [inserted] = await db
+      .insert(videoUploadClips)
+      .values({
+        setId: input.setId,
+        originalFilename: input.originalFilename,
+        blobUrl: input.blobUrl,
+        pathname: input.pathname,
+        sizeBytes: input.sizeBytes ?? 0,
+        uploadComplete: true,
+      })
+      .returning()
+    clip = inserted
+  } catch (err) {
+    if (!isUniquePathnameError(err)) throw err
+    const [raced] = await db
+      .select()
+      .from(videoUploadClips)
+      .where(eq(videoUploadClips.pathname, input.pathname))
+      .limit(1)
+    if (!raced || raced.setId !== input.setId) throw err
+    return mapClip(raced)
+  }
 
-  await db
-    .update(videoUploadSets)
-    .set({
-      status: set.status === 'draft' ? 'uploading' : set.status === 'failed' ? 'uploading' : set.status,
-      updatedAt: new Date(),
-      errorMessage: null,
-    })
-    .where(eq(videoUploadSets.id, input.setId))
+  // Do not demote queued sets; late in-flight uploads may land before the worker claims.
+  if (set.status === 'queued') {
+    await db
+      .update(videoUploadSets)
+      .set({ updatedAt: new Date() })
+      .where(eq(videoUploadSets.id, input.setId))
+  } else {
+    await db
+      .update(videoUploadSets)
+      .set({
+        status:
+          set.status === 'draft' || set.status === 'failed'
+            ? 'uploading'
+            : set.status,
+        updatedAt: new Date(),
+        errorMessage: null,
+      })
+      .where(eq(videoUploadSets.id, input.setId))
+  }
 
   return mapClip(clip)
 }
 
 export async function markSetReady(setId: string): Promise<VideoUploadSetRecord> {
   const db = getDb()
+  const [set] = await db
+    .select()
+    .from(videoUploadSets)
+    .where(eq(videoUploadSets.id, setId))
+    .limit(1)
+  if (!set) throw new Error('Upload set not found')
+  if (!(READY_ALLOWED_STATUSES as readonly string[]).includes(set.status)) {
+    throw new Error(`Cannot mark ready while set is ${set.status}`)
+  }
+
   const clips = await listClipsForSet(setId)
   if (clips.length === 0) {
     throw new Error('Add at least one clip before marking ready')
@@ -180,10 +244,18 @@ export async function markSetReady(setId: string): Promise<VideoUploadSetRecord>
       updatedAt: new Date(),
       errorMessage: null,
     })
-    .where(eq(videoUploadSets.id, setId))
+    .where(
+      and(
+        eq(videoUploadSets.id, setId),
+        // Re-check so we never clobber queued/processing/complete mid-flight.
+        eq(videoUploadSets.status, set.status)
+      )
+    )
     .returning()
 
-  if (!updated) throw new Error('Upload set not found')
+  if (!updated) {
+    throw new Error('Upload set status changed; cannot mark ready')
+  }
   return mapSet(updated)
 }
 
@@ -198,7 +270,7 @@ export async function enqueueVideoUploadSet(
     .limit(1)
   if (!set) throw new Error('Upload set not found')
 
-  if (!['ready', 'failed'].includes(set.status)) {
+  if (!(ENQUEUE_ALLOWED_STATUSES as readonly string[]).includes(set.status)) {
     throw new Error(`Cannot enqueue set in status ${set.status}`)
   }
 
@@ -234,10 +306,17 @@ export async function enqueueVideoUploadSet(
       mergedBlobUrl: null,
       mergedBlobPathname: null,
     })
-    .where(eq(videoUploadSets.id, setId))
+    .where(
+      and(
+        eq(videoUploadSets.id, setId),
+        inArray(videoUploadSets.status, [...ENQUEUE_ALLOWED_STATUSES])
+      )
+    )
     .returning()
 
-  if (!updated) throw new Error('Upload set not found')
+  if (!updated) {
+    throw new Error('Upload set status changed; cannot enqueue')
+  }
   return mapSet(updated)
 }
 
@@ -328,11 +407,27 @@ export async function failVideoUploadSet(input: {
       updatedAt: new Date(),
       errorMessage: input.errorMessage.slice(0, 2000),
     })
-    .where(eq(videoUploadSets.id, input.setId))
+    .where(
+      and(
+        eq(videoUploadSets.id, input.setId),
+        eq(videoUploadSets.status, 'processing')
+      )
+    )
     .returning()
 
-  if (!updated) throw new Error('Upload set not found')
-  return mapSet(updated)
+  if (updated) return mapSet(updated)
+
+  const [existing] = await db
+    .select()
+    .from(videoUploadSets)
+    .where(eq(videoUploadSets.id, input.setId))
+    .limit(1)
+  if (!existing) throw new Error('Upload set not found')
+  // Idempotent / race-safe: do not overwrite a successful complete (or prior fail).
+  if (existing.status === 'complete' || existing.status === 'failed') {
+    return mapSet(existing)
+  }
+  throw new Error(`Set not found or not processing (status: ${existing.status})`)
 }
 
 export async function updateVideoUploadSetStatus(

--- a/app/lib/video-tools/mutations.ts
+++ b/app/lib/video-tools/mutations.ts
@@ -125,8 +125,13 @@ export async function markSetUploading(setId: string): Promise<void> {
 export const READY_ALLOWED_STATUSES = ['draft', 'uploading', 'ready', 'failed'] as const
 /** Allow clip registration while queued so in-flight multipart uploads can finish before claim. */
 export const CLIP_LOCKED_STATUSES = ['processing', 'complete'] as const
-/** New upload tokens only while actively collecting clips. */
-export const UPLOAD_TOKEN_ALLOWED_STATUSES = ['draft', 'uploading', 'failed'] as const
+/** New upload tokens while collecting clips (ready demotes back to uploading). */
+export const UPLOAD_TOKEN_ALLOWED_STATUSES = [
+  'draft',
+  'uploading',
+  'failed',
+  'ready',
+] as const
 /** ready = normal; failed/processing = operator retry for stuck or failed merges. */
 export const ENQUEUE_ALLOWED_STATUSES = ['ready', 'failed', 'processing'] as const
 
@@ -174,6 +179,11 @@ async function releasePendingClipUpload(setId: string): Promise<void> {
       updatedAt: new Date(),
     })
     .where(eq(videoUploadSets.id, setId))
+}
+
+/** Public release for abandoned / failed client uploads after a token was minted. */
+export async function cancelPendingClipUpload(setId: string): Promise<void> {
+  await releasePendingClipUpload(setId)
 }
 
 export async function recordUploadedClip(input: {

--- a/app/lib/video-tools/mutations.ts
+++ b/app/lib/video-tools/mutations.ts
@@ -239,6 +239,14 @@ export async function recordUploadedClip(input: {
       )
     )
 
+  // Only demote statuses we were admitted under. Do not include `failed` unless
+  // this request started against a failed set (retry upload); otherwise a
+  // queued→failed race could clear the merge error.
+  const demoteFrom =
+    set.status === 'failed'
+      ? (['draft', 'ready', 'uploading', 'failed'] as const)
+      : (['draft', 'ready', 'uploading'] as const)
+
   await db
     .update(videoUploadSets)
     .set({
@@ -249,12 +257,7 @@ export async function recordUploadedClip(input: {
     .where(
       and(
         eq(videoUploadSets.id, input.setId),
-        inArray(videoUploadSets.status, [
-          'draft',
-          'failed',
-          'ready',
-          'uploading',
-        ])
+        inArray(videoUploadSets.status, [...demoteFrom])
       )
     )
 

--- a/app/lib/video-tools/mutations.ts
+++ b/app/lib/video-tools/mutations.ts
@@ -1,6 +1,7 @@
 import { and, asc, eq, inArray } from 'drizzle-orm'
 import { getDb } from '@/app/lib/db'
 import { videoUploadClips, videoUploadSets } from '@/app/db/schema'
+import { assertSafeVideoClipBlobUrl } from '@/app/lib/video-tools/blob-url'
 import { orderClipsForMerge } from '@/app/lib/video-tools/gopro-order'
 import {
   buildUntrimmedOutputFilename,
@@ -141,6 +142,7 @@ export async function recordUploadedClip(input: {
   sizeBytes?: number
 }): Promise<VideoUploadClipRecord> {
   const db = getDb()
+  const safeBlobUrl = assertSafeVideoClipBlobUrl(input.blobUrl, input.pathname)
 
   const [existing] = await db
     .select()
@@ -151,7 +153,17 @@ export async function recordUploadedClip(input: {
     if (existing.setId !== input.setId) {
       throw new Error('Clip pathname already belongs to another upload set')
     }
-    return mapClip(existing)
+    if (existing.blobUrl === safeBlobUrl) {
+      return mapClip(existing)
+    }
+    // Replace a mismatched / previously unvalidated URL so the worker never
+    // fetches an attacker-controlled address after an idempotent re-register.
+    const [updated] = await db
+      .update(videoUploadClips)
+      .set({ blobUrl: safeBlobUrl, uploadComplete: true })
+      .where(eq(videoUploadClips.id, existing.id))
+      .returning()
+    return mapClip(updated)
   }
 
   const [set] = await db
@@ -171,7 +183,7 @@ export async function recordUploadedClip(input: {
       .values({
         setId: input.setId,
         originalFilename: input.originalFilename,
-        blobUrl: input.blobUrl,
+        blobUrl: safeBlobUrl,
         pathname: input.pathname,
         sizeBytes: input.sizeBytes ?? 0,
         uploadComplete: true,
@@ -186,7 +198,13 @@ export async function recordUploadedClip(input: {
       .where(eq(videoUploadClips.pathname, input.pathname))
       .limit(1)
     if (!raced || raced.setId !== input.setId) throw err
-    return mapClip(raced)
+    if (raced.blobUrl === safeBlobUrl) return mapClip(raced)
+    const [updated] = await db
+      .update(videoUploadClips)
+      .set({ blobUrl: safeBlobUrl, uploadComplete: true })
+      .where(eq(videoUploadClips.id, raced.id))
+      .returning()
+    return mapClip(updated)
   }
 
   // Do not demote queued sets; late in-flight uploads may land before the worker claims.

--- a/app/lib/video-tools/mutations.ts
+++ b/app/lib/video-tools/mutations.ts
@@ -228,6 +228,7 @@ export async function recordUploadedClip(input: {
   }
 
   // Do not demote queued sets; late in-flight uploads may land before the worker claims.
+  // Demote ready → uploading if another clip arrives after Mark ready.
   if (set.status === 'queued') {
     await db
       .update(videoUploadSets)
@@ -238,7 +239,9 @@ export async function recordUploadedClip(input: {
       .update(videoUploadSets)
       .set({
         status:
-          set.status === 'draft' || set.status === 'failed'
+          set.status === 'draft' ||
+          set.status === 'failed' ||
+          set.status === 'ready'
             ? 'uploading'
             : set.status,
         updatedAt: new Date(),

--- a/app/lib/video-tools/mutations.ts
+++ b/app/lib/video-tools/mutations.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, inArray } from 'drizzle-orm'
+import { and, asc, eq, inArray, sql } from 'drizzle-orm'
 import { randomUUID } from 'node:crypto'
 import { getDb } from '@/app/lib/db'
 import { videoUploadClips, videoUploadSets } from '@/app/db/schema'
@@ -162,9 +162,8 @@ export async function recordUploadedClip(input: {
     if (existing.setId !== input.setId) {
       throw new Error('Clip pathname already belongs to another upload set')
     }
-    const nextSize = Math.max(existing.sizeBytes, incomingSize)
     const needsUrl = existing.blobUrl !== safeBlobUrl
-    const needsSize = nextSize > existing.sizeBytes
+    const needsSize = incomingSize > 0 && incomingSize > existing.sizeBytes
     if (!needsUrl && !needsSize) {
       return mapClip(existing)
     }
@@ -172,7 +171,11 @@ export async function recordUploadedClip(input: {
       .update(videoUploadClips)
       .set({
         ...(needsUrl ? { blobUrl: safeBlobUrl } : {}),
-        ...(needsSize ? { sizeBytes: nextSize } : {}),
+        ...(incomingSize > 0
+          ? {
+              sizeBytes: sql`greatest(${videoUploadClips.sizeBytes}, ${incomingSize})`,
+            }
+          : {}),
         uploadComplete: true,
       })
       .where(eq(videoUploadClips.id, existing.id))
@@ -390,6 +393,22 @@ export async function claimNextQueuedSet(): Promise<WorkerClaimPayload | null> {
 
   const clips = await listClipsForSet(claimed.id)
   const ordered = orderClipsForMerge(clips)
+
+  try {
+    for (const clip of ordered) {
+      assertSafeVideoClipBlobUrl(clip.blobUrl, clip.pathname, claimed.id)
+    }
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Invalid clip blob URL at claim'
+    await failVideoUploadSet({
+      setId: claimed.id,
+      claimToken,
+      errorMessage: `Refusing to merge: ${message}`,
+    })
+    return null
+  }
+
   const outputFilename =
     claimed.outputFilename ||
     buildUntrimmedOutputFilename({

--- a/app/lib/video-tools/mutations.ts
+++ b/app/lib/video-tools/mutations.ts
@@ -48,6 +48,7 @@ function mapSet(row: typeof videoUploadSets.$inferSelect): VideoUploadSetRecord 
     mergedBlobUrl: row.mergedBlobUrl,
     mergedBlobPathname: row.mergedBlobPathname,
     outputFilename: row.outputFilename,
+    pendingUploadCount: row.pendingUploadCount,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   }
@@ -124,6 +125,8 @@ export async function markSetUploading(setId: string): Promise<void> {
 export const READY_ALLOWED_STATUSES = ['draft', 'uploading', 'ready', 'failed'] as const
 /** Allow clip registration while queued so in-flight multipart uploads can finish before claim. */
 export const CLIP_LOCKED_STATUSES = ['processing', 'complete'] as const
+/** New upload tokens only while actively collecting clips. */
+export const UPLOAD_TOKEN_ALLOWED_STATUSES = ['draft', 'uploading', 'failed'] as const
 /** ready = normal; failed/processing = operator retry for stuck or failed merges. */
 export const ENQUEUE_ALLOWED_STATUSES = ['ready', 'failed', 'processing'] as const
 
@@ -136,6 +139,41 @@ function isUniquePathnameError(err: unknown): boolean {
     message.includes('video_upload_clips_pathname_uidx') ||
     message.toLowerCase().includes('unique')
   )
+}
+
+/** Reserve an in-flight upload slot when minting a Blob client token. */
+export async function beginPendingClipUpload(setId: string): Promise<void> {
+  const db = getDb()
+  const [updated] = await db
+    .update(videoUploadSets)
+    .set({
+      pendingUploadCount: sql`${videoUploadSets.pendingUploadCount} + 1`,
+      status: 'uploading',
+      updatedAt: new Date(),
+      errorMessage: null,
+    })
+    .where(
+      and(
+        eq(videoUploadSets.id, setId),
+        inArray(videoUploadSets.status, [...UPLOAD_TOKEN_ALLOWED_STATUSES])
+      )
+    )
+    .returning()
+
+  if (!updated) {
+    throw new Error('Cannot upload clips in the current set status')
+  }
+}
+
+async function releasePendingClipUpload(setId: string): Promise<void> {
+  const db = getDb()
+  await db
+    .update(videoUploadSets)
+    .set({
+      pendingUploadCount: sql`greatest(${videoUploadSets.pendingUploadCount} - 1, 0)`,
+      updatedAt: new Date(),
+    })
+    .where(eq(videoUploadSets.id, setId))
 }
 
 export async function recordUploadedClip(input: {
@@ -227,6 +265,8 @@ export async function recordUploadedClip(input: {
     return reconcileExisting(raced)
   }
 
+  await releasePendingClipUpload(input.setId)
+
   // Conditional updates only — never clobber queued/processing/complete if the
   // set advanced between the initial read and this write (Start merge race).
   await db
@@ -275,6 +315,11 @@ export async function markSetReady(setId: string): Promise<VideoUploadSetRecord>
   if (!(READY_ALLOWED_STATUSES as readonly string[]).includes(set.status)) {
     throw new Error(`Cannot mark ready while set is ${set.status}`)
   }
+  if (set.pendingUploadCount > 0) {
+    throw new Error(
+      `Wait for ${set.pendingUploadCount} in-flight upload(s) to finish before marking ready`
+    )
+  }
 
   const clips = await listClipsForSet(setId)
   if (clips.length === 0) {
@@ -300,13 +345,16 @@ export async function markSetReady(setId: string): Promise<VideoUploadSetRecord>
       and(
         eq(videoUploadSets.id, setId),
         // Re-check so we never clobber queued/processing/complete mid-flight.
-        eq(videoUploadSets.status, set.status)
+        eq(videoUploadSets.status, set.status),
+        eq(videoUploadSets.pendingUploadCount, 0)
       )
     )
     .returning()
 
   if (!updated) {
-    throw new Error('Upload set status changed; cannot mark ready')
+    throw new Error(
+      'Upload set changed or uploads are still in progress; cannot mark ready'
+    )
   }
   return mapSet(updated)
 }
@@ -324,6 +372,11 @@ export async function enqueueVideoUploadSet(
 
   if (!(ENQUEUE_ALLOWED_STATUSES as readonly string[]).includes(set.status)) {
     throw new Error(`Cannot enqueue set in status ${set.status}`)
+  }
+  if (set.pendingUploadCount > 0) {
+    throw new Error(
+      `Wait for ${set.pendingUploadCount} in-flight upload(s) to finish before starting merge`
+    )
   }
 
   const clips = await listClipsForSet(setId)
@@ -363,13 +416,16 @@ export async function enqueueVideoUploadSet(
     .where(
       and(
         eq(videoUploadSets.id, setId),
-        inArray(videoUploadSets.status, [...ENQUEUE_ALLOWED_STATUSES])
+        inArray(videoUploadSets.status, [...ENQUEUE_ALLOWED_STATUSES]),
+        eq(videoUploadSets.pendingUploadCount, 0)
       )
     )
     .returning()
 
   if (!updated) {
-    throw new Error('Upload set status changed; cannot enqueue')
+    throw new Error(
+      'Upload set status changed or uploads are still in progress; cannot enqueue'
+    )
   }
   return mapSet(updated)
 }

--- a/app/lib/video-tools/mutations.ts
+++ b/app/lib/video-tools/mutations.ts
@@ -1,4 +1,5 @@
 import { and, asc, eq, inArray } from 'drizzle-orm'
+import { randomUUID } from 'node:crypto'
 import { getDb } from '@/app/lib/db'
 import { videoUploadClips, videoUploadSets } from '@/app/db/schema'
 import { assertSafeVideoClipBlobUrl } from '@/app/lib/video-tools/blob-url'
@@ -323,6 +324,8 @@ export async function enqueueVideoUploadSet(
       outputFilename,
       mergedBlobUrl: null,
       mergedBlobPathname: null,
+      // Invalidate any in-flight worker claim so a stale complete cannot win.
+      claimToken: null,
     })
     .where(
       and(
@@ -350,9 +353,15 @@ export async function claimNextQueuedSet(): Promise<WorkerClaimPayload | null> {
 
   if (!next) return null
 
+  const claimToken = randomUUID()
   const [claimed] = await db
     .update(videoUploadSets)
-    .set({ status: 'processing', updatedAt: new Date(), errorMessage: null })
+    .set({
+      status: 'processing',
+      updatedAt: new Date(),
+      errorMessage: null,
+      claimToken,
+    })
     .where(
       and(
         eq(videoUploadSets.id, next.id),
@@ -377,15 +386,20 @@ export async function claimNextQueuedSet(): Promise<WorkerClaimPayload | null> {
     set: mapSet(claimed),
     clips: ordered,
     outputFilename,
+    claimToken,
   }
 }
 
 export async function completeVideoUploadSet(input: {
   setId: string
+  claimToken: string
   mergedBlobUrl: string
   mergedBlobPathname: string
   outputFilename?: string
 }): Promise<VideoUploadSetRecord> {
+  const claimToken = input.claimToken.trim()
+  if (!claimToken) throw new Error('claimToken is required')
+
   const db = getDb()
   const [updated] = await db
     .update(videoUploadSets)
@@ -402,21 +416,26 @@ export async function completeVideoUploadSet(input: {
     .where(
       and(
         eq(videoUploadSets.id, input.setId),
-        eq(videoUploadSets.status, 'processing')
+        eq(videoUploadSets.status, 'processing'),
+        eq(videoUploadSets.claimToken, claimToken)
       )
     )
     .returning()
 
   if (!updated) {
-    throw new Error('Set not found or not processing')
+    throw new Error('Set not found, not processing, or stale claim token')
   }
   return mapSet(updated)
 }
 
 export async function failVideoUploadSet(input: {
   setId: string
+  claimToken: string
   errorMessage: string
 }): Promise<VideoUploadSetRecord> {
+  const claimToken = input.claimToken.trim()
+  if (!claimToken) throw new Error('claimToken is required')
+
   const db = getDb()
   const [updated] = await db
     .update(videoUploadSets)
@@ -428,7 +447,8 @@ export async function failVideoUploadSet(input: {
     .where(
       and(
         eq(videoUploadSets.id, input.setId),
-        eq(videoUploadSets.status, 'processing')
+        eq(videoUploadSets.status, 'processing'),
+        eq(videoUploadSets.claimToken, claimToken)
       )
     )
     .returning()
@@ -444,6 +464,14 @@ export async function failVideoUploadSet(input: {
   // Idempotent / race-safe: do not overwrite a successful complete (or prior fail).
   if (existing.status === 'complete' || existing.status === 'failed') {
     return mapSet(existing)
+  }
+  // Another claim owns this set (retry / second worker) — do not mutate.
+  if (
+    existing.status === 'processing' &&
+    existing.claimToken &&
+    existing.claimToken !== claimToken
+  ) {
+    throw new Error('Stale claim token')
   }
   throw new Error(`Set not found or not processing (status: ${existing.status})`)
 }

--- a/app/lib/video-tools/naming.ts
+++ b/app/lib/video-tools/naming.ts
@@ -1,0 +1,39 @@
+/** ASCII slug for filenames: spaces → underscores, strip unsafe chars. */
+export function slugifyForFilename(value: string): string {
+  return value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^A-Za-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .replace(/_+/g, '_')
+    .slice(0, 80)
+}
+
+/**
+ * Merged, not-yet-trimmed deliverable name:
+ * `{EventSlug}_{YYYY-MM-DD}_{LabelSlug}_untrimmed.MP4`
+ */
+export function buildUntrimmedOutputFilename(input: {
+  eventName: string
+  eventDate: string
+  label: string
+}): string {
+  const eventSlug = slugifyForFilename(input.eventName) || 'Event'
+  const labelSlug = slugifyForFilename(input.label) || 'Court'
+  return `${eventSlug}_${input.eventDate}_${labelSlug}_untrimmed.MP4`
+}
+
+export function displayTitle(eventName: string, label: string): string {
+  return `${eventName} · ${label}`
+}
+
+export const VIDEO_TOOLS_BLOB_PREFIX = 'video-tools/'
+
+export function clipBlobPathname(setId: string, originalFilename: string): string {
+  const safeName = originalFilename.replace(/[/\\]/g, '_').replace(/\0/g, '')
+  return `${VIDEO_TOOLS_BLOB_PREFIX}${setId}/clips/${crypto.randomUUID()}-${safeName}`
+}
+
+export function mergedBlobPathname(setId: string, outputFilename: string): string {
+  return `${VIDEO_TOOLS_BLOB_PREFIX}${setId}/merged/${outputFilename}`
+}

--- a/app/lib/video-tools/queries.ts
+++ b/app/lib/video-tools/queries.ts
@@ -21,6 +21,7 @@ function mapSet(row: typeof videoUploadSets.$inferSelect): VideoUploadSetRecord 
     mergedBlobUrl: row.mergedBlobUrl,
     mergedBlobPathname: row.mergedBlobPathname,
     outputFilename: row.outputFilename,
+    pendingUploadCount: row.pendingUploadCount,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   }

--- a/app/lib/video-tools/queries.ts
+++ b/app/lib/video-tools/queries.ts
@@ -1,0 +1,102 @@
+import { asc, desc, eq, sql } from 'drizzle-orm'
+import { getDb } from '@/app/lib/db'
+import { videoUploadClips, videoUploadSets } from '@/app/db/schema'
+import { displayTitle } from '@/app/lib/video-tools/naming'
+import type {
+  VideoUploadClipRecord,
+  VideoUploadSetDetail,
+  VideoUploadSetListItem,
+  VideoUploadSetRecord,
+} from '@/app/lib/video-tools/types'
+
+function mapSet(row: typeof videoUploadSets.$inferSelect): VideoUploadSetRecord {
+  return {
+    id: row.id,
+    eventName: row.eventName,
+    label: row.label,
+    eventDate: row.eventDate,
+    status: row.status,
+    createdByEmail: row.createdByEmail,
+    errorMessage: row.errorMessage,
+    mergedBlobUrl: row.mergedBlobUrl,
+    mergedBlobPathname: row.mergedBlobPathname,
+    outputFilename: row.outputFilename,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  }
+}
+
+function mapClip(row: typeof videoUploadClips.$inferSelect): VideoUploadClipRecord {
+  return {
+    id: row.id,
+    setId: row.setId,
+    originalFilename: row.originalFilename,
+    blobUrl: row.blobUrl,
+    pathname: row.pathname,
+    sizeBytes: row.sizeBytes,
+    sortIndex: row.sortIndex,
+    uploadComplete: row.uploadComplete,
+    createdAt: row.createdAt,
+  }
+}
+
+export async function listVideoUploadSets(): Promise<VideoUploadSetListItem[]> {
+  const db = getDb()
+  const rows = await db
+    .select({
+      set: videoUploadSets,
+      clipCount: sql<number>`cast(count(${videoUploadClips.id}) as int)`,
+    })
+    .from(videoUploadSets)
+    .leftJoin(videoUploadClips, eq(videoUploadClips.setId, videoUploadSets.id))
+    .groupBy(videoUploadSets.id)
+    .orderBy(desc(videoUploadSets.createdAt))
+
+  return rows.map(({ set, clipCount }) => {
+    const mapped = mapSet(set)
+    return {
+      ...mapped,
+      clipCount: Number(clipCount) || 0,
+      displayTitle: displayTitle(mapped.eventName, mapped.label),
+    }
+  })
+}
+
+export async function getVideoUploadSet(id: string): Promise<VideoUploadSetDetail | null> {
+  const db = getDb()
+  const [set] = await db
+    .select()
+    .from(videoUploadSets)
+    .where(eq(videoUploadSets.id, id))
+    .limit(1)
+  if (!set) return null
+
+  const clips = await db
+    .select()
+    .from(videoUploadClips)
+    .where(eq(videoUploadClips.setId, id))
+    .orderBy(
+      asc(videoUploadClips.sortIndex),
+      asc(videoUploadClips.createdAt)
+    )
+
+  const mapped = mapSet(set)
+  return {
+    ...mapped,
+    displayTitle: displayTitle(mapped.eventName, mapped.label),
+    clips: clips.map(mapClip),
+  }
+}
+
+export async function listClipsForSet(setId: string): Promise<VideoUploadClipRecord[]> {
+  const db = getDb()
+  const clips = await db
+    .select()
+    .from(videoUploadClips)
+    .where(eq(videoUploadClips.setId, setId))
+    .orderBy(
+      asc(videoUploadClips.sortIndex),
+      asc(videoUploadClips.createdAt)
+    )
+  return clips.map(mapClip)
+}

--- a/app/lib/video-tools/types.ts
+++ b/app/lib/video-tools/types.ts
@@ -1,0 +1,58 @@
+export const VIDEO_SET_STATUSES = [
+  'draft',
+  'uploading',
+  'ready',
+  'queued',
+  'processing',
+  'complete',
+  'failed',
+] as const
+
+export type VideoSetStatus = (typeof VIDEO_SET_STATUSES)[number]
+
+export function isValidVideoSetStatus(value: string): value is VideoSetStatus {
+  return (VIDEO_SET_STATUSES as readonly string[]).includes(value)
+}
+
+export type VideoUploadClipRecord = {
+  id: string
+  setId: string
+  originalFilename: string
+  blobUrl: string
+  pathname: string
+  sizeBytes: number
+  sortIndex: number | null
+  uploadComplete: boolean
+  createdAt: Date
+}
+
+export type VideoUploadSetRecord = {
+  id: string
+  eventName: string
+  label: string
+  eventDate: string
+  status: string
+  createdByEmail: string
+  errorMessage: string | null
+  mergedBlobUrl: string | null
+  mergedBlobPathname: string | null
+  outputFilename: string | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+export type VideoUploadSetListItem = VideoUploadSetRecord & {
+  clipCount: number
+  displayTitle: string
+}
+
+export type VideoUploadSetDetail = VideoUploadSetRecord & {
+  displayTitle: string
+  clips: VideoUploadClipRecord[]
+}
+
+export type WorkerClaimPayload = {
+  set: VideoUploadSetRecord
+  clips: VideoUploadClipRecord[]
+  outputFilename: string
+}

--- a/app/lib/video-tools/types.ts
+++ b/app/lib/video-tools/types.ts
@@ -55,4 +55,6 @@ export type WorkerClaimPayload = {
   set: VideoUploadSetRecord
   clips: VideoUploadClipRecord[]
   outputFilename: string
+  /** Must be sent back on complete/fail; rotated on each claim. */
+  claimToken: string
 }

--- a/app/lib/video-tools/types.ts
+++ b/app/lib/video-tools/types.ts
@@ -37,6 +37,7 @@ export type VideoUploadSetRecord = {
   mergedBlobUrl: string | null
   mergedBlobPathname: string | null
   outputFilename: string | null
+  pendingUploadCount: number
   createdAt: Date
   updatedAt: Date
 }

--- a/app/lib/video-tools/worker-auth.ts
+++ b/app/lib/video-tools/worker-auth.ts
@@ -1,0 +1,28 @@
+import { timingSafeEqual } from 'node:crypto'
+import { NextRequest, NextResponse } from 'next/server'
+
+function safeEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a)
+  const bBuf = Buffer.from(b)
+  if (aBuf.length !== bBuf.length) return false
+  return timingSafeEqual(aBuf, bBuf)
+}
+
+export function getVideoWorkerSecret(): string | null {
+  const secret = process.env.VIDEO_WORKER_SECRET?.trim()
+  return secret ? secret : null
+}
+
+export function verifyVideoWorkerRequest(request: NextRequest): boolean {
+  const secret = getVideoWorkerSecret()
+  if (!secret) return false
+  const header = request.headers.get('authorization')
+  if (!header) return false
+  const match = /^Bearer\s+(.+)$/i.exec(header)
+  if (!match) return false
+  return safeEqual(match[1].trim(), secret)
+}
+
+export function workerUnauthorizedResponse() {
+  return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+}

--- a/app/video-tools/[id]/page.tsx
+++ b/app/video-tools/[id]/page.tsx
@@ -106,7 +106,8 @@ function VideoUploadSetDetailContent() {
   const canStartOrRetryMerge =
     set != null &&
     set.clips.length > 0 &&
-    ['draft', 'uploading', 'ready', 'failed', 'processing'].includes(set.status)
+    ['ready', 'failed', 'processing'].includes(set.status) &&
+    !busy
 
   async function uploadFiles(files: FileList | File[]) {
     if (!set || !canUpload) return
@@ -217,17 +218,7 @@ function VideoUploadSetDetailContent() {
     setBusy(true)
     setActionError(null)
     try {
-      // Ensure ready first if still uploading
-      if (set && (set.status === 'uploading' || set.status === 'draft')) {
-        const readyRes = await fetch(`/api/video-tools/sets/${setId}`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ action: 'mark_ready' }),
-        })
-        const readyData = await readyRes.json()
-        if (!readyRes.ok) throw new Error(readyData.error || 'Failed to mark ready')
-      }
-
+      // Merge only from ready/failed/processing — require Mark ready after uploads finish.
       const res = await fetch(`/api/video-tools/sets/${setId}/enqueue`, {
         method: 'POST',
       })
@@ -334,7 +325,8 @@ function VideoUploadSetDetailContent() {
       <section className="mt-8">
         <h2 className="text-lg font-medium text-gray-900">Clips</h2>
         <p className="mt-1 text-sm text-gray-600">
-          Drop GoPro MP4s here. Order is applied automatically (GoPro session +
+          Drop GoPro MP4s here. When all uploads are finished, click Mark ready,
+          then Start merge. Order is applied automatically (GoPro session +
           chapter rules) when you start the merge.
         </p>
 

--- a/app/video-tools/[id]/page.tsx
+++ b/app/video-tools/[id]/page.tsx
@@ -186,6 +186,19 @@ function VideoUploadSetDetailContent() {
               idx === i ? { ...u, status: 'error', error: message } : u
             )
           )
+          // Release the pending slot reserved when the Blob token was minted.
+          try {
+            const cancelRes = await fetch(
+              `/api/video-tools/sets/${set.id}/cancel-upload`,
+              { method: 'POST' }
+            )
+            if (cancelRes.ok) {
+              const cancelData = await cancelRes.json()
+              if (cancelData.set) setSet(cancelData.set)
+            }
+          } catch {
+            // best-effort
+          }
         }
       }
       await loadSet()

--- a/app/video-tools/[id]/page.tsx
+++ b/app/video-tools/[id]/page.tsx
@@ -103,6 +103,11 @@ function VideoUploadSetDetailContent() {
     !['queued', 'processing', 'complete'].includes(set.status) &&
     !busy
 
+  const canStartOrRetryMerge =
+    set != null &&
+    set.clips.length > 0 &&
+    ['draft', 'uploading', 'ready', 'failed', 'processing'].includes(set.status)
+
   async function uploadFiles(files: FileList | File[]) {
     if (!set || !canUpload) return
     const list = Array.from(files).filter((f) =>
@@ -322,7 +327,7 @@ function VideoUploadSetDetailContent() {
         <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950">
           {set.status === 'queued'
             ? 'Queued for the merge worker…'
-            : 'Worker is merging clips (this can take a while for large sets).'}
+            : 'Worker is merging clips (this can take a while for large sets). If this seems stuck, use Retry merge to re-queue.'}
         </div>
       )}
 
@@ -442,15 +447,16 @@ function VideoUploadSetDetailContent() {
             Mark ready
           </button>
         )}
-        {set.clips.length > 0 &&
-          ['draft', 'uploading', 'ready', 'failed'].includes(set.status) && (
+        {canStartOrRetryMerge && (
             <button
               type="button"
               onClick={() => void startMerge()}
               disabled={busy}
               className="rounded-md bg-blue-700 px-4 py-2 text-sm font-medium text-white hover:bg-blue-800 disabled:opacity-60"
             >
-              {set.status === 'failed' ? 'Retry merge' : 'Start merge'}
+              {set.status === 'failed' || set.status === 'processing'
+                ? 'Retry merge'
+                : 'Start merge'}
             </button>
           )}
       </div>

--- a/app/video-tools/[id]/page.tsx
+++ b/app/video-tools/[id]/page.tsx
@@ -134,6 +134,7 @@ function VideoUploadSetDetailContent() {
         const file = list[i]
         const pathname = clipBlobPathname(set.id, file.name)
 
+        let tokenMinted = false
         try {
           const blob = await upload(pathname, file, {
             access: 'public',
@@ -144,6 +145,7 @@ function VideoUploadSetDetailContent() {
               originalFilename: file.name,
             }),
             onUploadProgress: (event) => {
+              tokenMinted = true
               setUploads((prev) =>
                 prev.map((u, idx) =>
                   idx === i
@@ -153,6 +155,7 @@ function VideoUploadSetDetailContent() {
               )
             },
           })
+          tokenMinted = true
 
           setUploads((prev) =>
             prev.map((u, idx) =>
@@ -186,18 +189,19 @@ function VideoUploadSetDetailContent() {
               idx === i ? { ...u, status: 'error', error: message } : u
             )
           )
-          // Release the pending slot reserved when the Blob token was minted.
-          try {
-            const cancelRes = await fetch(
-              `/api/video-tools/sets/${set.id}/cancel-upload`,
-              { method: 'POST' }
-            )
-            if (cancelRes.ok) {
-              const cancelData = await cancelRes.json()
-              if (cancelData.set) setSet(cancelData.set)
+          if (tokenMinted) {
+            try {
+              const cancelRes = await fetch(
+                `/api/video-tools/sets/${set.id}/cancel-upload`,
+                { method: 'POST' }
+              )
+              if (cancelRes.ok) {
+                const cancelData = await cancelRes.json()
+                if (cancelData.set) setSet(cancelData.set)
+              }
+            } catch {
+              // best-effort
             }
-          } catch {
-            // best-effort
           }
         }
       }

--- a/app/video-tools/[id]/page.tsx
+++ b/app/video-tools/[id]/page.tsx
@@ -1,0 +1,459 @@
+'use client'
+
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
+import { Suspense, useCallback, useEffect, useRef, useState } from 'react'
+import { upload } from '@vercel/blob/client'
+import { withDevMode } from '@/app/lib/devMode'
+import { useDevMode } from '@/app/hooks/useDevMode'
+import { clipBlobPathname } from '@/app/lib/video-tools/naming'
+import type { VideoUploadSetDetail } from '@/app/lib/video-tools/types'
+
+type UploadProgress = {
+  filename: string
+  percent: number
+  status: 'uploading' | 'registering' | 'done' | 'error'
+  error?: string
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
+  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`
+  return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`
+}
+
+function statusBadgeClass(status: string): string {
+  switch (status) {
+    case 'complete':
+      return 'bg-green-100 text-green-800'
+    case 'failed':
+      return 'bg-red-100 text-red-800'
+    case 'processing':
+    case 'queued':
+      return 'bg-amber-100 text-amber-900'
+    case 'uploading':
+    case 'ready':
+      return 'bg-blue-100 text-blue-800'
+    default:
+      return 'bg-gray-100 text-gray-700'
+  }
+}
+
+export default function VideoUploadSetDetailPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="mx-auto max-w-4xl p-6 text-sm text-gray-600">Loading…</div>
+      }
+    >
+      <VideoUploadSetDetailContent />
+    </Suspense>
+  )
+}
+
+function VideoUploadSetDetailContent() {
+  const params = useParams<{ id: string }>()
+  const setId = params.id
+  const { devMode } = useDevMode()
+  const [set, setSet] = useState<VideoUploadSetDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [uploads, setUploads] = useState<UploadProgress[]>([])
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const loadSet = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/video-tools/sets/${setId}`)
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to load set')
+      setSet(data.set)
+      setError(null)
+      return data.set as VideoUploadSetDetail
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load set')
+      return null
+    } finally {
+      setLoading(false)
+    }
+  }, [setId])
+
+  useEffect(() => {
+    void loadSet()
+  }, [loadSet])
+
+  useEffect(() => {
+    if (!set) return
+    const shouldPoll = set.status === 'queued' || set.status === 'processing'
+    if (shouldPoll) {
+      pollRef.current = setInterval(() => {
+        void loadSet()
+      }, 4000)
+    }
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current)
+    }
+  }, [set?.status, loadSet, set])
+
+  const canUpload =
+    set != null &&
+    !['queued', 'processing', 'complete'].includes(set.status) &&
+    !busy
+
+  async function uploadFiles(files: FileList | File[]) {
+    if (!set || !canUpload) return
+    const list = Array.from(files).filter((f) =>
+      /\.(mp4|mov)$/i.test(f.name) || f.type.startsWith('video/')
+    )
+    if (list.length === 0) {
+      setActionError('Select MP4 or MOV video files')
+      return
+    }
+
+    setBusy(true)
+    setActionError(null)
+    setUploads(
+      list.map((f) => ({
+        filename: f.name,
+        percent: 0,
+        status: 'uploading',
+      }))
+    )
+
+    try {
+      for (let i = 0; i < list.length; i++) {
+        const file = list[i]
+        const pathname = clipBlobPathname(set.id, file.name)
+
+        try {
+          const blob = await upload(pathname, file, {
+            access: 'public',
+            handleUploadUrl: '/api/video-tools/upload',
+            multipart: true,
+            clientPayload: JSON.stringify({
+              setId: set.id,
+              originalFilename: file.name,
+            }),
+            onUploadProgress: (event) => {
+              setUploads((prev) =>
+                prev.map((u, idx) =>
+                  idx === i
+                    ? { ...u, percent: Math.round(event.percentage), status: 'uploading' }
+                    : u
+                )
+              )
+            },
+          })
+
+          setUploads((prev) =>
+            prev.map((u, idx) =>
+              idx === i ? { ...u, percent: 100, status: 'registering' } : u
+            )
+          )
+
+          const reg = await fetch(`/api/video-tools/sets/${set.id}/clips`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              originalFilename: file.name,
+              blobUrl: blob.url,
+              pathname: blob.pathname,
+              sizeBytes: file.size,
+            }),
+          })
+          const regData = await reg.json()
+          if (!reg.ok) throw new Error(regData.error || 'Failed to register clip')
+
+          setUploads((prev) =>
+            prev.map((u, idx) =>
+              idx === i ? { ...u, percent: 100, status: 'done' } : u
+            )
+          )
+          if (regData.set) setSet(regData.set)
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Upload failed'
+          setUploads((prev) =>
+            prev.map((u, idx) =>
+              idx === i ? { ...u, status: 'error', error: message } : u
+            )
+          )
+        }
+      }
+      await loadSet()
+    } finally {
+      setBusy(false)
+      if (fileInputRef.current) fileInputRef.current.value = ''
+    }
+  }
+
+  async function markReady() {
+    setBusy(true)
+    setActionError(null)
+    try {
+      const res = await fetch(`/api/video-tools/sets/${setId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'mark_ready' }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to mark ready')
+      setSet(data.set)
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to mark ready')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function startMerge() {
+    setBusy(true)
+    setActionError(null)
+    try {
+      // Ensure ready first if still uploading
+      if (set && (set.status === 'uploading' || set.status === 'draft')) {
+        const readyRes = await fetch(`/api/video-tools/sets/${setId}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'mark_ready' }),
+        })
+        const readyData = await readyRes.json()
+        if (!readyRes.ok) throw new Error(readyData.error || 'Failed to mark ready')
+      }
+
+      const res = await fetch(`/api/video-tools/sets/${setId}/enqueue`, {
+        method: 'POST',
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to start merge')
+      setSet(data.set)
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to start merge')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-4xl p-6 text-sm text-gray-600" role="status">
+        Loading…
+      </div>
+    )
+  }
+
+  if (error || !set) {
+    return (
+      <div className="mx-auto max-w-4xl p-6">
+        <Link
+          href={withDevMode('/video-tools', devMode)}
+          className="text-sm text-blue-700 hover:underline"
+        >
+          ← Video Tools
+        </Link>
+        <p className="mt-4 text-sm text-red-700" role="alert">
+          {error || 'Upload set not found'}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl p-6">
+      <Link
+        href={withDevMode('/video-tools', devMode)}
+        className="text-sm text-blue-700 hover:underline"
+      >
+        ← Video Tools
+      </Link>
+
+      <div className="mt-3 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">{set.displayTitle}</h1>
+          <p className="mt-1 text-sm text-gray-600">
+            {set.eventDate} · started by {set.createdByEmail}
+          </p>
+        </div>
+        <span
+          className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium capitalize ${statusBadgeClass(set.status)}`}
+        >
+          {set.status}
+        </span>
+      </div>
+
+      {set.errorMessage && (
+        <div
+          className="mt-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800"
+          role="alert"
+        >
+          {set.errorMessage}
+        </div>
+      )}
+
+      {actionError && (
+        <div
+          className="mt-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800"
+          role="alert"
+        >
+          {actionError}
+        </div>
+      )}
+
+      {set.status === 'complete' && set.mergedBlobUrl && (
+        <div className="mt-4 rounded-md border border-green-200 bg-green-50 px-4 py-3">
+          <p className="text-sm font-medium text-green-900">Merge complete</p>
+          <p className="mt-1 text-sm text-green-800">
+            {set.outputFilename || 'untrimmed merge'}
+          </p>
+          <a
+            href={set.mergedBlobUrl}
+            className="mt-2 inline-block text-sm font-medium text-green-900 underline"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Download merged video
+          </a>
+        </div>
+      )}
+
+      {(set.status === 'queued' || set.status === 'processing') && (
+        <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950">
+          {set.status === 'queued'
+            ? 'Queued for the merge worker…'
+            : 'Worker is merging clips (this can take a while for large sets).'}
+        </div>
+      )}
+
+      <section className="mt-8">
+        <h2 className="text-lg font-medium text-gray-900">Clips</h2>
+        <p className="mt-1 text-sm text-gray-600">
+          Drop GoPro MP4s here. Order is applied automatically (GoPro session +
+          chapter rules) when you start the merge.
+        </p>
+
+        {canUpload && (
+          <div
+            className="mt-4 rounded-md border-2 border-dashed border-gray-300 px-4 py-8 text-center"
+            onDragOver={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+            }}
+            onDrop={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              if (e.dataTransfer.files?.length) {
+                void uploadFiles(e.dataTransfer.files)
+              }
+            }}
+          >
+            <p className="text-sm text-gray-600">Drag and drop videos, or</p>
+            <button
+              type="button"
+              className="mt-2 rounded-md bg-blue-700 px-4 py-2 text-sm font-medium text-white hover:bg-blue-800"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={busy}
+            >
+              Choose files
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="video/mp4,video/quicktime,.mp4,.MP4,.mov,.MOV"
+              multiple
+              className="hidden"
+              onChange={(e) => {
+                if (e.target.files?.length) void uploadFiles(e.target.files)
+              }}
+            />
+          </div>
+        )}
+
+        {uploads.length > 0 && (
+          <ul className="mt-4 space-y-2">
+            {uploads.map((u) => (
+              <li
+                key={u.filename + u.status}
+                className="rounded-md border border-gray-200 px-3 py-2 text-sm"
+              >
+                <div className="flex justify-between gap-2">
+                  <span className="truncate font-medium text-gray-800">
+                    {u.filename}
+                  </span>
+                  <span className="shrink-0 text-gray-600">
+                    {u.status === 'error'
+                      ? 'Error'
+                      : u.status === 'done'
+                        ? 'Done'
+                        : u.status === 'registering'
+                          ? 'Saving…'
+                          : `${u.percent}%`}
+                  </span>
+                </div>
+                {u.status === 'uploading' && (
+                  <div className="mt-1 h-1.5 overflow-hidden rounded bg-gray-100">
+                    <div
+                      className="h-full bg-blue-600 transition-all"
+                      style={{ width: `${u.percent}%` }}
+                    />
+                  </div>
+                )}
+                {u.error && (
+                  <p className="mt-1 text-xs text-red-700">{u.error}</p>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {set.clips.length === 0 ? (
+          <p className="mt-4 text-sm text-gray-600">No clips uploaded yet.</p>
+        ) : (
+          <ul className="mt-4 divide-y divide-gray-200 rounded-md border border-gray-200">
+            {set.clips.map((clip, idx) => (
+              <li
+                key={clip.id}
+                className="flex flex-wrap items-center justify-between gap-2 px-3 py-2 text-sm"
+              >
+                <div className="min-w-0">
+                  <span className="text-gray-500 mr-2">
+                    {clip.sortIndex != null ? clip.sortIndex + 1 : idx + 1}.
+                  </span>
+                  <span className="font-medium text-gray-900">
+                    {clip.originalFilename}
+                  </span>
+                </div>
+                <span className="text-gray-600">{formatBytes(clip.sizeBytes)}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <div className="mt-8 flex flex-wrap gap-3">
+        {canUpload && set.clips.length > 0 && set.status !== 'ready' && (
+          <button
+            type="button"
+            onClick={() => void markReady()}
+            disabled={busy}
+            className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-800 hover:bg-gray-50 disabled:opacity-60"
+          >
+            Mark ready
+          </button>
+        )}
+        {set.clips.length > 0 &&
+          ['draft', 'uploading', 'ready', 'failed'].includes(set.status) && (
+            <button
+              type="button"
+              onClick={() => void startMerge()}
+              disabled={busy}
+              className="rounded-md bg-blue-700 px-4 py-2 text-sm font-medium text-white hover:bg-blue-800 disabled:opacity-60"
+            >
+              {set.status === 'failed' ? 'Retry merge' : 'Start merge'}
+            </button>
+          )}
+      </div>
+    </div>
+  )
+}

--- a/app/video-tools/[id]/page.tsx
+++ b/app/video-tools/[id]/page.tsx
@@ -189,6 +189,8 @@ function VideoUploadSetDetailContent() {
               idx === i ? { ...u, status: 'error', error: message } : u
             )
           )
+          // Best-effort: clear this slot if a token was minted. Safe at floor 0;
+          // operators can also use Clear stuck uploads if a count remains.
           if (tokenMinted) {
             try {
               const cancelRes = await fetch(
@@ -226,6 +228,27 @@ function VideoUploadSetDetailContent() {
       setSet(data.set)
     } catch (err) {
       setActionError(err instanceof Error ? err.message : 'Failed to mark ready')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function resetPending() {
+    setBusy(true)
+    setActionError(null)
+    try {
+      const res = await fetch(`/api/video-tools/sets/${setId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'reset_pending_uploads' }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to clear pending uploads')
+      setSet(data.set)
+    } catch (err) {
+      setActionError(
+        err instanceof Error ? err.message : 'Failed to clear pending uploads'
+      )
     } finally {
       setBusy(false)
     }
@@ -458,6 +481,17 @@ function VideoUploadSetDetailContent() {
               : 'Mark ready'}
           </button>
         )}
+        {set.pendingUploadCount > 0 &&
+          !['queued', 'processing', 'complete'].includes(set.status) && (
+            <button
+              type="button"
+              onClick={() => void resetPending()}
+              disabled={busy}
+              className="rounded-md border border-amber-300 bg-amber-50 px-4 py-2 text-sm font-medium text-amber-950 hover:bg-amber-100 disabled:opacity-60"
+            >
+              Clear stuck uploads ({set.pendingUploadCount})
+            </button>
+          )}
         {canStartOrRetryMerge && (
             <button
               type="button"

--- a/app/video-tools/[id]/page.tsx
+++ b/app/video-tools/[id]/page.tsx
@@ -433,10 +433,12 @@ function VideoUploadSetDetailContent() {
           <button
             type="button"
             onClick={() => void markReady()}
-            disabled={busy}
+            disabled={busy || set.pendingUploadCount > 0}
             className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-800 hover:bg-gray-50 disabled:opacity-60"
           >
-            Mark ready
+            {set.pendingUploadCount > 0
+              ? `Mark ready (${set.pendingUploadCount} uploading…)`
+              : 'Mark ready'}
           </button>
         )}
         {canStartOrRetryMerge && (

--- a/app/video-tools/new/page.tsx
+++ b/app/video-tools/new/page.tsx
@@ -1,0 +1,137 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { Suspense, useState } from 'react'
+import { withDevMode } from '@/app/lib/devMode'
+import { useDevMode } from '@/app/hooks/useDevMode'
+
+export default function NewVideoUploadSetPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="mx-auto max-w-lg p-6 text-sm text-gray-600">Loading…</div>
+      }
+    >
+      <NewVideoUploadSetContent />
+    </Suspense>
+  )
+}
+
+function NewVideoUploadSetContent() {
+  const router = useRouter()
+  const { devMode } = useDevMode()
+  const [eventName, setEventName] = useState('')
+  const [label, setLabel] = useState('')
+  const [eventDate, setEventDate] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setSaving(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/video-tools/sets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ eventName, label, eventDate }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to create upload set')
+      router.push(withDevMode(`/video-tools/${data.set.id}`, devMode))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create upload set')
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-lg p-6">
+      <div className="mb-6">
+        <Link
+          href={withDevMode('/video-tools', devMode)}
+          className="text-sm text-blue-700 hover:underline"
+        >
+          ← Video Tools
+        </Link>
+        <h1 className="mt-2 text-2xl font-semibold text-gray-900">New upload set</h1>
+        <p className="mt-1 text-sm text-gray-600">
+          One set = one court or camera session (for example Court 1). Create
+          another set for Court 2 so both can upload at the same time.
+        </p>
+      </div>
+
+      <form onSubmit={(e) => void onSubmit(e)} className="space-y-4">
+        <div>
+          <label htmlFor="eventName" className="block text-sm font-medium text-gray-800">
+            Event name
+          </label>
+          <input
+            id="eventName"
+            type="text"
+            required
+            value={eventName}
+            onChange={(e) => setEventName(e.target.value)}
+            placeholder="BDL Season 7: Summer Remix"
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-600 focus:outline-none focus:ring-1 focus:ring-blue-600"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="label" className="block text-sm font-medium text-gray-800">
+            Label (court / session)
+          </label>
+          <input
+            id="label"
+            type="text"
+            required
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="Court 1"
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-600 focus:outline-none focus:ring-1 focus:ring-blue-600"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="eventDate" className="block text-sm font-medium text-gray-800">
+            Event date
+          </label>
+          <input
+            id="eventDate"
+            type="date"
+            required
+            value={eventDate}
+            onChange={(e) => setEventDate(e.target.value)}
+            className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-600 focus:outline-none focus:ring-1 focus:ring-blue-600"
+          />
+        </div>
+
+        {error && (
+          <div
+            className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800"
+            role="alert"
+          >
+            {error}
+          </div>
+        )}
+
+        <div className="flex gap-3 pt-2">
+          <button
+            type="submit"
+            disabled={saving}
+            className="rounded-md bg-blue-700 px-4 py-2 text-sm font-medium text-white hover:bg-blue-800 disabled:opacity-60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700"
+          >
+            {saving ? 'Creating…' : 'Create set'}
+          </button>
+          <Link
+            href={withDevMode('/video-tools', devMode)}
+            className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            Cancel
+          </Link>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/app/video-tools/page.tsx
+++ b/app/video-tools/page.tsx
@@ -1,0 +1,151 @@
+'use client'
+
+import Link from 'next/link'
+import { Suspense, useCallback, useEffect, useState } from 'react'
+import { withDevMode } from '@/app/lib/devMode'
+import { useDevMode } from '@/app/hooks/useDevMode'
+import type { VideoUploadSetListItem } from '@/app/lib/video-tools/types'
+
+function formatDisplayDate(isoDate: string): string {
+  const d = new Date(`${isoDate}T12:00:00`)
+  if (Number.isNaN(d.getTime())) return isoDate
+  return d.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+function statusBadgeClass(status: string): string {
+  switch (status) {
+    case 'complete':
+      return 'bg-green-100 text-green-800'
+    case 'failed':
+      return 'bg-red-100 text-red-800'
+    case 'processing':
+    case 'queued':
+      return 'bg-amber-100 text-amber-900'
+    case 'uploading':
+    case 'ready':
+      return 'bg-blue-100 text-blue-800'
+    default:
+      return 'bg-gray-100 text-gray-700'
+  }
+}
+
+export default function VideoToolsPage() {
+  return (
+    <Suspense
+      fallback={
+        <div
+          className="mx-auto max-w-5xl p-6 text-sm text-gray-600"
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+        >
+          Loading…
+        </div>
+      }
+    >
+      <VideoToolsPageContent />
+    </Suspense>
+  )
+}
+
+function VideoToolsPageContent() {
+  const { devMode } = useDevMode()
+  const [sets, setSets] = useState<VideoUploadSetListItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const loadSets = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/video-tools/sets')
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to load upload sets')
+      setSets(data.sets)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load upload sets')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadSets()
+  }, [loadSets])
+
+  return (
+    <div className="mx-auto max-w-5xl p-6">
+      <div className="flex flex-wrap items-start justify-between gap-4 mb-6">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">Video Tools</h1>
+          <p className="mt-1 text-sm text-gray-600">
+            Upload GoPro clips per court or session, then merge into one untrimmed
+            video. Multiple sets can run at the same time.
+          </p>
+        </div>
+        <Link
+          href={withDevMode('/video-tools/new', devMode)}
+          className="inline-flex items-center rounded-md bg-blue-700 px-4 py-2 text-sm font-medium text-white hover:bg-blue-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700"
+        >
+          New upload set
+        </Link>
+      </div>
+
+      {error && (
+        <div
+          className="mb-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800"
+          role="alert"
+        >
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <p className="text-sm text-gray-600" role="status" aria-live="polite">
+          Loading…
+        </p>
+      ) : sets.length === 0 ? (
+        <div className="rounded-md border border-dashed border-gray-300 px-4 py-10 text-center">
+          <p className="text-sm text-gray-600">No upload sets yet.</p>
+          <Link
+            href={withDevMode('/video-tools/new', devMode)}
+            className="mt-3 inline-block text-sm font-medium text-blue-700 hover:underline"
+          >
+            Create the first set
+          </Link>
+        </div>
+      ) : (
+        <ul className="divide-y divide-gray-200 rounded-md border border-gray-200 bg-white">
+          {sets.map((set) => (
+            <li key={set.id}>
+              <Link
+                href={withDevMode(`/video-tools/${set.id}`, devMode)}
+                className="flex flex-wrap items-center justify-between gap-3 px-4 py-3 hover:bg-gray-50 focus-visible:bg-gray-50 focus-visible:outline-none"
+              >
+                <div className="min-w-0">
+                  <div className="font-medium text-gray-900 truncate">
+                    {set.displayTitle}
+                  </div>
+                  <div className="mt-0.5 text-sm text-gray-600">
+                    {formatDisplayDate(set.eventDate)} · {set.clipCount} clip
+                    {set.clipCount === 1 ? '' : 's'} · {set.createdByEmail}
+                  </div>
+                </div>
+                <span
+                  className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium capitalize ${statusBadgeClass(set.status)}`}
+                >
+                  {set.status}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/drizzle/0016_video_tools.sql
+++ b/drizzle/0016_video_tools.sql
@@ -1,0 +1,42 @@
+CREATE TABLE IF NOT EXISTS "video_upload_sets" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"event_name" text NOT NULL,
+	"label" text NOT NULL,
+	"event_date" date NOT NULL,
+	"status" text DEFAULT 'draft' NOT NULL,
+	"created_by_email" text NOT NULL,
+	"error_message" text,
+	"merged_blob_url" text,
+	"merged_blob_pathname" text,
+	"output_filename" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "video_upload_clips" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"set_id" uuid NOT NULL,
+	"original_filename" text NOT NULL,
+	"blob_url" text NOT NULL,
+	"pathname" text NOT NULL,
+	"size_bytes" integer DEFAULT 0 NOT NULL,
+	"sort_index" integer,
+	"upload_complete" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "video_upload_clips" ADD CONSTRAINT "video_upload_clips_set_id_video_upload_sets_id_fk" FOREIGN KEY ("set_id") REFERENCES "public"."video_upload_sets"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "video_upload_sets_status_idx" ON "video_upload_sets" USING btree ("status");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "video_upload_sets_event_date_idx" ON "video_upload_sets" USING btree ("event_date");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "video_upload_sets_created_at_idx" ON "video_upload_sets" USING btree ("created_at");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "video_upload_clips_set_id_idx" ON "video_upload_clips" USING btree ("set_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "video_upload_clips_pathname_uidx" ON "video_upload_clips" USING btree ("pathname");

--- a/drizzle/0017_video_tools_claim_token.sql
+++ b/drizzle/0017_video_tools_claim_token.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "video_upload_sets" ADD COLUMN IF NOT EXISTS "claim_token" uuid;

--- a/drizzle/0018_video_tools_pending_uploads.sql
+++ b/drizzle/0018_video_tools_pending_uploads.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "video_upload_sets" ADD COLUMN IF NOT EXISTS "pending_upload_count" integer DEFAULT 0 NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1753804800000,
       "tag": "0016_video_tools",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1753812000000,
+      "tag": "0017_video_tools_claim_token",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1753304000000,
       "tag": "0015_player_photo",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1753804800000,
+      "tag": "0016_video_tools",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1753812000000,
       "tag": "0017_video_tools_claim_token",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1753815600000,
+      "tag": "0018_video_tools_pending_uploads",
+      "breakpoints": true
     }
   ]
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -11,6 +11,9 @@ function isPublicPath(pathname: string): boolean {
   // Allow session probe + logout without a valid cookie (401 / clear cookie).
   if (pathname === '/api/admin/session') return true
   if (pathname === '/api/admin/logout') return true
+  // Video Tools: Blob upload completion webhook + secret-gated worker APIs.
+  if (pathname === '/api/video-tools/upload') return true
+  if (pathname.startsWith('/api/video-tools/worker/')) return true
   return false
 }
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "db:migrate:deploy": "node scripts/migrate-on-deploy.mjs",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
-    "smoke:preview": "node scripts/smoke-preview.mjs"
+    "smoke:preview": "node scripts/smoke-preview.mjs",
+    "worker:video-merge": "node workers/video-merge/index.mjs"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/workers/video-merge/Dockerfile
+++ b/workers/video-merge/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:22-bookworm-slim
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ffmpeg ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install --omit=dev
+
+COPY index.mjs ./
+
+ENV NODE_ENV=production
+CMD ["node", "index.mjs"]

--- a/workers/video-merge/README.md
+++ b/workers/video-merge/README.md
@@ -1,0 +1,38 @@
+# Video Tools merge worker
+
+Long-running Node process that claims queued upload sets from bdl-admin, downloads
+clips from Vercel Blob, concatenates with system `ffmpeg` (`-c copy`, GoPro order),
+and uploads `{Event}_{date}_{Label}_untrimmed.MP4`.
+
+## Required env
+
+| Variable | Purpose |
+|----------|---------|
+| `VIDEO_TOOLS_API_BASE` | Admin app origin, e.g. `https://admin.bostondodgeballleague.com` |
+| `VIDEO_WORKER_SECRET` | Same value as in the admin app (Bearer auth) |
+| `BLOB_READ_WRITE_TOKEN` | Vercel Blob read-write token |
+
+## Local run
+
+```bash
+# from bdl-admin repo root (needs ffmpeg + npm deps)
+export VIDEO_TOOLS_API_BASE=http://localhost:3000
+export VIDEO_WORKER_SECRET=dev-secret
+export BLOB_READ_WRITE_TOKEN=vercel_blob_...
+node workers/video-merge/index.mjs
+```
+
+Also set `VIDEO_WORKER_SECRET` in the Next.js app (`.env.local` / Vercel).
+
+## Docker / Fly.io
+
+Build context is this directory (`workers/video-merge`):
+
+```bash
+cd workers/video-merge
+docker build -t bdl-video-merge .
+# or from here:
+fly deploy
+```
+
+Disk and memory need room for concurrent multi-GB court sets; bump VM size as needed.

--- a/workers/video-merge/fly.toml
+++ b/workers/video-merge/fly.toml
@@ -14,6 +14,8 @@ primary_region = "bos"
 [env]
   POLL_INTERVAL_MS = "15000"
 
+# Disk: clip downloads + merged output need headroom (uploads allow up to 20GB/clip).
+# Attach a volume or raise the VM size before large multi-court merges.
 [[vm]]
   size = "shared-cpu-2x"
   memory = "4gb"

--- a/workers/video-merge/fly.toml
+++ b/workers/video-merge/fly.toml
@@ -1,0 +1,19 @@
+# fly.toml — example config for the Video Tools merge worker.
+# Deploy from repo root:
+#   fly apps create bdl-video-merge
+#   fly secrets set VIDEO_TOOLS_API_BASE=https://admin.bostondodgeballleague.com \
+#     VIDEO_WORKER_SECRET=... BLOB_READ_WRITE_TOKEN=...
+#   fly deploy -c workers/video-merge/fly.toml
+
+app = "bdl-video-merge"
+primary_region = "bos"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  POLL_INTERVAL_MS = "15000"
+
+[[vm]]
+  size = "shared-cpu-2x"
+  memory = "4gb"

--- a/workers/video-merge/index.mjs
+++ b/workers/video-merge/index.mjs
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+/**
+ * Video Tools merge worker.
+ *
+ * Polls bdl-admin for queued upload sets, downloads clips from Vercel Blob,
+ * concatenates with ffmpeg (-c copy) in GoPro-aware order, uploads the
+ * untrimmed result, and reports complete/fail.
+ *
+ * Env:
+ *   VIDEO_TOOLS_API_BASE   e.g. https://admin.bostondodgeballleague.com
+ *   VIDEO_WORKER_SECRET    shared secret (Bearer)
+ *   BLOB_READ_WRITE_TOKEN  Vercel Blob RW token (for put of merged output)
+ *   POLL_INTERVAL_MS       optional, default 15000
+ *   WORK_DIR               optional temp dir, default os.tmpdir()/video-merge-worker
+ *
+ * Requires: ffmpeg, ffprobe on PATH.
+ */
+
+import { createWriteStream, promises as fs } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { spawn } from 'node:child_process'
+import { pipeline } from 'node:stream/promises'
+import { Readable } from 'node:stream'
+
+const API_BASE = (process.env.VIDEO_TOOLS_API_BASE || '').replace(/\/$/, '')
+const SECRET = process.env.VIDEO_WORKER_SECRET || ''
+const BLOB_TOKEN = process.env.BLOB_READ_WRITE_TOKEN || ''
+const POLL_MS = Number(process.env.POLL_INTERVAL_MS || 15000)
+const WORK_ROOT =
+  process.env.WORK_DIR || path.join(tmpdir(), 'video-merge-worker')
+
+if (!API_BASE) {
+  console.error('VIDEO_TOOLS_API_BASE is required')
+  process.exit(1)
+}
+if (!SECRET) {
+  console.error('VIDEO_WORKER_SECRET is required')
+  process.exit(1)
+}
+if (!BLOB_TOKEN) {
+  console.error('BLOB_READ_WRITE_TOKEN is required')
+  process.exit(1)
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function api(pathname, options = {}) {
+  const res = await fetch(`${API_BASE}${pathname}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${SECRET}`,
+      'Content-Type': 'application/json',
+      ...(options.headers || {}),
+    },
+  })
+  const data = await res.json().catch(() => ({}))
+  if (!res.ok) {
+    throw new Error(data.error || `API ${pathname} failed (${res.status})`)
+  }
+  return data
+}
+
+function run(cmd, args, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      ...opts,
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (d) => {
+      stdout += d.toString()
+    })
+    child.stderr.on('data', (d) => {
+      stderr += d.toString()
+    })
+    child.on('error', reject)
+    child.on('close', (code) => {
+      if (code === 0) resolve({ stdout, stderr })
+      else {
+        reject(
+          new Error(
+            `${cmd} exited ${code}: ${stderr.slice(-2000) || stdout.slice(-2000)}`
+          )
+        )
+      }
+    })
+  })
+}
+
+async function downloadToFile(url, destPath) {
+  const res = await fetch(url)
+  if (!res.ok) {
+    throw new Error(`Download failed ${res.status} for ${url}`)
+  }
+  if (!res.body) throw new Error('Empty download body')
+  await pipeline(Readable.fromWeb(res.body), createWriteStream(destPath))
+}
+
+async function probeStream(filePath) {
+  const { stdout } = await run('ffprobe', [
+    '-v',
+    'error',
+    '-select_streams',
+    'v:0',
+    '-show_entries',
+    'stream=codec_name,width,height,r_frame_rate,avg_frame_rate,time_base',
+    '-of',
+    'json',
+    filePath,
+  ])
+  const parsed = JSON.parse(stdout)
+  const stream = parsed.streams?.[0]
+  if (!stream) throw new Error(`No video stream in ${filePath}`)
+  return {
+    codec: stream.codec_name,
+    width: stream.width,
+    height: stream.height,
+    rFrameRate: stream.r_frame_rate,
+    timeBase: stream.time_base,
+  }
+}
+
+function assertCompatible(probes, filenames) {
+  const first = probes[0]
+  for (let i = 1; i < probes.length; i++) {
+    const p = probes[i]
+    if (
+      p.codec !== first.codec ||
+      p.width !== first.width ||
+      p.height !== first.height
+    ) {
+      throw new Error(
+        `Incompatible clips for stream-copy concat: ` +
+          `${filenames[0]} (${first.codec} ${first.width}x${first.height}) vs ` +
+          `${filenames[i]} (${p.codec} ${p.width}x${p.height}). ` +
+          `Split into separate merges or re-encode.`
+      )
+    }
+  }
+}
+
+async function uploadMerged(localPath, pathname) {
+  const { put } = await import('@vercel/blob')
+  const { createReadStream } = await import('node:fs')
+  const blob = await put(pathname, createReadStream(localPath), {
+    access: 'public',
+    addRandomSuffix: false,
+    contentType: 'video/mp4',
+    multipart: true,
+    token: BLOB_TOKEN,
+  })
+  return blob
+}
+
+async function processJob(job) {
+  const { set, clips, outputFilename } = job
+  console.log(
+    `[job ${set.id}] ${set.eventName} · ${set.label} — ${clips.length} clips → ${outputFilename}`
+  )
+
+  if (!clips.length) {
+    throw new Error('Job has no clips')
+  }
+
+  const workDir = path.join(WORK_ROOT, set.id)
+  await fs.mkdir(workDir, { recursive: true })
+
+  const localFiles = []
+  try {
+    for (let i = 0; i < clips.length; i++) {
+      const clip = clips[i]
+      const safe = `${String(i).padStart(4, '0')}_${path.basename(clip.originalFilename)}`
+      const dest = path.join(workDir, safe)
+      console.log(`[job ${set.id}] download ${clip.originalFilename}`)
+      await downloadToFile(clip.blobUrl, dest)
+      localFiles.push({ path: dest, name: clip.originalFilename })
+    }
+
+    console.log(`[job ${set.id}] probing compatibility`)
+    const probes = []
+    for (const f of localFiles) {
+      probes.push(await probeStream(f.path))
+    }
+    assertCompatible(
+      probes,
+      localFiles.map((f) => f.name)
+    )
+
+    const listPath = path.join(workDir, 'concat_list.txt')
+    const listBody = localFiles
+      .map((f) => `file '${f.path.replace(/'/g, `'\\''`)}'`)
+      .join('\n')
+    await fs.writeFile(listPath, listBody, 'utf8')
+
+    const outPath = path.join(workDir, outputFilename)
+    console.log(`[job ${set.id}] ffmpeg concat`)
+    await run('ffmpeg', [
+      '-y',
+      '-f',
+      'concat',
+      '-safe',
+      '0',
+      '-i',
+      listPath,
+      '-c',
+      'copy',
+      outPath,
+    ])
+
+    const mergedPathname = `video-tools/${set.id}/merged/${outputFilename}`
+    console.log(`[job ${set.id}] upload ${mergedPathname}`)
+    const blob = await uploadMerged(outPath, mergedPathname)
+
+    await api('/api/video-tools/worker/complete', {
+      method: 'POST',
+      body: JSON.stringify({
+        setId: set.id,
+        mergedBlobUrl: blob.url,
+        mergedBlobPathname: blob.pathname,
+        outputFilename,
+      }),
+    })
+    console.log(`[job ${set.id}] complete`)
+  } finally {
+    await fs.rm(workDir, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+async function tick() {
+  const data = await api('/api/video-tools/worker/claim', { method: 'POST' })
+  const job = data.job
+  if (!job) return false
+
+  try {
+    await processJob(job)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.error(`[job ${job.set.id}] failed:`, message)
+    try {
+      await api('/api/video-tools/worker/fail', {
+        method: 'POST',
+        body: JSON.stringify({
+          setId: job.set.id,
+          errorMessage: message,
+        }),
+      })
+    } catch (failErr) {
+      console.error('Failed to report failure:', failErr)
+    }
+  }
+  return true
+}
+
+async function main() {
+  await run('ffmpeg', ['-version']).catch(() => {
+    console.error('ffmpeg not found on PATH')
+    process.exit(1)
+  })
+  await run('ffprobe', ['-version']).catch(() => {
+    console.error('ffprobe not found on PATH')
+    process.exit(1)
+  })
+
+  console.log(`Video merge worker polling ${API_BASE} every ${POLL_MS}ms`)
+  await fs.mkdir(WORK_ROOT, { recursive: true })
+
+  for (;;) {
+    try {
+      const worked = await tick()
+      if (!worked) await sleep(POLL_MS)
+    } catch (err) {
+      console.error('Poll error:', err)
+      await sleep(POLL_MS)
+    }
+  }
+}
+
+main()

--- a/workers/video-merge/index.mjs
+++ b/workers/video-merge/index.mjs
@@ -157,7 +157,10 @@ async function uploadMerged(localPath, pathname) {
 }
 
 async function processJob(job) {
-  const { set, clips, outputFilename } = job
+  const { set, clips, outputFilename, claimToken } = job
+  if (!claimToken) {
+    throw new Error('Job missing claimToken')
+  }
   console.log(
     `[job ${set.id}] ${set.eventName} · ${set.label} — ${clips.length} clips → ${outputFilename}`
   )
@@ -219,6 +222,7 @@ async function processJob(job) {
       method: 'POST',
       body: JSON.stringify({
         setId: set.id,
+        claimToken,
         mergedBlobUrl: blob.url,
         mergedBlobPathname: blob.pathname,
         outputFilename,
@@ -245,6 +249,7 @@ async function tick() {
         method: 'POST',
         body: JSON.stringify({
           setId: job.set.id,
+          claimToken: job.claimToken,
           errorMessage: message,
         }),
       })

--- a/workers/video-merge/package.json
+++ b/workers/video-merge/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "bdl-video-merge-worker",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@vercel/blob": "^2.4.0"
+  }
+}


### PR DESCRIPTION
## Summary
- Promotes preview → main after merging [#118](https://github.com/jsartin513/bdl-admin/pull/118): Team Video Tools for concurrent GoPro upload sets, Blob multipart uploads, merge job APIs, `/video-tools` UI, and `workers/video-merge`.
- Includes Bugbot follow-up hardening: idempotent clip registration, safer status transitions (`mark_ready` / `fail` / stuck `processing` retry).

## Env (set on Vercel; also needed on worker)
| Where | Variable |
|-------|----------|
| App | `VIDEO_WORKER_SECRET` (+ existing `BLOB_READ_WRITE_TOKEN`) |
| Worker | `VIDEO_TOOLS_API_BASE`, `VIDEO_WORKER_SECRET`, `BLOB_READ_WRITE_TOKEN` |

Ensure migration `0016_video_tools.sql` runs on deploy.

## Test plan
- [ ] Preview deploy healthy with Video Tools nav + pages
- [ ] `npx vitest run app/lib/video-tools` (already in CI)
- [ ] Create concurrent court sets, upload clips, enqueue merge (worker optional for this promote)
- [ ] Confirm main merge gate `from-preview` passes (head is `preview`)


Made with [Cursor](https://cursor.com)