### PR TITLE
Gate Mark ready on in-flight upload count

### DIFF
--- a/app/api/video-tools/upload/route.ts
+++ b/app/api/video-tools/upload/route.ts
@@ -4,7 +4,7 @@ import {
   adminUnauthorizedResponse,
   getAdminSessionFromRequest,
 } from '@/app/lib/admin-auth'
-import { recordUploadedClip } from '@/app/lib/video-tools/mutations'
+import { beginPendingClipUpload, recordUploadedClip } from '@/app/lib/video-tools/mutations'
 import { getVideoUploadSet } from '@/app/lib/video-tools/queries'
 import { VIDEO_TOOLS_BLOB_PREFIX } from '@/app/lib/video-tools/naming'
 
@@ -46,9 +46,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
         const set = await getVideoUploadSet(setId)
         if (!set) throw new Error('Upload set not found')
-        // Block new tokens once merge has started or finished. Queued still
-        // allows in-flight multipart completions via onUploadCompleted.
-        if (['processing', 'complete'].includes(set.status)) {
+        // New tokens only while collecting clips. In-flight completions may still
+        // land via onUploadCompleted / /clips after Mark ready.
+        if (!['draft', 'uploading', 'failed'].includes(set.status)) {
           throw new Error(`Cannot upload clips while set is ${set.status}`)
         }
 
@@ -56,6 +56,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         if (!pathname.startsWith(expectedPrefix)) {
           throw new Error('Invalid upload pathname')
         }
+
+        await beginPendingClipUpload(setId)
 
         return {
           allowedContentTypes: [

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -398,6 +398,8 @@ export const videoUploadSets = pgTable(
     outputFilename: text('output_filename'),
     /** Rotated on each worker claim; invalidates stale complete/fail after retry. */
     claimToken: uuid('claim_token'),
+    /** In-flight Blob upload tokens; Mark ready / enqueue require zero. */
+    pendingUploadCount: integer('pending_upload_count').notNull().default(0),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },

--- a/app/lib/video-tools/__tests__/status-transitions.test.ts
+++ b/app/lib/video-tools/__tests__/status-transitions.test.ts
@@ -3,6 +3,7 @@ import {
   CLIP_LOCKED_STATUSES,
   ENQUEUE_ALLOWED_STATUSES,
   READY_ALLOWED_STATUSES,
+  UPLOAD_TOKEN_ALLOWED_STATUSES,
 } from '@/app/lib/video-tools/mutations'
 import { VIDEO_SET_STATUSES } from '@/app/lib/video-tools/types'
 
@@ -37,6 +38,14 @@ describe('video tools status transition policy', () => {
     expect(ENQUEUE_ALLOWED_STATUSES).not.toContain('uploading')
     expect(ENQUEUE_ALLOWED_STATUSES).not.toContain('draft')
     expect(READY_ALLOWED_STATUSES).toContain('uploading')
+  })
+
+  it('only mints upload tokens while collecting clips', () => {
+    expect([...UPLOAD_TOKEN_ALLOWED_STATUSES]).toEqual([
+      'draft',
+      'uploading',
+      'failed',
+    ])
   })
 
   it('documents claim-token invalidation on retry', () => {

--- a/app/lib/video-tools/mutations.ts
+++ b/app/lib/video-tools/mutations.ts
@@ -48,6 +48,7 @@ function mapSet(row: typeof videoUploadSets.$inferSelect): VideoUploadSetRecord 
     mergedBlobUrl: row.mergedBlobUrl,
     mergedBlobPathname: row.mergedBlobPathname,
     outputFilename: row.outputFilename,
+    pendingUploadCount: row.pendingUploadCount,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   }
@@ -124,6 +125,8 @@ export async function markSetUploading(setId: string): Promise<void> {
 export const READY_ALLOWED_STATUSES = ['draft', 'uploading', 'ready', 'failed'] as const
 /** Allow clip registration while queued so in-flight multipart uploads can finish before claim. */
 export const CLIP_LOCKED_STATUSES = ['processing', 'complete'] as const
+/** New upload tokens only while actively collecting clips. */
+export const UPLOAD_TOKEN_ALLOWED_STATUSES = ['draft', 'uploading', 'failed'] as const
 /** ready = normal; failed/processing = operator retry for stuck or failed merges. */
 export const ENQUEUE_ALLOWED_STATUSES = ['ready', 'failed', 'processing'] as const
 
@@ -136,6 +139,41 @@ function isUniquePathnameError(err: unknown): boolean {
     message.includes('video_upload_clips_pathname_uidx') ||
     message.toLowerCase().includes('unique')
   )
+}
+
+/** Reserve an in-flight upload slot when minting a Blob client token. */
+export async function beginPendingClipUpload(setId: string): Promise<void> {
+  const db = getDb()
+  const [updated] = await db
+    .update(videoUploadSets)
+    .set({
+      pendingUploadCount: sql`${videoUploadSets.pendingUploadCount} + 1`,
+      status: 'uploading',
+      updatedAt: new Date(),
+      errorMessage: null,
+    })
+    .where(
+      and(
+        eq(videoUploadSets.id, setId),
+        inArray(videoUploadSets.status, [...UPLOAD_TOKEN_ALLOWED_STATUSES])
+      )
+    )
+    .returning()
+
+  if (!updated) {
+    throw new Error('Cannot upload clips in the current set status')
+  }
+}
+
+async function releasePendingClipUpload(setId: string): Promise<void> {
+  const db = getDb()
+  await db
+    .update(videoUploadSets)
+    .set({
+      pendingUploadCount: sql`greatest(${videoUploadSets.pendingUploadCount} - 1, 0)`,
+      updatedAt: new Date(),
+    })
+    .where(eq(videoUploadSets.id, setId))
 }
 
 export async function recordUploadedClip(input: {
@@ -227,6 +265,8 @@ export async function recordUploadedClip(input: {
     return reconcileExisting(raced)
   }
 
+  await releasePendingClipUpload(input.setId)
+
   // Conditional updates only — never clobber queued/processing/complete if the
   // set advanced between the initial read and this write (Start merge race).
   await db
@@ -275,6 +315,11 @@ export async function markSetReady(setId: string): Promise<VideoUploadSetRecord>
   if (!(READY_ALLOWED_STATUSES as readonly string[]).includes(set.status)) {
     throw new Error(`Cannot mark ready while set is ${set.status}`)
   }
+  if (set.pendingUploadCount > 0) {
+    throw new Error(
+      `Wait for ${set.pendingUploadCount} in-flight upload(s) to finish before marking ready`
+    )
+  }
 
   const clips = await listClipsForSet(setId)
   if (clips.length === 0) {
@@ -300,13 +345,16 @@ export async function markSetReady(setId: string): Promise<VideoUploadSetRecord>
       and(
         eq(videoUploadSets.id, setId),
         // Re-check so we never clobber queued/processing/complete mid-flight.
-        eq(videoUploadSets.status, set.status)
+        eq(videoUploadSets.status, set.status),
+        eq(videoUploadSets.pendingUploadCount, 0)
       )
     )
     .returning()
 
   if (!updated) {
-    throw new Error('Upload set status changed; cannot mark ready')
+    throw new Error(
+      'Upload set changed or uploads are still in progress; cannot mark ready'
+    )
   }
   return mapSet(updated)
 }
@@ -324,6 +372,11 @@ export async function enqueueVideoUploadSet(
 
   if (!(ENQUEUE_ALLOWED_STATUSES as readonly string[]).includes(set.status)) {
     throw new Error(`Cannot enqueue set in status ${set.status}`)
+  }
+  if (set.pendingUploadCount > 0) {
+    throw new Error(
+      `Wait for ${set.pendingUploadCount} in-flight upload(s) to finish before starting merge`
+    )
   }
 
   const clips = await listClipsForSet(setId)
@@ -363,13 +416,16 @@ export async function enqueueVideoUploadSet(
     .where(
       and(
         eq(videoUploadSets.id, setId),
-        inArray(videoUploadSets.status, [...ENQUEUE_ALLOWED_STATUSES])
+        inArray(videoUploadSets.status, [...ENQUEUE_ALLOWED_STATUSES]),
+        eq(videoUploadSets.pendingUploadCount, 0)
       )
     )
     .returning()
 
   if (!updated) {
-    throw new Error('Upload set status changed; cannot enqueue')
+    throw new Error(
+      'Upload set status changed or uploads are still in progress; cannot enqueue'
+    )
   }
   return mapSet(updated)
 }

--- a/app/lib/video-tools/queries.ts
+++ b/app/lib/video-tools/queries.ts
@@ -21,6 +21,7 @@ function mapSet(row: typeof videoUploadSets.$inferSelect): VideoUploadSetRecord 
     mergedBlobUrl: row.mergedBlobUrl,
     mergedBlobPathname: row.mergedBlobPathname,
     outputFilename: row.outputFilename,
+    pendingUploadCount: row.pendingUploadCount,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   }

--- a/app/lib/video-tools/types.ts
+++ b/app/lib/video-tools/types.ts
@@ -37,6 +37,7 @@ export type VideoUploadSetRecord = {
   mergedBlobUrl: string | null
   mergedBlobPathname: string | null
   outputFilename: string | null
+  pendingUploadCount: number
   createdAt: Date
   updatedAt: Date
 }

--- a/app/video-tools/[id]/page.tsx
+++ b/app/video-tools/[id]/page.tsx
@@ -433,10 +433,12 @@ function VideoUploadSetDetailContent() {
           <button
             type="button"
             onClick={() => void markReady()}
-            disabled={busy}
+            disabled={busy || set.pendingUploadCount > 0}
             className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-800 hover:bg-gray-50 disabled:opacity-60"
           >
-            Mark ready
+            {set.pendingUploadCount > 0
+              ? `Mark ready (${set.pendingUploadCount} uploading…)`
+              : 'Mark ready'}
           </button>
         )}
         {canStartOrRetryMerge && (

--- a/drizzle/0018_video_tools_pending_uploads.sql
+++ b/drizzle/0018_video_tools_pending_uploads.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "video_upload_sets" ADD COLUMN IF NOT EXISTS "pending_upload_count" integer DEFAULT 0 NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1753812000000,
       "tag": "0017_video_tools_claim_token",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1753815600000,
+      "tag": "0018_video_tools_pending_uploads",
+      "breakpoints": true
     }
   ]
 }

--- a/workers/video-merge/fly.toml
+++ b/workers/video-merge/fly.toml
@@ -14,6 +14,8 @@ primary_region = "bos"
 [env]
   POLL_INTERVAL_MS = "15000"
 
+# Disk: clip downloads + merged output need headroom (uploads allow up to 20GB/clip).
+# Attach a volume or raise the VM size before large multi-court merges.
 [[vm]]
   size = "shared-cpu-2x"
   memory = "4gb"


### PR DESCRIPTION
## Summary
- Adds `pending_upload_count` (migration `0018`); increments on Blob token mint, decrements when a new clip row is inserted.
- Mark ready / enqueue require `pending_upload_count = 0`.
- New upload tokens only while `draft` / `uploading` / `failed`.
- Notes worker disk sizing for large multi-clip merges in `fly.toml`.

Addresses Bugbot finding on [#119](https://github.com/jsartin513/bdl-admin/pull/119) (merge while uploads still in flight across tabs).

## Test plan
- [ ] `npx vitest run app/lib/video-tools`
- [ ] Start an upload; Mark ready stays disabled / errors until it finishes
- [ ] After all uploads complete, Mark ready → Start merge works


Made with [Cursor](https://cursor.com)