### PR TITLE
Document Fly video-merge worker and auto-deploy on main

### DIFF
--- a/.cursor/video-tools-runbook.md
+++ b/.cursor/video-tools-runbook.md
@@ -2,6 +2,26 @@
 
 Team UI for concurrent GoPro upload sets (e.g. Court 1 + Court 2) and cloud merge.
 
+## Architecture (two deployables)
+
+```
+Admin (Vercel)                         Worker (Fly.io)
+──────────────                         ───────────────
+/video-tools UI                        bdl-video-merge (ewr)
+Blob multipart uploads                 polls every 15s
+POST …/enqueue → status=queued    →    POST /api/video-tools/worker/claim
+                                       ffmpeg concat (-c copy)
+                                       upload _untrimmed.MP4
+                                  ←    POST …/worker/complete
+```
+
+| Piece | Host | What it does |
+|-------|------|----------------|
+| **bdl-admin** | Vercel | UI, APIs, Blob upload tokens, job status in Postgres |
+| **bdl-video-merge** | Fly.io | Long-running Node + ffmpeg; claims queued sets and merges |
+
+Deploying the Next.js app alone does **not** start merges. Jobs stay **queued** until the Fly worker is running and can authenticate with the same `VIDEO_WORKER_SECRET`.
+
 ## App env (Vercel / `.env.local`)
 
 | Variable | Purpose |
@@ -9,13 +29,98 @@ Team UI for concurrent GoPro upload sets (e.g. Court 1 + Court 2) and cloud merg
 | `BLOB_READ_WRITE_TOKEN` | Already used for player/event photos; required for client video uploads |
 | `VIDEO_WORKER_SECRET` | Shared bearer secret for `/api/video-tools/worker/*` |
 
-## Worker env
+## Worker env (Fly secrets)
 
 See [`workers/video-merge/README.md`](../workers/video-merge/README.md).
+
+| Variable | Purpose |
+|----------|---------|
+| `VIDEO_TOOLS_API_BASE` | Prod admin origin: `https://admin.bostondodgeballleague.com` |
+| `VIDEO_WORKER_SECRET` | **Same value** as Vercel |
+| `BLOB_READ_WRITE_TOKEN` | **Same** Blob read/write token as Vercel |
+
+Production worker: Fly app **`bdl-video-merge`**, region **`ewr`** (Newark; `bos` is deprecated for new machines).
+
+```bash
+cd workers/video-merge
+fly status
+fly logs
+fly deploy   # after worker code changes (or rely on GitHub Action on main)
+```
+
+### Secret rotation
+
+Update **both** Vercel (`VIDEO_WORKER_SECRET`) and Fly (`fly secrets set VIDEO_WORKER_SECRET=… -a bdl-video-merge`). Mismatch → claim returns 401 and jobs stay queued.
+
+### Preview vs production
+
+The Fly worker is pointed at **production** admin. Merges started on [admin-preview](https://admin-preview.bostondodgeballleague.com) are **not** claimed unless you run a separate worker with `VIDEO_TOOLS_API_BASE` set to the preview URL. Prefer end-to-end merge tests against production (or a local worker + local/preview app).
 
 ## Flow
 
 1. **Video Tools** → New upload set (event name, date, label)
 2. Upload MP4s (multipart client → Vercel Blob)
-3. **Start merge** → status `queued`
-4. Worker claims job → ffmpeg concat → uploads `_untrimmed.MP4` → `complete`
+3. **Mark ready** → **Start merge** → status `queued`
+4. Fly worker claims job → ffmpeg concat → uploads `_untrimmed.MP4` → `complete`
+
+### Stuck on “queued”
+
+1. `fly status -a bdl-video-merge` — machine should be `started`
+2. `fly logs -a bdl-video-merge` — look for `polling https://admin…`
+3. Confirm Vercel + Fly share the same `VIDEO_WORKER_SECRET`
+4. Use **Retry merge** on the set page after the worker is healthy
+
+## CI / auto-deploy
+
+- Pushing changes under `workers/video-merge/` to **`main`** runs [`.github/workflows/deploy-video-merge-worker.yml`](../.github/workflows/deploy-video-merge-worker.yml) (`fly deploy`).
+- Requires GitHub Actions secret **`FLY_API_TOKEN`** (Fly dashboard → Account → Access Tokens, or `fly tokens create deploy -x 999999h`).
+- Admin app continues to deploy via the normal Vercel Git integration (preview → main).
+
+## Local testing with short demo clips
+
+### Generate fixtures
+
+Requires `ffmpeg` and `python3` with Pillow. Writes gitignored MP4s under `tmp/gopro-demo-clips/`:
+
+```bash
+bash scripts/generate-gopro-demo-clips.sh
+```
+
+Creates 2s H.264 clips with large on-screen step numbers (1–6), GoPro chapter names, plus an offline `merged_smoke.MP4` concat in correct order.
+
+| File | Expected step |
+|------|---------------|
+| `GOPR0010.MP4` | 1 |
+| `GX010010.MP4` | 2 |
+| `GX020010.MP4` | 3 |
+| `GX030010.MP4` | 4 |
+| `GX010020.MP4` | 5 (session 0020 after 0010) |
+| `zzz_tail.mp4` | 6 (non-GoPro, after all GoPro) |
+
+To reuse after an upload, rename to a new session id (e.g. `0010` → `0030`) or re-run the script.
+
+### Unit tests (ordering / naming only)
+
+```bash
+npx vitest run app/lib/video-tools
+```
+
+### Local E2E (app + worker)
+
+1. Ensure `.env.local` has `BLOB_READ_WRITE_TOKEN` and `VIDEO_WORKER_SECRET`.
+2. Start the Next app (`npm run dev` or equivalent).
+3. Start the merge worker in another terminal:
+
+```bash
+export VIDEO_TOOLS_API_BASE=http://localhost:3000
+export VIDEO_WORKER_SECRET=…   # same as app
+export BLOB_READ_WRITE_TOKEN=…
+node workers/video-merge/index.mjs
+```
+
+4. **Video Tools** → New upload set (e.g. `Demo Event` / `Court 1` / today’s date).
+5. Drop the six clips from `tmp/gopro-demo-clips/` **out of order** (skip `merged_smoke.MP4` and `concat_list.txt`).
+6. **Mark ready** → **Start merge** → wait for `complete`.
+7. Download the `_untrimmed.MP4` and confirm playback shows steps **1 → 2 → 3 → 4 → 5 → 6** (not upload order).
+
+Optional concurrent check: create a second set (`Court 2`) and upload another batch (re-run the script into a second folder, or duplicate/rename with a different session id) so both merges finish independently without mixing clips.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,3 +12,4 @@
 - [ ] Lint / unit / build CI green
 - [ ] If targeting `preview`: confirm [admin-preview](https://admin-preview.bostondodgeballleague.com) deploys and `/players` + `/events` load (sign in)
 - [ ] If targeting `main`: head branch is `preview` and Preview smoke is green
+- [ ] If changing `workers/video-merge/`: after merge to `main`, confirm Fly deploy workflow succeeds (`bdl-video-merge`); merges stay queued until that worker is healthy

--- a/.github/workflows/deploy-video-merge-worker.yml
+++ b/.github/workflows/deploy-video-merge-worker.yml
@@ -1,0 +1,34 @@
+name: Deploy video-merge worker
+
+# Production Fly worker. Only deploys when worker sources change on main
+# (after preview → main promote). Does not deploy the Vercel admin app.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'workers/video-merge/**'
+      - '.github/workflows/deploy-video-merge-worker.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: workers/video-merge
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          if [ -z "$FLY_API_TOKEN" ]; then
+            echo "::error::Missing GitHub Actions secret FLY_API_TOKEN. Create a Fly deploy token and add it under repo Settings → Secrets."
+            exit 1
+          fi
+          flyctl deploy --remote-only --yes

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ next-env.d.ts
 # test output
 test-league-output.xlsx
 
+# local Video Tools demo clips (ffmpeg-generated)
+/tmp/
+
 # Python
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 
 ## Deploy on Vercel
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+The admin app deploys with the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) (Git: `preview` → `main`).
+
+**Video Tools** also needs a separate Fly.io worker (`bdl-video-merge`) for ffmpeg merges — that is not part of the Vercel deploy. See [`.cursor/video-tools-runbook.md`](.cursor/video-tools-runbook.md) and [`workers/video-merge/README.md`](workers/video-merge/README.md).
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.

--- a/scripts/generate-gopro-demo-clips.sh
+++ b/scripts/generate-gopro-demo-clips.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Generate short, visually numbered GoPro-named MP4s for Video Tools testing.
+# Requires: ffmpeg + python3 with Pillow (PIL).
+#
+# Usage:
+#   bash scripts/generate-gopro-demo-clips.sh [output_dir]
+#
+# Default output: tmp/gopro-demo-clips/
+# Also writes an offline concat smoke test (merged_smoke.MP4) in correct GoPro order.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="${1:-$ROOT/tmp/gopro-demo-clips}"
+DURATION=2
+WIDTH=640
+HEIGHT=360
+FPS=30
+
+mkdir -p "$OUT"
+
+# Render a still PNG with large step number (Pillow — works without ffmpeg drawtext).
+render_frame() {
+  local png="$1"
+  local step="$2"
+  local hex_color="$3"
+  local label="$4"
+  python3 - "$png" "$step" "$hex_color" "$label" "$WIDTH" "$HEIGHT" <<'PY'
+import sys
+from PIL import Image, ImageDraw, ImageFont
+
+path, step, hex_color, label, w, h = sys.argv[1:7]
+w, h = int(w), int(h)
+rgb = tuple(int(hex_color[i : i + 2], 16) for i in (0, 2, 4))
+img = Image.new("RGB", (w, h), rgb)
+draw = ImageDraw.Draw(img)
+
+def load_font(size: int):
+    for candidate in (
+        "/System/Library/Fonts/Supplemental/Arial Bold.ttf",
+        "/System/Library/Fonts/Supplemental/Arial.ttf",
+        "/Library/Fonts/Arial Unicode.ttf",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+        "/usr/share/fonts/truetype/liberation/LiberationSans-Bold.ttf",
+    ):
+        try:
+            return ImageFont.truetype(candidate, size)
+        except OSError:
+            continue
+    return ImageFont.load_default()
+
+big = load_font(140)
+small = load_font(36)
+
+def centered(text, font, y):
+    bbox = draw.textbbox((0, 0), text, font=font)
+    tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]
+    x = (w - tw) // 2
+    # black outline for readability
+    for dx, dy in ((-2, 0), (2, 0), (0, -2), (0, 2), (-2, -2), (2, 2), (-2, 2), (2, -2)):
+        draw.text((x + dx, y + dy), text, font=font, fill=(0, 0, 0))
+    draw.text((x, y), text, font=font, fill=(255, 255, 255))
+    return th
+
+centered(step, big, h // 2 - 90)
+centered(label, small, h // 2 + 50)
+img.save(path)
+PY
+}
+
+make_clip() {
+  local filename="$1"
+  local step="$2"
+  local hex_color="$3"
+  local label="$4"
+  local png="$OUT/_frame_${step}.png"
+  local path="$OUT/$filename"
+
+  render_frame "$png" "$step" "$hex_color" "$label"
+
+  # Shared encode settings so worker ffmpeg -c copy concat stays compatible.
+  ffmpeg -y -hide_banner -loglevel error \
+    -loop 1 -i "$png" \
+    -c:v libx264 -pix_fmt yuv420p -r "$FPS" -t "$DURATION" \
+    -movflags +faststart \
+    "$path"
+  rm -f "$png"
+  echo "  $filename  (step $step)"
+}
+
+echo "Generating demo clips → $OUT"
+echo ""
+
+# Session 0010 — chapters in GoPro order (upload these shuffled in the UI)
+make_clip "GOPR0010.MP4" "1" "1E3A8A" "1 · GOPR0010"
+make_clip "GX010010.MP4" "2" "166534" "2 · GX010010"
+make_clip "GX020010.MP4" "3" "A16207" "3 · GX020010"
+make_clip "GX030010.MP4" "4" "C2410C" "4 · GX030010"
+
+# Session 0020 — sorts after 0010
+make_clip "GX010020.MP4" "5" "6B21A8" "5 · GX010020"
+
+# Non-GoPro — sorts after all GoPro sessions
+make_clip "zzz_tail.mp4" "6" "374151" "6 · zzz_tail"
+
+# Offline smoke: concat in correct GoPro order (not alphabetical / upload order)
+LIST="$OUT/concat_list.txt"
+MERGED="$OUT/merged_smoke.MP4"
+{
+  echo "file '$OUT/GOPR0010.MP4'"
+  echo "file '$OUT/GX010010.MP4'"
+  echo "file '$OUT/GX020010.MP4'"
+  echo "file '$OUT/GX030010.MP4'"
+  echo "file '$OUT/GX010020.MP4'"
+  echo "file '$OUT/zzz_tail.mp4'"
+} > "$LIST"
+
+ffmpeg -y -hide_banner -loglevel error \
+  -f concat -safe 0 -i "$LIST" -c copy "$MERGED"
+
+echo ""
+echo "Expected merge order (watch for steps 1 → 6):"
+echo "  GOPR0010.MP4 → GX010010.MP4 → GX020010.MP4 → GX030010.MP4 → GX010020.MP4 → zzz_tail.mp4"
+echo ""
+echo "Offline smoke concat: $MERGED"
+echo "Upload the six clips from $OUT via Video Tools (drop out of order)."
+ls -lh "$OUT"/*.MP4 "$OUT"/*.mp4 2>/dev/null | awk '{print "  " $5 "\t" $9}'

--- a/workers/video-merge/README.md
+++ b/workers/video-merge/README.md
@@ -30,9 +30,15 @@ Build context is this directory (`workers/video-merge`):
 
 ```bash
 cd workers/video-merge
-docker build -t bdl-video-merge .
-# or from here:
+# first time:
+#   fly apps create bdl-video-merge
+#   fly secrets set VIDEO_TOOLS_API_BASE=https://admin.bostondodgeballleague.com \
+#     VIDEO_WORKER_SECRET=... BLOB_READ_WRITE_TOKEN=...
 fly deploy
 ```
+
+App: **`bdl-video-merge`** (primary region `ewr`). Monitor with `fly status` / `fly logs`.
+
+Pushes to `main` that touch this directory auto-deploy via GitHub Actions (secret `FLY_API_TOKEN`). Manual: `fly deploy` from this directory.
 
 Disk and memory need room for concurrent multi-GB court sets; bump VM size as needed.

--- a/workers/video-merge/fly.toml
+++ b/workers/video-merge/fly.toml
@@ -1,12 +1,14 @@
-# fly.toml — example config for the Video Tools merge worker.
-# Deploy from repo root:
+# fly.toml — Video Tools merge worker.
+# Deploy from workers/video-merge/:
 #   fly apps create bdl-video-merge
 #   fly secrets set VIDEO_TOOLS_API_BASE=https://admin.bostondodgeballleague.com \
 #     VIDEO_WORKER_SECRET=... BLOB_READ_WRITE_TOKEN=...
-#   fly deploy -c workers/video-merge/fly.toml
+#   fly deploy
+#
+# Region: ewr (Newark). bos is deprecated for new machines.
 
 app = "bdl-video-merge"
-primary_region = "bos"
+primary_region = "ewr"
 
 [build]
   dockerfile = "Dockerfile"


### PR DESCRIPTION
## Summary
- Documents the Vercel admin + Fly `bdl-video-merge` architecture, stuck-queue troubleshooting, secret rotation, and preview vs prod merge caveats.
- Adds short GoPro demo clip generator (`scripts/generate-gopro-demo-clips.sh`) and gitignores `tmp/`.
- Deploys the Fly worker via GitHub Actions when `workers/video-merge/**` lands on `main` (`FLY_API_TOKEN`); updates `fly.toml` primary region to `ewr`.

## Test plan
- [ ] Lint / unit / build CI green
- [ ] Skim [.cursor/video-tools-runbook.md](.cursor/video-tools-runbook.md) for accuracy vs live Fly app
- [ ] After merge to `main` (or workflow_dispatch): confirm Deploy video-merge worker workflow can authenticate with `FLY_API_TOKEN`
- [ ] Optional: `bash scripts/generate-gopro-demo-clips.sh` produces clips under `tmp/gopro-demo-clips/`


Made with [Cursor](https://cursor.com)