### PR TITLE
Require Mark ready before Start merge

### DIFF
--- a/app/lib/video-tools/__tests__/status-transitions.test.ts
+++ b/app/lib/video-tools/__tests__/status-transitions.test.ts
@@ -33,6 +33,12 @@ describe('video tools status transition policy', () => {
     }
   })
 
+  it('requires ready before enqueue (no merge while still uploading)', () => {
+    expect(ENQUEUE_ALLOWED_STATUSES).not.toContain('uploading')
+    expect(ENQUEUE_ALLOWED_STATUSES).not.toContain('draft')
+    expect(READY_ALLOWED_STATUSES).toContain('uploading')
+  })
+
   it('documents claim-token invalidation on retry', () => {
     // enqueue clears claimToken; complete/fail require matching token + processing.
     expect(ENQUEUE_ALLOWED_STATUSES).toContain('processing')

--- a/app/lib/video-tools/mutations.ts
+++ b/app/lib/video-tools/mutations.ts
@@ -228,6 +228,7 @@ export async function recordUploadedClip(input: {
   }
 
   // Do not demote queued sets; late in-flight uploads may land before the worker claims.
+  // Demote ready → uploading if another clip arrives after Mark ready.
   if (set.status === 'queued') {
     await db
       .update(videoUploadSets)
@@ -238,7 +239,9 @@ export async function recordUploadedClip(input: {
       .update(videoUploadSets)
       .set({
         status:
-          set.status === 'draft' || set.status === 'failed'
+          set.status === 'draft' ||
+          set.status === 'failed' ||
+          set.status === 'ready'
             ? 'uploading'
             : set.status,
         updatedAt: new Date(),

--- a/app/video-tools/[id]/page.tsx
+++ b/app/video-tools/[id]/page.tsx
@@ -106,7 +106,8 @@ function VideoUploadSetDetailContent() {
   const canStartOrRetryMerge =
     set != null &&
     set.clips.length > 0 &&
-    ['draft', 'uploading', 'ready', 'failed', 'processing'].includes(set.status)
+    ['ready', 'failed', 'processing'].includes(set.status) &&
+    !busy
 
   async function uploadFiles(files: FileList | File[]) {
     if (!set || !canUpload) return
@@ -217,17 +218,7 @@ function VideoUploadSetDetailContent() {
     setBusy(true)
     setActionError(null)
     try {
-      // Ensure ready first if still uploading
-      if (set && (set.status === 'uploading' || set.status === 'draft')) {
-        const readyRes = await fetch(`/api/video-tools/sets/${setId}`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ action: 'mark_ready' }),
-        })
-        const readyData = await readyRes.json()
-        if (!readyRes.ok) throw new Error(readyData.error || 'Failed to mark ready')
-      }
-
+      // Merge only from ready/failed/processing — require Mark ready after uploads finish.
       const res = await fetch(`/api/video-tools/sets/${setId}/enqueue`, {
         method: 'POST',
       })
@@ -334,7 +325,8 @@ function VideoUploadSetDetailContent() {
       <section className="mt-8">
         <h2 className="text-lg font-medium text-gray-900">Clips</h2>
         <p className="mt-1 text-sm text-gray-600">
-          Drop GoPro MP4s here. Order is applied automatically (GoPro session +
+          Drop GoPro MP4s here. When all uploads are finished, click Mark ready,
+          then Start merge. Order is applied automatically (GoPro session +
           chapter rules) when you start the merge.
         </p>
 


### PR DESCRIPTION
## Summary
- Start merge is only available from `ready` / `failed` / `processing` (no auto mark-ready from uploading).
- New clips after Mark ready demote the set back to `uploading`.
- UI copy: finish uploads → Mark ready → Start merge.

Addresses Bugbot finding on [#119](https://github.com/jsartin513/bdl-admin/pull/119) (merge while uploads still in flight).

## Test plan
- [ ] While uploading, Start merge is hidden; Mark ready is available after clips exist
- [ ] After Mark ready, Start merge appears; adding another clip returns status to uploading
- [ ] `npx vitest run app/lib/video-tools`


Made with [Cursor](https://cursor.com)