### PR TITLE
Fix Video Tools Blob URL SSRF and GoPro MOV ordering

### DIFF
--- a/app/api/video-tools/sets/[id]/clips/route.ts
+++ b/app/api/video-tools/sets/[id]/clips/route.ts
@@ -6,6 +6,7 @@ import {
 import { recordUploadedClip } from '@/app/lib/video-tools/mutations'
 import { getVideoUploadSet } from '@/app/lib/video-tools/queries'
 import { VIDEO_TOOLS_BLOB_PREFIX } from '@/app/lib/video-tools/naming'
+import { assertSafeVideoClipBlobUrl } from '@/app/lib/video-tools/blob-url'
 
 type RouteContext = { params: Promise<{ id: string }> }
 
@@ -42,6 +43,14 @@ export async function POST(request: NextRequest, context: RouteContext) {
       return NextResponse.json({ error: 'Invalid pathname for this set' }, { status: 400 })
     }
 
+    let safeBlobUrl: string
+    try {
+      safeBlobUrl = assertSafeVideoClipBlobUrl(body.blobUrl, body.pathname)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Invalid blobUrl'
+      return NextResponse.json({ error: message }, { status: 400 })
+    }
+
     const set = await getVideoUploadSet(setId)
     if (!set) {
       return NextResponse.json({ error: 'Upload set not found' }, { status: 404 })
@@ -51,7 +60,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
     const clip = await recordUploadedClip({
       setId,
       originalFilename: body.originalFilename,
-      blobUrl: body.blobUrl,
+      blobUrl: safeBlobUrl,
       pathname: body.pathname,
       sizeBytes: body.sizeBytes ?? 0,
     })

--- a/app/lib/video-tools/__tests__/blob-url.test.ts
+++ b/app/lib/video-tools/__tests__/blob-url.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { assertSafeVideoClipBlobUrl } from '@/app/lib/video-tools/blob-url'
+
+describe('assertSafeVideoClipBlobUrl', () => {
+  const pathname =
+    'video-tools/11111111-1111-1111-1111-111111111111/clips/abc-GX010100.MP4'
+
+  it('accepts matching Vercel Blob https URLs', () => {
+    const url = `https://abc123.public.blob.vercel-storage.com/${pathname}`
+    expect(assertSafeVideoClipBlobUrl(url, pathname)).toBe(url)
+  })
+
+  it('rejects non-blob hosts (SSRF)', () => {
+    expect(() =>
+      assertSafeVideoClipBlobUrl(
+        `https://169.254.169.254/${pathname}`,
+        pathname
+      )
+    ).toThrow(/Vercel Blob/)
+  })
+
+  it('rejects http', () => {
+    expect(() =>
+      assertSafeVideoClipBlobUrl(
+        `http://abc123.public.blob.vercel-storage.com/${pathname}`,
+        pathname
+      )
+    ).toThrow(/https/)
+  })
+
+  it('rejects pathname mismatch', () => {
+    expect(() =>
+      assertSafeVideoClipBlobUrl(
+        `https://abc123.public.blob.vercel-storage.com/${pathname}`,
+        'video-tools/other/clips/x.MP4'
+      )
+    ).toThrow(/must match/)
+  })
+})

--- a/app/lib/video-tools/__tests__/gopro-order.test.ts
+++ b/app/lib/video-tools/__tests__/gopro-order.test.ts
@@ -54,9 +54,26 @@ describe('orderClipsForMerge', () => {
     ])
   })
 
+  it('orders GoPro chapters for .mov the same as .mp4', () => {
+    const clips = [
+      { originalFilename: 'GX020010.MOV' },
+      { originalFilename: 'GX010010.mov' },
+      { originalFilename: 'GOPR0010.MOV' },
+      { originalFilename: 'random_clip.mov' },
+    ]
+    const ordered = orderClipsForMerge(clips).map((c) => c.originalFilename)
+    expect(ordered).toEqual([
+      'GOPR0010.MOV',
+      'GX010010.mov',
+      'GX020010.MOV',
+      'random_clip.mov',
+    ])
+  })
+
   it('extracts session ids', () => {
     expect(extractGoProSessionId('GX010554.MP4')).toBe('0554')
     expect(extractGoProSessionId('GOPR0554.MP4')).toBe('0554')
+    expect(extractGoProSessionId('GX010554.MOV')).toBe('0554')
     expect(extractGoProSessionId('other.mp4')).toBeNull()
   })
 })

--- a/app/lib/video-tools/blob-url.ts
+++ b/app/lib/video-tools/blob-url.ts
@@ -1,0 +1,47 @@
+import { VIDEO_TOOLS_BLOB_PREFIX } from '@/app/lib/video-tools/naming'
+
+const ALLOWED_BLOB_HOST_SUFFIXES = ['.blob.vercel-storage.com']
+
+function isVercelBlobHost(hostname: string): boolean {
+  return ALLOWED_BLOB_HOST_SUFFIXES.some(
+    (suffix) => hostname === suffix.slice(1) || hostname.endsWith(suffix)
+  )
+}
+
+function normalizeBlobPathname(pathname: string): string {
+  return pathname.startsWith('/') ? pathname.slice(1) : pathname
+}
+
+/**
+ * Ensure clip blobUrl is a Vercel Blob HTTPS URL whose path matches the
+ * trusted pathname for this set (prevents SSRF via the merge worker fetch).
+ */
+export function assertSafeVideoClipBlobUrl(
+  blobUrl: string,
+  pathname: string
+): string {
+  let parsed: URL
+  try {
+    parsed = new URL(blobUrl)
+  } catch {
+    throw new Error('blobUrl is not a valid URL')
+  }
+
+  if (parsed.protocol !== 'https:') {
+    throw new Error('blobUrl must be https')
+  }
+  if (!isVercelBlobHost(parsed.hostname)) {
+    throw new Error('blobUrl must be a Vercel Blob storage URL')
+  }
+
+  const urlPath = normalizeBlobPathname(decodeURIComponent(parsed.pathname))
+  const expectedPath = normalizeBlobPathname(pathname)
+  if (urlPath !== expectedPath) {
+    throw new Error('blobUrl pathname must match the clip pathname')
+  }
+  if (!expectedPath.startsWith(VIDEO_TOOLS_BLOB_PREFIX)) {
+    throw new Error('pathname must be under video-tools/')
+  }
+
+  return blobUrl.trim()
+}

--- a/app/lib/video-tools/gopro-order.ts
+++ b/app/lib/video-tools/gopro-order.ts
@@ -18,9 +18,9 @@ type GoProParsed = {
   basename: string
 }
 
-const GOPR_RE = /^GOPR(\d{4})\.(mp4|MP4)$/
-const GP_RE = /^GP(\d{2})(\d{4})\.(mp4|MP4)$/
-const GX_RE = /^GX(\d{2})(\d{4})\.(mp4|MP4)$/
+const GOPR_RE = /^GOPR(\d{4})\.(mp4|mov)$/i
+const GP_RE = /^GP(\d{2})(\d{4})\.(mp4|mov)$/i
+const GX_RE = /^GX(\d{2})(\d{4})\.(mp4|mov)$/i
 
 function basenameOf(filename: string): string {
   const parts = filename.replace(/\\/g, '/').split('/')

--- a/app/lib/video-tools/mutations.ts
+++ b/app/lib/video-tools/mutations.ts
@@ -1,6 +1,7 @@
 import { and, asc, eq, inArray } from 'drizzle-orm'
 import { getDb } from '@/app/lib/db'
 import { videoUploadClips, videoUploadSets } from '@/app/db/schema'
+import { assertSafeVideoClipBlobUrl } from '@/app/lib/video-tools/blob-url'
 import { orderClipsForMerge } from '@/app/lib/video-tools/gopro-order'
 import {
   buildUntrimmedOutputFilename,
@@ -141,6 +142,7 @@ export async function recordUploadedClip(input: {
   sizeBytes?: number
 }): Promise<VideoUploadClipRecord> {
   const db = getDb()
+  const safeBlobUrl = assertSafeVideoClipBlobUrl(input.blobUrl, input.pathname)
 
   const [existing] = await db
     .select()
@@ -151,7 +153,17 @@ export async function recordUploadedClip(input: {
     if (existing.setId !== input.setId) {
       throw new Error('Clip pathname already belongs to another upload set')
     }
-    return mapClip(existing)
+    if (existing.blobUrl === safeBlobUrl) {
+      return mapClip(existing)
+    }
+    // Replace a mismatched / previously unvalidated URL so the worker never
+    // fetches an attacker-controlled address after an idempotent re-register.
+    const [updated] = await db
+      .update(videoUploadClips)
+      .set({ blobUrl: safeBlobUrl, uploadComplete: true })
+      .where(eq(videoUploadClips.id, existing.id))
+      .returning()
+    return mapClip(updated)
   }
 
   const [set] = await db
@@ -171,7 +183,7 @@ export async function recordUploadedClip(input: {
       .values({
         setId: input.setId,
         originalFilename: input.originalFilename,
-        blobUrl: input.blobUrl,
+        blobUrl: safeBlobUrl,
         pathname: input.pathname,
         sizeBytes: input.sizeBytes ?? 0,
         uploadComplete: true,
@@ -186,7 +198,13 @@ export async function recordUploadedClip(input: {
       .where(eq(videoUploadClips.pathname, input.pathname))
       .limit(1)
     if (!raced || raced.setId !== input.setId) throw err
-    return mapClip(raced)
+    if (raced.blobUrl === safeBlobUrl) return mapClip(raced)
+    const [updated] = await db
+      .update(videoUploadClips)
+      .set({ blobUrl: safeBlobUrl, uploadComplete: true })
+      .where(eq(videoUploadClips.id, raced.id))
+      .returning()
+    return mapClip(updated)
   }
 
   // Do not demote queued sets; late in-flight uploads may land before the worker claims.


### PR DESCRIPTION
## Summary
- Validates clip `blobUrl` is an https Vercel Blob URL whose path matches the trusted `pathname` (blocks SSRF via the merge worker `fetch`).
- Extends GoPro filename parsing to `.mov`/`.MOV` so QuickTime uploads get session/chapter order instead of lexical fallback.

Addresses Bugbot findings on the preview→main promote ([#119](https://github.com/jsartin513/bdl-admin/pull/119)).

## Test plan
- [ ] `npx vitest run app/lib/video-tools`
- [ ] Registering a clip with a non-blob `blobUrl` returns 400
- [ ] GoPro `.MOV` files order like `.MP4` siblings


Made with [Cursor](https://cursor.com)