### PR TITLE
Use conditional status updates when registering clips

### DIFF
--- a/app/lib/video-tools/mutations.ts
+++ b/app/lib/video-tools/mutations.ts
@@ -227,28 +227,36 @@ export async function recordUploadedClip(input: {
     return reconcileExisting(raced)
   }
 
-  // Do not demote queued sets; late in-flight uploads may land before the worker claims.
-  // Demote ready → uploading if another clip arrives after Mark ready.
-  if (set.status === 'queued') {
-    await db
-      .update(videoUploadSets)
-      .set({ updatedAt: new Date() })
-      .where(eq(videoUploadSets.id, input.setId))
-  } else {
-    await db
-      .update(videoUploadSets)
-      .set({
-        status:
-          set.status === 'draft' ||
-          set.status === 'failed' ||
-          set.status === 'ready'
-            ? 'uploading'
-            : set.status,
-        updatedAt: new Date(),
-        errorMessage: null,
-      })
-      .where(eq(videoUploadSets.id, input.setId))
-  }
+  // Conditional updates only — never clobber queued/processing/complete if the
+  // set advanced between the initial read and this write (Start merge race).
+  await db
+    .update(videoUploadSets)
+    .set({ updatedAt: new Date() })
+    .where(
+      and(
+        eq(videoUploadSets.id, input.setId),
+        eq(videoUploadSets.status, 'queued')
+      )
+    )
+
+  await db
+    .update(videoUploadSets)
+    .set({
+      status: 'uploading',
+      updatedAt: new Date(),
+      errorMessage: null,
+    })
+    .where(
+      and(
+        eq(videoUploadSets.id, input.setId),
+        inArray(videoUploadSets.status, [
+          'draft',
+          'failed',
+          'ready',
+          'uploading',
+        ])
+      )
+    )
 
   return mapClip(clip)
 }

--- a/app/lib/video-tools/mutations.ts
+++ b/app/lib/video-tools/mutations.ts
@@ -239,6 +239,14 @@ export async function recordUploadedClip(input: {
       )
     )
 
+  // Only demote statuses we were admitted under. Do not include `failed` unless
+  // this request started against a failed set (retry upload); otherwise a
+  // queued→failed race could clear the merge error.
+  const demoteFrom =
+    set.status === 'failed'
+      ? (['draft', 'ready', 'uploading', 'failed'] as const)
+      : (['draft', 'ready', 'uploading'] as const)
+
   await db
     .update(videoUploadSets)
     .set({
@@ -249,12 +257,7 @@ export async function recordUploadedClip(input: {
     .where(
       and(
         eq(videoUploadSets.id, input.setId),
-        inArray(videoUploadSets.status, [
-          'draft',
-          'failed',
-          'ready',
-          'uploading',
-        ])
+        inArray(videoUploadSets.status, [...demoteFrom])
       )
     )
 


### PR DESCRIPTION
## Summary
- `recordUploadedClip` no longer writes set status from a stale snapshot.
- Queued sets only get `updatedAt`; draft/ready/failed/uploading may move to `uploading`.
- queued/processing/complete are never overwritten by a late clip register.

Addresses Bugbot finding on [#119](https://github.com/jsartin513/bdl-admin/pull/119).

## Test plan
- [ ] `npx vitest run app/lib/video-tools`
- [ ] Mark ready → Start merge while a clip POST is in flight still leaves set queued/processing


Made with [Cursor](https://cursor.com)