### PR TITLE
Validate merged Blob URLs and backfill clip sizeBytes

### DIFF
--- a/app/api/video-tools/sets/[id]/clips/route.ts
+++ b/app/api/video-tools/sets/[id]/clips/route.ts
@@ -45,7 +45,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
 
     let safeBlobUrl: string
     try {
-      safeBlobUrl = assertSafeVideoClipBlobUrl(body.blobUrl, body.pathname)
+      safeBlobUrl = assertSafeVideoClipBlobUrl(body.blobUrl, body.pathname, setId)
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Invalid blobUrl'
       return NextResponse.json({ error: message }, { status: 400 })

--- a/app/lib/video-tools/__tests__/blob-url.test.ts
+++ b/app/lib/video-tools/__tests__/blob-url.test.ts
@@ -1,20 +1,25 @@
 import { describe, expect, it } from 'vitest'
-import { assertSafeVideoClipBlobUrl } from '@/app/lib/video-tools/blob-url'
+import {
+  assertSafeVideoClipBlobUrl,
+  assertSafeVideoMergedBlobUrl,
+} from '@/app/lib/video-tools/blob-url'
+
+const setId = '11111111-1111-1111-1111-111111111111'
 
 describe('assertSafeVideoClipBlobUrl', () => {
-  const pathname =
-    'video-tools/11111111-1111-1111-1111-111111111111/clips/abc-GX010100.MP4'
+  const pathname = `video-tools/${setId}/clips/abc-GX010100.MP4`
 
   it('accepts matching Vercel Blob https URLs', () => {
     const url = `https://abc123.public.blob.vercel-storage.com/${pathname}`
-    expect(assertSafeVideoClipBlobUrl(url, pathname)).toBe(url)
+    expect(assertSafeVideoClipBlobUrl(url, pathname, setId)).toBe(url)
   })
 
   it('rejects non-blob hosts (SSRF)', () => {
     expect(() =>
       assertSafeVideoClipBlobUrl(
         `https://169.254.169.254/${pathname}`,
-        pathname
+        pathname,
+        setId
       )
     ).toThrow(/Vercel Blob/)
   })
@@ -23,7 +28,8 @@ describe('assertSafeVideoClipBlobUrl', () => {
     expect(() =>
       assertSafeVideoClipBlobUrl(
         `http://abc123.public.blob.vercel-storage.com/${pathname}`,
-        pathname
+        pathname,
+        setId
       )
     ).toThrow(/https/)
   })
@@ -32,8 +38,58 @@ describe('assertSafeVideoClipBlobUrl', () => {
     expect(() =>
       assertSafeVideoClipBlobUrl(
         `https://abc123.public.blob.vercel-storage.com/${pathname}`,
-        'video-tools/other/clips/x.MP4'
+        'video-tools/other/clips/x.MP4',
+        setId
       )
     ).toThrow(/must match/)
+  })
+
+  it('rejects clips for a different set when setId is provided', () => {
+    const otherPath =
+      'video-tools/22222222-2222-2222-2222-222222222222/clips/abc-GX010100.MP4'
+    const url = `https://abc123.public.blob.vercel-storage.com/${otherPath}`
+    expect(() => assertSafeVideoClipBlobUrl(url, otherPath, setId)).toThrow(
+      /must start with/
+    )
+  })
+})
+
+describe('assertSafeVideoMergedBlobUrl', () => {
+  const outputFilename = 'Summer_Remix_2026-07-12_Court_1_untrimmed.MP4'
+  const pathname = `video-tools/${setId}/merged/${outputFilename}`
+
+  it('accepts matching merged Blob URLs', () => {
+    const url = `https://abc123.public.blob.vercel-storage.com/${pathname}`
+    expect(
+      assertSafeVideoMergedBlobUrl({
+        blobUrl: url,
+        pathname,
+        setId,
+        outputFilename,
+      })
+    ).toBe(url)
+  })
+
+  it('rejects non-blob hosts', () => {
+    expect(() =>
+      assertSafeVideoMergedBlobUrl({
+        blobUrl: `https://evil.example/${pathname}`,
+        pathname,
+        setId,
+        outputFilename,
+      })
+    ).toThrow(/Vercel Blob/)
+  })
+
+  it('rejects wrong output filename path', () => {
+    const wrong = `video-tools/${setId}/merged/other_untrimmed.MP4`
+    expect(() =>
+      assertSafeVideoMergedBlobUrl({
+        blobUrl: `https://abc123.public.blob.vercel-storage.com/${wrong}`,
+        pathname: wrong,
+        setId,
+        outputFilename,
+      })
+    ).toThrow(/output filename/)
   })
 })

--- a/app/lib/video-tools/blob-url.ts
+++ b/app/lib/video-tools/blob-url.ts
@@ -1,4 +1,7 @@
-import { VIDEO_TOOLS_BLOB_PREFIX } from '@/app/lib/video-tools/naming'
+import {
+  VIDEO_TOOLS_BLOB_PREFIX,
+  mergedBlobPathname,
+} from '@/app/lib/video-tools/naming'
 
 const ALLOWED_BLOB_HOST_SUFFIXES = ['.blob.vercel-storage.com']
 
@@ -12,13 +15,10 @@ function normalizeBlobPathname(pathname: string): string {
   return pathname.startsWith('/') ? pathname.slice(1) : pathname
 }
 
-/**
- * Ensure clip blobUrl is a Vercel Blob HTTPS URL whose path matches the
- * trusted pathname for this set (prevents SSRF via the merge worker fetch).
- */
-export function assertSafeVideoClipBlobUrl(
+function assertSafeVideoToolsBlobUrl(
   blobUrl: string,
-  pathname: string
+  pathname: string,
+  requiredPrefix: string
 ): string {
   let parsed: URL
   try {
@@ -37,11 +37,53 @@ export function assertSafeVideoClipBlobUrl(
   const urlPath = normalizeBlobPathname(decodeURIComponent(parsed.pathname))
   const expectedPath = normalizeBlobPathname(pathname)
   if (urlPath !== expectedPath) {
-    throw new Error('blobUrl pathname must match the clip pathname')
+    throw new Error('blobUrl pathname must match the stored pathname')
+  }
+  if (!expectedPath.startsWith(requiredPrefix)) {
+    throw new Error(`pathname must start with ${requiredPrefix}`)
   }
   if (!expectedPath.startsWith(VIDEO_TOOLS_BLOB_PREFIX)) {
     throw new Error('pathname must be under video-tools/')
   }
 
   return blobUrl.trim()
+}
+
+/**
+ * Ensure clip blobUrl is a Vercel Blob HTTPS URL whose path matches the
+ * trusted pathname for this set (prevents SSRF via the merge worker fetch).
+ */
+export function assertSafeVideoClipBlobUrl(
+  blobUrl: string,
+  pathname: string,
+  setId?: string
+): string {
+  const prefix = setId
+    ? `${VIDEO_TOOLS_BLOB_PREFIX}${setId}/clips/`
+    : `${VIDEO_TOOLS_BLOB_PREFIX}`
+  return assertSafeVideoToolsBlobUrl(blobUrl, pathname, prefix)
+}
+
+/**
+ * Ensure merged deliverable URL is a Vercel Blob HTTPS URL under this set's
+ * merged/ prefix (download link shown in the admin UI).
+ */
+export function assertSafeVideoMergedBlobUrl(input: {
+  blobUrl: string
+  pathname: string
+  setId: string
+  outputFilename?: string | null
+}): string {
+  const expectedPrefix = `${VIDEO_TOOLS_BLOB_PREFIX}${input.setId}/merged/`
+  if (input.outputFilename) {
+    const expected = mergedBlobPathname(input.setId, input.outputFilename)
+    if (normalizeBlobPathname(input.pathname) !== normalizeBlobPathname(expected)) {
+      throw new Error('mergedBlobPathname must match the set output filename')
+    }
+  }
+  return assertSafeVideoToolsBlobUrl(
+    input.blobUrl,
+    input.pathname,
+    expectedPrefix
+  )
 }

--- a/app/lib/video-tools/mutations.ts
+++ b/app/lib/video-tools/mutations.ts
@@ -2,7 +2,10 @@ import { and, asc, eq, inArray } from 'drizzle-orm'
 import { randomUUID } from 'node:crypto'
 import { getDb } from '@/app/lib/db'
 import { videoUploadClips, videoUploadSets } from '@/app/db/schema'
-import { assertSafeVideoClipBlobUrl } from '@/app/lib/video-tools/blob-url'
+import {
+  assertSafeVideoClipBlobUrl,
+  assertSafeVideoMergedBlobUrl,
+} from '@/app/lib/video-tools/blob-url'
 import { orderClipsForMerge } from '@/app/lib/video-tools/gopro-order'
 import {
   buildUntrimmedOutputFilename,
@@ -143,7 +146,39 @@ export async function recordUploadedClip(input: {
   sizeBytes?: number
 }): Promise<VideoUploadClipRecord> {
   const db = getDb()
-  const safeBlobUrl = assertSafeVideoClipBlobUrl(input.blobUrl, input.pathname)
+  const safeBlobUrl = assertSafeVideoClipBlobUrl(
+    input.blobUrl,
+    input.pathname,
+    input.setId
+  )
+  const incomingSize =
+    typeof input.sizeBytes === 'number' && input.sizeBytes > 0
+      ? Math.floor(input.sizeBytes)
+      : 0
+
+  async function reconcileExisting(
+    existing: typeof videoUploadClips.$inferSelect
+  ): Promise<VideoUploadClipRecord> {
+    if (existing.setId !== input.setId) {
+      throw new Error('Clip pathname already belongs to another upload set')
+    }
+    const nextSize = Math.max(existing.sizeBytes, incomingSize)
+    const needsUrl = existing.blobUrl !== safeBlobUrl
+    const needsSize = nextSize > existing.sizeBytes
+    if (!needsUrl && !needsSize) {
+      return mapClip(existing)
+    }
+    const [updated] = await db
+      .update(videoUploadClips)
+      .set({
+        ...(needsUrl ? { blobUrl: safeBlobUrl } : {}),
+        ...(needsSize ? { sizeBytes: nextSize } : {}),
+        uploadComplete: true,
+      })
+      .where(eq(videoUploadClips.id, existing.id))
+      .returning()
+    return mapClip(updated)
+  }
 
   const [existing] = await db
     .select()
@@ -151,20 +186,7 @@ export async function recordUploadedClip(input: {
     .where(eq(videoUploadClips.pathname, input.pathname))
     .limit(1)
   if (existing) {
-    if (existing.setId !== input.setId) {
-      throw new Error('Clip pathname already belongs to another upload set')
-    }
-    if (existing.blobUrl === safeBlobUrl) {
-      return mapClip(existing)
-    }
-    // Replace a mismatched / previously unvalidated URL so the worker never
-    // fetches an attacker-controlled address after an idempotent re-register.
-    const [updated] = await db
-      .update(videoUploadClips)
-      .set({ blobUrl: safeBlobUrl, uploadComplete: true })
-      .where(eq(videoUploadClips.id, existing.id))
-      .returning()
-    return mapClip(updated)
+    return reconcileExisting(existing)
   }
 
   const [set] = await db
@@ -186,7 +208,7 @@ export async function recordUploadedClip(input: {
         originalFilename: input.originalFilename,
         blobUrl: safeBlobUrl,
         pathname: input.pathname,
-        sizeBytes: input.sizeBytes ?? 0,
+        sizeBytes: incomingSize,
         uploadComplete: true,
       })
       .returning()
@@ -198,14 +220,8 @@ export async function recordUploadedClip(input: {
       .from(videoUploadClips)
       .where(eq(videoUploadClips.pathname, input.pathname))
       .limit(1)
-    if (!raced || raced.setId !== input.setId) throw err
-    if (raced.blobUrl === safeBlobUrl) return mapClip(raced)
-    const [updated] = await db
-      .update(videoUploadClips)
-      .set({ blobUrl: safeBlobUrl, uploadComplete: true })
-      .where(eq(videoUploadClips.id, raced.id))
-      .returning()
-    return mapClip(updated)
+    if (!raced) throw err
+    return reconcileExisting(raced)
   }
 
   // Do not demote queued sets; late in-flight uploads may land before the worker claims.
@@ -401,17 +417,38 @@ export async function completeVideoUploadSet(input: {
   if (!claimToken) throw new Error('claimToken is required')
 
   const db = getDb()
+  const [current] = await db
+    .select()
+    .from(videoUploadSets)
+    .where(eq(videoUploadSets.id, input.setId))
+    .limit(1)
+  if (!current) throw new Error('Upload set not found')
+
+  const outputFilename =
+    input.outputFilename?.trim() ||
+    current.outputFilename ||
+    buildUntrimmedOutputFilename({
+      eventName: current.eventName,
+      eventDate: current.eventDate,
+      label: current.label,
+    })
+
+  const safeMergedUrl = assertSafeVideoMergedBlobUrl({
+    blobUrl: input.mergedBlobUrl,
+    pathname: input.mergedBlobPathname,
+    setId: input.setId,
+    outputFilename,
+  })
+
   const [updated] = await db
     .update(videoUploadSets)
     .set({
       status: 'complete',
       updatedAt: new Date(),
       errorMessage: null,
-      mergedBlobUrl: input.mergedBlobUrl,
-      mergedBlobPathname: input.mergedBlobPathname,
-      ...(input.outputFilename
-        ? { outputFilename: input.outputFilename }
-        : {}),
+      mergedBlobUrl: safeMergedUrl,
+      mergedBlobPathname: input.mergedBlobPathname.trim(),
+      outputFilename,
     })
     .where(
       and(

--- a/app/lib/video-tools/mutations.ts
+++ b/app/lib/video-tools/mutations.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, inArray } from 'drizzle-orm'
+import { and, asc, eq, inArray, sql } from 'drizzle-orm'
 import { randomUUID } from 'node:crypto'
 import { getDb } from '@/app/lib/db'
 import { videoUploadClips, videoUploadSets } from '@/app/db/schema'
@@ -162,9 +162,8 @@ export async function recordUploadedClip(input: {
     if (existing.setId !== input.setId) {
       throw new Error('Clip pathname already belongs to another upload set')
     }
-    const nextSize = Math.max(existing.sizeBytes, incomingSize)
     const needsUrl = existing.blobUrl !== safeBlobUrl
-    const needsSize = nextSize > existing.sizeBytes
+    const needsSize = incomingSize > 0 && incomingSize > existing.sizeBytes
     if (!needsUrl && !needsSize) {
       return mapClip(existing)
     }
@@ -172,7 +171,11 @@ export async function recordUploadedClip(input: {
       .update(videoUploadClips)
       .set({
         ...(needsUrl ? { blobUrl: safeBlobUrl } : {}),
-        ...(needsSize ? { sizeBytes: nextSize } : {}),
+        ...(incomingSize > 0
+          ? {
+              sizeBytes: sql`greatest(${videoUploadClips.sizeBytes}, ${incomingSize})`,
+            }
+          : {}),
         uploadComplete: true,
       })
       .where(eq(videoUploadClips.id, existing.id))
@@ -390,6 +393,22 @@ export async function claimNextQueuedSet(): Promise<WorkerClaimPayload | null> {
 
   const clips = await listClipsForSet(claimed.id)
   const ordered = orderClipsForMerge(clips)
+
+  try {
+    for (const clip of ordered) {
+      assertSafeVideoClipBlobUrl(clip.blobUrl, clip.pathname, claimed.id)
+    }
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Invalid clip blob URL at claim'
+    await failVideoUploadSet({
+      setId: claimed.id,
+      claimToken,
+      errorMessage: `Refusing to merge: ${message}`,
+    })
+    return null
+  }
+
   const outputFilename =
     claimed.outputFilename ||
     buildUntrimmedOutputFilename({


### PR DESCRIPTION
## Summary
- Validates `mergedBlobUrl` / `mergedBlobPathname` on worker complete (Vercel Blob host + set `merged/` path + output filename).
- On idempotent clip register, backfills `sizeBytes` when the client POST arrives after a webhook that stored `0`.

Addresses remaining Bugbot findings on [#119](https://github.com/jsartin513/bdl-admin/pull/119).

## Test plan
- [ ] `npx vitest run app/lib/video-tools`
- [ ] Worker complete with non-blob URL → 400
- [ ] Upload clip: detail UI shows non-zero size after client register


Made with [Cursor](https://cursor.com)