### PR TITLE
Invalidate stale Video Tools workers with claim tokens

### DIFF
--- a/app/api/video-tools/worker/complete/route.ts
+++ b/app/api/video-tools/worker/complete/route.ts
@@ -13,6 +13,7 @@ export async function POST(request: NextRequest) {
   try {
     const body = (await request.json()) as {
       setId?: string
+      claimToken?: string
       mergedBlobUrl?: string
       mergedBlobPathname?: string
       outputFilename?: string
@@ -20,6 +21,9 @@ export async function POST(request: NextRequest) {
 
     if (!body.setId?.trim()) {
       return NextResponse.json({ error: 'setId is required' }, { status: 400 })
+    }
+    if (!body.claimToken?.trim()) {
+      return NextResponse.json({ error: 'claimToken is required' }, { status: 400 })
     }
     if (!body.mergedBlobUrl?.trim()) {
       return NextResponse.json({ error: 'mergedBlobUrl is required' }, { status: 400 })
@@ -33,6 +37,7 @@ export async function POST(request: NextRequest) {
 
     const set = await completeVideoUploadSet({
       setId: body.setId,
+      claimToken: body.claimToken,
       mergedBlobUrl: body.mergedBlobUrl,
       mergedBlobPathname: body.mergedBlobPathname,
       outputFilename: body.outputFilename,

--- a/app/api/video-tools/worker/fail/route.ts
+++ b/app/api/video-tools/worker/fail/route.ts
@@ -13,11 +13,15 @@ export async function POST(request: NextRequest) {
   try {
     const body = (await request.json()) as {
       setId?: string
+      claimToken?: string
       errorMessage?: string
     }
 
     if (!body.setId?.trim()) {
       return NextResponse.json({ error: 'setId is required' }, { status: 400 })
+    }
+    if (!body.claimToken?.trim()) {
+      return NextResponse.json({ error: 'claimToken is required' }, { status: 400 })
     }
     if (!body.errorMessage?.trim()) {
       return NextResponse.json({ error: 'errorMessage is required' }, { status: 400 })
@@ -25,6 +29,7 @@ export async function POST(request: NextRequest) {
 
     const set = await failVideoUploadSet({
       setId: body.setId,
+      claimToken: body.claimToken,
       errorMessage: body.errorMessage,
     })
 

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -396,6 +396,8 @@ export const videoUploadSets = pgTable(
     mergedBlobUrl: text('merged_blob_url'),
     mergedBlobPathname: text('merged_blob_pathname'),
     outputFilename: text('output_filename'),
+    /** Rotated on each worker claim; invalidates stale complete/fail after retry. */
+    claimToken: uuid('claim_token'),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },

--- a/app/lib/video-tools/__tests__/status-transitions.test.ts
+++ b/app/lib/video-tools/__tests__/status-transitions.test.ts
@@ -33,6 +33,11 @@ describe('video tools status transition policy', () => {
     }
   })
 
+  it('documents claim-token invalidation on retry', () => {
+    // enqueue clears claimToken; complete/fail require matching token + processing.
+    expect(ENQUEUE_ALLOWED_STATUSES).toContain('processing')
+  })
+
   it('covers every set status in at least one transition list', () => {
     const covered = new Set<string>([
       ...READY_ALLOWED_STATUSES,

--- a/app/lib/video-tools/mutations.ts
+++ b/app/lib/video-tools/mutations.ts
@@ -1,4 +1,5 @@
 import { and, asc, eq, inArray } from 'drizzle-orm'
+import { randomUUID } from 'node:crypto'
 import { getDb } from '@/app/lib/db'
 import { videoUploadClips, videoUploadSets } from '@/app/db/schema'
 import { assertSafeVideoClipBlobUrl } from '@/app/lib/video-tools/blob-url'
@@ -323,6 +324,8 @@ export async function enqueueVideoUploadSet(
       outputFilename,
       mergedBlobUrl: null,
       mergedBlobPathname: null,
+      // Invalidate any in-flight worker claim so a stale complete cannot win.
+      claimToken: null,
     })
     .where(
       and(
@@ -350,9 +353,15 @@ export async function claimNextQueuedSet(): Promise<WorkerClaimPayload | null> {
 
   if (!next) return null
 
+  const claimToken = randomUUID()
   const [claimed] = await db
     .update(videoUploadSets)
-    .set({ status: 'processing', updatedAt: new Date(), errorMessage: null })
+    .set({
+      status: 'processing',
+      updatedAt: new Date(),
+      errorMessage: null,
+      claimToken,
+    })
     .where(
       and(
         eq(videoUploadSets.id, next.id),
@@ -377,15 +386,20 @@ export async function claimNextQueuedSet(): Promise<WorkerClaimPayload | null> {
     set: mapSet(claimed),
     clips: ordered,
     outputFilename,
+    claimToken,
   }
 }
 
 export async function completeVideoUploadSet(input: {
   setId: string
+  claimToken: string
   mergedBlobUrl: string
   mergedBlobPathname: string
   outputFilename?: string
 }): Promise<VideoUploadSetRecord> {
+  const claimToken = input.claimToken.trim()
+  if (!claimToken) throw new Error('claimToken is required')
+
   const db = getDb()
   const [updated] = await db
     .update(videoUploadSets)
@@ -402,21 +416,26 @@ export async function completeVideoUploadSet(input: {
     .where(
       and(
         eq(videoUploadSets.id, input.setId),
-        eq(videoUploadSets.status, 'processing')
+        eq(videoUploadSets.status, 'processing'),
+        eq(videoUploadSets.claimToken, claimToken)
       )
     )
     .returning()
 
   if (!updated) {
-    throw new Error('Set not found or not processing')
+    throw new Error('Set not found, not processing, or stale claim token')
   }
   return mapSet(updated)
 }
 
 export async function failVideoUploadSet(input: {
   setId: string
+  claimToken: string
   errorMessage: string
 }): Promise<VideoUploadSetRecord> {
+  const claimToken = input.claimToken.trim()
+  if (!claimToken) throw new Error('claimToken is required')
+
   const db = getDb()
   const [updated] = await db
     .update(videoUploadSets)
@@ -428,7 +447,8 @@ export async function failVideoUploadSet(input: {
     .where(
       and(
         eq(videoUploadSets.id, input.setId),
-        eq(videoUploadSets.status, 'processing')
+        eq(videoUploadSets.status, 'processing'),
+        eq(videoUploadSets.claimToken, claimToken)
       )
     )
     .returning()
@@ -444,6 +464,14 @@ export async function failVideoUploadSet(input: {
   // Idempotent / race-safe: do not overwrite a successful complete (or prior fail).
   if (existing.status === 'complete' || existing.status === 'failed') {
     return mapSet(existing)
+  }
+  // Another claim owns this set (retry / second worker) — do not mutate.
+  if (
+    existing.status === 'processing' &&
+    existing.claimToken &&
+    existing.claimToken !== claimToken
+  ) {
+    throw new Error('Stale claim token')
   }
   throw new Error(`Set not found or not processing (status: ${existing.status})`)
 }

--- a/app/lib/video-tools/types.ts
+++ b/app/lib/video-tools/types.ts
@@ -55,4 +55,6 @@ export type WorkerClaimPayload = {
   set: VideoUploadSetRecord
   clips: VideoUploadClipRecord[]
   outputFilename: string
+  /** Must be sent back on complete/fail; rotated on each claim. */
+  claimToken: string
 }

--- a/drizzle/0017_video_tools_claim_token.sql
+++ b/drizzle/0017_video_tools_claim_token.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "video_upload_sets" ADD COLUMN IF NOT EXISTS "claim_token" uuid;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1753804800000,
       "tag": "0016_video_tools",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1753812000000,
+      "tag": "0017_video_tools_claim_token",
+      "breakpoints": true
     }
   ]
 }

--- a/workers/video-merge/index.mjs
+++ b/workers/video-merge/index.mjs
@@ -157,7 +157,10 @@ async function uploadMerged(localPath, pathname) {
 }
 
 async function processJob(job) {
-  const { set, clips, outputFilename } = job
+  const { set, clips, outputFilename, claimToken } = job
+  if (!claimToken) {
+    throw new Error('Job missing claimToken')
+  }
   console.log(
     `[job ${set.id}] ${set.eventName} · ${set.label} — ${clips.length} clips → ${outputFilename}`
   )
@@ -219,6 +222,7 @@ async function processJob(job) {
       method: 'POST',
       body: JSON.stringify({
         setId: set.id,
+        claimToken,
         mergedBlobUrl: blob.url,
         mergedBlobPathname: blob.pathname,
         outputFilename,
@@ -245,6 +249,7 @@ async function tick() {
         method: 'POST',
         body: JSON.stringify({
           setId: job.set.id,
+          claimToken: job.claimToken,
           errorMessage: message,
         }),
       })


### PR DESCRIPTION
## Summary
- Adds `claim_token` on `video_upload_sets` (migration `0017`).
- Worker claim issues a new token; complete/fail require it.
- Retry merge clears the token so a stale in-flight worker cannot mark the set complete with an outdated clip list.

Addresses Bugbot finding on [#119](https://github.com/jsartin513/bdl-admin/pull/119).

## Test plan
- [ ] `npx vitest run app/lib/video-tools`
- [ ] Migration `0017` applies cleanly
- [ ] Worker complete without `claimToken` → 400
- [ ] After Retry merge, old worker complete with old token is rejected


Made with [Cursor](https://cursor.com)