### PR TITLE
Set-and-forget Video Tools: edit while uploading, auto-merge, notify

### DIFF
--- a/.cursor/video-tools-runbook.md
+++ b/.cursor/video-tools-runbook.md
@@ -28,6 +28,9 @@ Deploying the Next.js app alone does **not** start merges. Jobs stay **queued** 
 |----------|---------|
 | `BLOB_READ_WRITE_TOKEN` | Already used for player/event photos; required for client video uploads |
 | `VIDEO_WORKER_SECRET` | Shared bearer secret for `/api/video-tools/worker/*` |
+| `RESEND_API_KEY` | Optional. When set with `NOTIFY_FROM_EMAIL`, email on merge complete/fail |
+| `NOTIFY_FROM_EMAIL` | Optional Resend “from” address for merge notifications |
+| `NEXT_PUBLIC_APP_URL` | Optional absolute site URL used in notification email links |
 
 ## Worker env (Fly secrets)
 
@@ -59,9 +62,13 @@ The Fly worker is pointed at **production** admin. Merges started on [admin-prev
 ## Flow
 
 1. **Video Tools** → New upload set (event name, date, label)
-2. Upload MP4s (multipart client → Vercel Blob)
-3. **Mark ready** → **Start merge** → status `queued`
-4. Fly worker claims job → ffmpeg concat → uploads `_untrimmed.MP4` → `complete`
+2. Upload MP4s (multipart client → Vercel Blob). Details can be edited while uploading.
+3. Optional: enable **When uploads finish, start merge automatically** (use one fully successful batch, or turn this on after every clip is uploaded)
+4. Or manually **Mark ready** → **Start merge** → status `queued`
+5. Fly worker claims job → ffmpeg concat → uploads `_untrimmed.MP4` → `complete`
+6. In-app notification (nav **Alerts**) for the set creator; optional email if Resend is configured
+
+Keep the browser tab open until uploads finish. After enqueue, merge is backgrounded.
 
 ### Stuck on “queued”
 
@@ -120,7 +127,7 @@ node workers/video-merge/index.mjs
 
 4. **Video Tools** → New upload set (e.g. `Demo Event` / `Court 1` / today’s date).
 5. Drop the six clips from `tmp/gopro-demo-clips/` **out of order** (skip `merged_smoke.MP4` and `concat_list.txt`).
-6. **Mark ready** → **Start merge** → wait for `complete`.
+6. **Mark ready** → **Start merge** (or enable auto-start) → wait for `complete`.
 7. Download the `_untrimmed.MP4` and confirm playback shows steps **1 → 2 → 3 → 4 → 5 → 6** (not upload order).
 
 Optional concurrent check: create a second set (`Court 2`) and upload another batch (re-run the script into a second folder, or duplicate/rename with a different session id) so both merges finish independently without mixing clips.

--- a/app/api/admin/notifications/[id]/route.ts
+++ b/app/api/admin/notifications/[id]/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import {
+  countUnreadAdminNotifications,
+  markAdminNotificationRead,
+} from '@/app/lib/admin-notifications'
+
+type RouteContext = { params: Promise<{ id: string }> }
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id } = await context.params
+    const body = (await request.json()) as { action?: string }
+    if (body.action !== 'mark_read') {
+      return NextResponse.json({ error: 'Unknown action' }, { status: 400 })
+    }
+
+    const notification = await markAdminNotificationRead(id, session.email)
+    if (!notification) {
+      return NextResponse.json({ error: 'Notification not found' }, { status: 404 })
+    }
+    const unreadCount = await countUnreadAdminNotifications(session.email)
+    return NextResponse.json({ notification, unreadCount })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to update notification'
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+}

--- a/app/api/admin/notifications/route.ts
+++ b/app/api/admin/notifications/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import {
+  countUnreadAdminNotifications,
+  listAdminNotificationsForEmail,
+  markAllAdminNotificationsRead,
+} from '@/app/lib/admin-notifications'
+
+export async function GET(request: NextRequest) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const unreadOnly = request.nextUrl.searchParams.get('unread') === '1'
+    const limitParam = request.nextUrl.searchParams.get('limit')
+    const limit = limitParam ? Number(limitParam) : 20
+
+    const [notifications, unreadCount] = await Promise.all([
+      listAdminNotificationsForEmail(session.email, {
+        limit: Number.isFinite(limit) ? limit : 20,
+        unreadOnly,
+      }),
+      countUnreadAdminNotifications(session.email),
+    ])
+
+    return NextResponse.json({ notifications, unreadCount })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to load notifications'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const body = (await request.json()) as { action?: string }
+    if (body.action === 'mark_all_read') {
+      const updated = await markAllAdminNotificationsRead(session.email)
+      const unreadCount = await countUnreadAdminNotifications(session.email)
+      return NextResponse.json({ updated, unreadCount })
+    }
+    return NextResponse.json({ error: 'Unknown action' }, { status: 400 })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to update notifications'
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+}

--- a/app/api/video-tools/sets/[id]/reserve-uploads/route.ts
+++ b/app/api/video-tools/sets/[id]/reserve-uploads/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  adminUnauthorizedResponse,
+  getAdminSessionFromRequest,
+} from '@/app/lib/admin-auth'
+import { reservePendingClipUploads } from '@/app/lib/video-tools/mutations'
+import { getVideoUploadSet } from '@/app/lib/video-tools/queries'
+
+type RouteContext = { params: Promise<{ id: string }> }
+
+/**
+ * Reserve N pending upload slots before a multi-file batch so pending count
+ * does not hit zero between sequential files (auto-enqueue race).
+ */
+export async function POST(request: NextRequest, context: RouteContext) {
+  const session = getAdminSessionFromRequest(request)
+  if (!session) return adminUnauthorizedResponse()
+
+  try {
+    const { id } = await context.params
+    const body = (await request.json()) as { count?: number }
+    const count = typeof body.count === 'number' ? body.count : NaN
+
+    const updated = await reservePendingClipUploads(id, count)
+    const set = await getVideoUploadSet(updated.id)
+    return NextResponse.json({ set })
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Failed to reserve upload slots'
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+}

--- a/app/api/video-tools/sets/[id]/route.ts
+++ b/app/api/video-tools/sets/[id]/route.ts
@@ -3,7 +3,13 @@ import {
   adminUnauthorizedResponse,
   getAdminSessionFromRequest,
 } from '@/app/lib/admin-auth'
-import { markSetReady, resetPendingUploads } from '@/app/lib/video-tools/mutations'
+import {
+  markSetReady,
+  maybeAutoEnqueueVideoUploadSet,
+  resetPendingUploads,
+  setAutoEnqueueOnReady,
+  updateVideoUploadSetMetadata,
+} from '@/app/lib/video-tools/mutations'
 import { getVideoUploadSet } from '@/app/lib/video-tools/queries'
 
 type RouteContext = { params: Promise<{ id: string }> }
@@ -31,7 +37,13 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
 
   try {
     const { id } = await context.params
-    const body = (await request.json()) as { action?: string }
+    const body = (await request.json()) as {
+      action?: string
+      eventName?: string
+      label?: string
+      eventDate?: string
+      autoEnqueueOnReady?: boolean
+    }
 
     if (body.action === 'mark_ready') {
       const updated = await markSetReady(id)
@@ -42,6 +54,47 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     if (body.action === 'reset_pending_uploads') {
       const updated = await resetPendingUploads(id)
       const set = await getVideoUploadSet(updated.id)
+      return NextResponse.json({ set })
+    }
+
+    if (body.action === 'update_metadata') {
+      if (
+        typeof body.eventName !== 'string' ||
+        typeof body.label !== 'string' ||
+        typeof body.eventDate !== 'string'
+      ) {
+        return NextResponse.json(
+          { error: 'eventName, label, and eventDate are required' },
+          { status: 400 }
+        )
+      }
+      const set = await updateVideoUploadSetMetadata(id, {
+        eventName: body.eventName,
+        label: body.label,
+        eventDate: body.eventDate,
+      })
+      return NextResponse.json({ set })
+    }
+
+    if (body.action === 'set_auto_enqueue') {
+      if (typeof body.autoEnqueueOnReady !== 'boolean') {
+        return NextResponse.json(
+          { error: 'autoEnqueueOnReady must be a boolean' },
+          { status: 400 }
+        )
+      }
+      await setAutoEnqueueOnReady(id, body.autoEnqueueOnReady)
+      // If enabling after uploads already finished, try to enqueue now.
+      if (body.autoEnqueueOnReady) {
+        await maybeAutoEnqueueVideoUploadSet(id)
+      }
+      const set = await getVideoUploadSet(id)
+      return NextResponse.json({ set })
+    }
+
+    if (body.action === 'maybe_auto_enqueue') {
+      await maybeAutoEnqueueVideoUploadSet(id)
+      const set = await getVideoUploadSet(id)
       return NextResponse.json({ set })
     }
 

--- a/app/api/video-tools/upload/route.ts
+++ b/app/api/video-tools/upload/route.ts
@@ -28,15 +28,18 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
         let setId: string | null = null
         let originalFilename: string | null = null
+        let preReserved = false
         try {
           const payload = clientPayload
             ? (JSON.parse(clientPayload) as {
                 setId?: string
                 originalFilename?: string
+                preReserved?: boolean
               })
             : {}
           setId = payload.setId?.trim() || null
           originalFilename = payload.originalFilename?.trim() || null
+          preReserved = Boolean(payload.preReserved)
         } catch {
           throw new Error('Invalid client payload')
         }
@@ -56,7 +59,14 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
           throw new Error('Invalid upload pathname')
         }
 
-        await beginPendingClipUpload(setId)
+        // Batch uploads reserve pending slots upfront so auto-enqueue does not
+        // fire between sequential files. Skip the per-token increment when reserved.
+        if (!preReserved) {
+          await beginPendingClipUpload(setId)
+        } else if (set.pendingUploadCount < 1) {
+          // Safety: reservation missing — fall back to incrementing.
+          await beginPendingClipUpload(setId)
+        }
 
         return {
           allowedContentTypes: [

--- a/app/components/TopNav.tsx
+++ b/app/components/TopNav.tsx
@@ -2,12 +2,13 @@
 
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
-import { useEffect, useId, useRef, useState } from 'react'
+import { useCallback, useEffect, useId, useRef, useState } from 'react'
 import { useDevMode } from '@/app/hooks/useDevMode'
 import { withDevMode } from '@/app/lib/devMode'
 import { fetchAdminSession, logoutAdminSession } from '@/app/lib/admin-client-auth'
 import BoardAppsMenu from '@/app/components/BoardAppsMenu'
 import { Tooltip } from '@/app/components/ui'
+import type { AdminNotificationRecord } from '@/app/lib/video-tools/types'
 
 function NavDropdown({ label, children }: { label: string; children: React.ReactNode }) {
   const [open, setOpen] = useState(false)
@@ -64,6 +65,203 @@ function NavDropdown({ label, children }: { label: string; children: React.React
 
 function menuItemClassName() {
   return 'block px-3 py-2 text-sm text-gray-100 hover:bg-gray-600 focus-visible:bg-gray-600 focus-visible:outline-none'
+}
+
+function NotificationsBell({
+  enabled,
+  devMode,
+}: {
+  enabled: boolean
+  devMode: boolean
+}) {
+  const [open, setOpen] = useState(false)
+  const [notifications, setNotifications] = useState<AdminNotificationRecord[]>(
+    []
+  )
+  const [unreadCount, setUnreadCount] = useState(0)
+  const ref = useRef<HTMLDivElement>(null)
+  const panelId = useId()
+  const buttonRef = useRef<HTMLButtonElement>(null)
+
+  const load = useCallback(async () => {
+    if (!enabled) return
+    try {
+      const res = await fetch('/api/admin/notifications?limit=15')
+      if (!res.ok) return
+      const data = await res.json()
+      setNotifications(data.notifications ?? [])
+      setUnreadCount(Number(data.unreadCount) || 0)
+    } catch {
+      // ignore poll errors
+    }
+  }, [enabled])
+
+  useEffect(() => {
+    if (!enabled) return
+    void load()
+    const id = setInterval(() => void load(), 30000)
+    return () => clearInterval(id)
+  }, [enabled, load])
+
+  useEffect(() => {
+    if (!open) return
+    const onMouseDown = (event: MouseEvent) => {
+      if (!ref.current?.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false)
+        buttonRef.current?.focus()
+      }
+    }
+    document.addEventListener('mousedown', onMouseDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
+
+  async function markRead(id: string) {
+    try {
+      const res = await fetch(`/api/admin/notifications/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'mark_read' }),
+      })
+      if (!res.ok) return
+      const data = await res.json()
+      setUnreadCount(Number(data.unreadCount) || 0)
+      setNotifications((prev) =>
+        prev.map((n) =>
+          n.id === id ? { ...n, readAt: data.notification?.readAt ?? new Date() } : n
+        )
+      )
+    } catch {
+      // ignore
+    }
+  }
+
+  async function markAllRead() {
+    try {
+      const res = await fetch('/api/admin/notifications', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'mark_all_read' }),
+      })
+      if (!res.ok) return
+      const data = await res.json()
+      setUnreadCount(Number(data.unreadCount) || 0)
+      setNotifications((prev) =>
+        prev.map((n) => ({ ...n, readAt: n.readAt ?? new Date() }))
+      )
+    } catch {
+      // ignore
+    }
+  }
+
+  if (!enabled) return null
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => {
+          setOpen((v) => !v)
+          if (!open) void load()
+        }}
+        className="relative rounded px-2 py-1 hover:bg-gray-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+        aria-expanded={open}
+        aria-haspopup="true"
+        aria-controls={panelId}
+        aria-label={
+          unreadCount > 0
+            ? `Notifications, ${unreadCount} unread`
+            : 'Notifications'
+        }
+      >
+        <span aria-hidden="true">Alerts</span>
+        {unreadCount > 0 && (
+          <span className="ml-1 inline-flex min-w-[1.25rem] items-center justify-center rounded-full bg-amber-400 px-1.5 text-xs font-semibold text-gray-900">
+            {unreadCount > 9 ? '9+' : unreadCount}
+          </span>
+        )}
+      </button>
+      {open && (
+        <div
+          id={panelId}
+          className="absolute right-0 mt-1 w-80 max-w-[calc(100vw-2rem)] rounded-md bg-gray-700 py-1 shadow-lg ring-1 ring-gray-600 z-50"
+          role="menu"
+        >
+          <div className="flex items-center justify-between gap-2 border-b border-gray-600 px-3 py-2">
+            <span className="text-sm font-medium text-gray-100">Notifications</span>
+            {unreadCount > 0 && (
+              <button
+                type="button"
+                onClick={() => void markAllRead()}
+                className="text-xs text-blue-200 hover:underline"
+              >
+                Mark all read
+              </button>
+            )}
+          </div>
+          {notifications.length === 0 ? (
+            <p className="px-3 py-4 text-sm text-gray-300">No notifications yet.</p>
+          ) : (
+            <ul className="max-h-80 overflow-y-auto">
+              {notifications.map((n) => {
+                const href = n.href
+                  ? withDevMode(n.href, devMode)
+                  : null
+                const unread = !n.readAt
+                const content = (
+                  <>
+                    <div
+                      className={`text-sm ${unread ? 'font-semibold text-white' : 'text-gray-100'}`}
+                    >
+                      {n.title}
+                    </div>
+                    <div className="mt-0.5 text-xs text-gray-300 line-clamp-2">
+                      {n.body}
+                    </div>
+                  </>
+                )
+                return (
+                  <li key={n.id} className="border-b border-gray-600 last:border-0">
+                    {href ? (
+                      <Link
+                        href={href}
+                        className="block px-3 py-2 hover:bg-gray-600"
+                        onClick={() => {
+                          if (unread) void markRead(n.id)
+                          setOpen(false)
+                        }}
+                      >
+                        {content}
+                      </Link>
+                    ) : (
+                      <button
+                        type="button"
+                        className="block w-full px-3 py-2 text-left hover:bg-gray-600"
+                        onClick={() => {
+                          if (unread) void markRead(n.id)
+                        }}
+                      >
+                        {content}
+                      </button>
+                    )}
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  )
 }
 
 export default function TopNav() {
@@ -163,6 +361,7 @@ export default function TopNav() {
         )}
       </div>
       <div className="flex items-center gap-4 text-sm">
+        <NotificationsBell enabled={Boolean(email)} devMode={devMode} />
         <BoardAppsMenu currentApp="admin" />
         {email ? (
           <>

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -400,6 +400,8 @@ export const videoUploadSets = pgTable(
     claimToken: uuid('claim_token'),
     /** In-flight Blob upload tokens; Mark ready / enqueue require zero. */
     pendingUploadCount: integer('pending_upload_count').notNull().default(0),
+    /** When true, mark ready + enqueue once pending uploads hit zero. */
+    autoEnqueueOnReady: boolean('auto_enqueue_on_ready').notNull().default(false),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
@@ -407,6 +409,24 @@ export const videoUploadSets = pgTable(
     index('video_upload_sets_status_idx').on(table.status),
     index('video_upload_sets_event_date_idx').on(table.eventDate),
     index('video_upload_sets_created_at_idx').on(table.createdAt),
+  ]
+)
+
+/** In-app notifications for admins (e.g. video merge complete/fail). */
+export const adminNotifications = pgTable(
+  'admin_notifications',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    recipientEmail: text('recipient_email').notNull(),
+    title: text('title').notNull(),
+    body: text('body').notNull(),
+    href: text('href'),
+    readAt: timestamp('read_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index('admin_notifications_recipient_email_idx').on(table.recipientEmail),
+    index('admin_notifications_created_at_idx').on(table.createdAt),
   ]
 )
 

--- a/app/lib/__tests__/notify-email.test.ts
+++ b/app/lib/__tests__/notify-email.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  isNotifyEmailConfigured,
+  sendNotifyEmail,
+} from '@/app/lib/notify-email'
+
+describe('notify-email', () => {
+  const originalKey = process.env.RESEND_API_KEY
+  const originalFrom = process.env.NOTIFY_FROM_EMAIL
+
+  afterEach(() => {
+    if (originalKey === undefined) delete process.env.RESEND_API_KEY
+    else process.env.RESEND_API_KEY = originalKey
+    if (originalFrom === undefined) delete process.env.NOTIFY_FROM_EMAIL
+    else process.env.NOTIFY_FROM_EMAIL = originalFrom
+  })
+
+  it('reports not configured when env is missing', () => {
+    delete process.env.RESEND_API_KEY
+    delete process.env.NOTIFY_FROM_EMAIL
+    expect(isNotifyEmailConfigured()).toBe(false)
+  })
+
+  it('skips send when not configured', async () => {
+    delete process.env.RESEND_API_KEY
+    delete process.env.NOTIFY_FROM_EMAIL
+    const result = await sendNotifyEmail({
+      to: 'ops@example.com',
+      subject: 'Test',
+      text: 'Hello',
+    })
+    expect(result.sent).toBe(false)
+    expect(result.skipped).toMatch(/not configured/)
+  })
+})

--- a/app/lib/admin-notifications.ts
+++ b/app/lib/admin-notifications.ts
@@ -1,0 +1,135 @@
+import { and, desc, eq, isNull, sql } from 'drizzle-orm'
+import { getDb } from '@/app/lib/db'
+import { adminNotifications } from '@/app/db/schema'
+import type { AdminNotificationRecord } from '@/app/lib/video-tools/types'
+
+function mapNotification(
+  row: typeof adminNotifications.$inferSelect
+): AdminNotificationRecord {
+  return {
+    id: row.id,
+    recipientEmail: row.recipientEmail,
+    title: row.title,
+    body: row.body,
+    href: row.href,
+    readAt: row.readAt,
+    createdAt: row.createdAt,
+  }
+}
+
+export async function createAdminNotification(input: {
+  recipientEmail: string
+  title: string
+  body: string
+  href?: string | null
+}): Promise<AdminNotificationRecord> {
+  const recipientEmail = input.recipientEmail.trim().toLowerCase()
+  if (!recipientEmail) throw new Error('recipientEmail is required')
+  const title = input.title.trim()
+  const body = input.body.trim()
+  if (!title) throw new Error('title is required')
+  if (!body) throw new Error('body is required')
+
+  const db = getDb()
+  const [created] = await db
+    .insert(adminNotifications)
+    .values({
+      recipientEmail,
+      title,
+      body,
+      href: input.href?.trim() || null,
+    })
+    .returning()
+
+  return mapNotification(created)
+}
+
+export async function listAdminNotificationsForEmail(
+  email: string,
+  options?: { limit?: number; unreadOnly?: boolean }
+): Promise<AdminNotificationRecord[]> {
+  const recipientEmail = email.trim().toLowerCase()
+  if (!recipientEmail) return []
+
+  const limit = Math.min(Math.max(options?.limit ?? 20, 1), 50)
+  const db = getDb()
+
+  const conditions = [eq(adminNotifications.recipientEmail, recipientEmail)]
+  if (options?.unreadOnly) {
+    conditions.push(isNull(adminNotifications.readAt))
+  }
+
+  const rows = await db
+    .select()
+    .from(adminNotifications)
+    .where(and(...conditions))
+    .orderBy(desc(adminNotifications.createdAt))
+    .limit(limit)
+
+  return rows.map(mapNotification)
+}
+
+export async function countUnreadAdminNotifications(
+  email: string
+): Promise<number> {
+  const recipientEmail = email.trim().toLowerCase()
+  if (!recipientEmail) return 0
+
+  const db = getDb()
+  const [row] = await db
+    .select({
+      count: sql<number>`cast(count(*) as int)`,
+    })
+    .from(adminNotifications)
+    .where(
+      and(
+        eq(adminNotifications.recipientEmail, recipientEmail),
+        isNull(adminNotifications.readAt)
+      )
+    )
+
+  return Number(row?.count) || 0
+}
+
+export async function markAdminNotificationRead(
+  id: string,
+  email: string
+): Promise<AdminNotificationRecord | null> {
+  const recipientEmail = email.trim().toLowerCase()
+  if (!recipientEmail) return null
+
+  const db = getDb()
+  const [updated] = await db
+    .update(adminNotifications)
+    .set({ readAt: new Date() })
+    .where(
+      and(
+        eq(adminNotifications.id, id),
+        eq(adminNotifications.recipientEmail, recipientEmail)
+      )
+    )
+    .returning()
+
+  return updated ? mapNotification(updated) : null
+}
+
+export async function markAllAdminNotificationsRead(
+  email: string
+): Promise<number> {
+  const recipientEmail = email.trim().toLowerCase()
+  if (!recipientEmail) return 0
+
+  const db = getDb()
+  const updated = await db
+    .update(adminNotifications)
+    .set({ readAt: new Date() })
+    .where(
+      and(
+        eq(adminNotifications.recipientEmail, recipientEmail),
+        isNull(adminNotifications.readAt)
+      )
+    )
+    .returning({ id: adminNotifications.id })
+
+  return updated.length
+}

--- a/app/lib/notify-email.ts
+++ b/app/lib/notify-email.ts
@@ -1,0 +1,67 @@
+/**
+ * Optional outbound email for admin job completion.
+ * Sends only when RESEND_API_KEY and NOTIFY_FROM_EMAIL are set.
+ * Uses Resend's HTTP API (no SDK dependency).
+ */
+
+export type NotifyEmailInput = {
+  to: string
+  subject: string
+  text: string
+}
+
+export function isNotifyEmailConfigured(): boolean {
+  return Boolean(
+    process.env.RESEND_API_KEY?.trim() && process.env.NOTIFY_FROM_EMAIL?.trim()
+  )
+}
+
+export async function sendNotifyEmail(
+  input: NotifyEmailInput
+): Promise<{ sent: boolean; skipped?: string; error?: string }> {
+  const apiKey = process.env.RESEND_API_KEY?.trim()
+  const from = process.env.NOTIFY_FROM_EMAIL?.trim()
+  const to = input.to.trim().toLowerCase()
+
+  if (!apiKey || !from) {
+    return { sent: false, skipped: 'email not configured' }
+  }
+  if (!to) {
+    return { sent: false, skipped: 'missing recipient' }
+  }
+
+  try {
+    const res = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from,
+        to: [to],
+        subject: input.subject,
+        text: input.text,
+      }),
+    })
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => '')
+      console.error(
+        '[notify-email] Resend error',
+        res.status,
+        body.slice(0, 500)
+      )
+      return {
+        sent: false,
+        error: `Resend returned ${res.status}`,
+      }
+    }
+
+    return { sent: true }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'send failed'
+    console.error('[notify-email]', message)
+    return { sent: false, error: message }
+  }
+}

--- a/app/lib/video-tools/__tests__/status-transitions.test.ts
+++ b/app/lib/video-tools/__tests__/status-transitions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   CLIP_LOCKED_STATUSES,
   ENQUEUE_ALLOWED_STATUSES,
+  METADATA_EDITABLE_STATUSES,
   READY_ALLOWED_STATUSES,
   UPLOAD_TOKEN_ALLOWED_STATUSES,
 } from '@/app/lib/video-tools/mutations'
@@ -49,6 +50,18 @@ describe('video tools status transition policy', () => {
     ])
   })
 
+  it('allows metadata edits while collecting clips or after failure', () => {
+    expect([...METADATA_EDITABLE_STATUSES]).toEqual([
+      'draft',
+      'uploading',
+      'ready',
+      'failed',
+    ])
+    for (const status of ['queued', 'processing', 'complete'] as const) {
+      expect(METADATA_EDITABLE_STATUSES).not.toContain(status)
+    }
+  })
+
   it('documents claim-token invalidation on retry', () => {
     // enqueue clears claimToken; complete/fail require matching token + processing.
     expect(ENQUEUE_ALLOWED_STATUSES).toContain('processing')
@@ -59,6 +72,7 @@ describe('video tools status transition policy', () => {
       ...READY_ALLOWED_STATUSES,
       ...CLIP_LOCKED_STATUSES,
       ...ENQUEUE_ALLOWED_STATUSES,
+      ...METADATA_EDITABLE_STATUSES,
       'queued', // claim target
       'complete', // completeVideoUploadSet terminal
     ])

--- a/app/lib/video-tools/mutations.ts
+++ b/app/lib/video-tools/mutations.ts
@@ -515,13 +515,11 @@ export async function recordUploadedClip(input: {
   // second decrement in the upload webhook catch handler.
   await releasePendingClipUpload(input.setId)
 
-  // When the last in-flight upload finishes and auto-enqueue is on, queue merge.
-  // Safe mid-batch only if the client reserved all slots upfront (preReserved).
-  try {
-    await maybeAutoEnqueueVideoUploadSet(input.setId)
-  } catch {
-    // best-effort; upload registration itself succeeded
-  }
+  // Auto-enqueue is triggered by the client after a fully successful upload
+  // batch (or when enabling the checkbox with pending already at zero). Do not
+  // enqueue here — a mid-batch webhook completion must not start merge early,
+  // and a successful first batch should not block a planned second batch until
+  // the operator finishes uploading.
 
   return mapClip(clip)
 }

--- a/app/lib/video-tools/mutations.ts
+++ b/app/lib/video-tools/mutations.ts
@@ -49,6 +49,7 @@ function mapSet(row: typeof videoUploadSets.$inferSelect): VideoUploadSetRecord 
     mergedBlobPathname: row.mergedBlobPathname,
     outputFilename: row.outputFilename,
     pendingUploadCount: row.pendingUploadCount,
+    autoEnqueueOnReady: row.autoEnqueueOnReady,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   }
@@ -134,6 +135,13 @@ export const UPLOAD_TOKEN_ALLOWED_STATUSES = [
 ] as const
 /** ready = normal; failed/processing = operator retry for stuck or failed merges. */
 export const ENQUEUE_ALLOWED_STATUSES = ['ready', 'failed', 'processing'] as const
+/** Metadata editable while collecting clips / after failure (not mid-merge). */
+export const METADATA_EDITABLE_STATUSES = [
+  'draft',
+  'uploading',
+  'ready',
+  'failed',
+] as const
 
 function isUniquePathnameError(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false
@@ -184,6 +192,186 @@ async function releasePendingClipUpload(setId: string): Promise<void> {
 /** Public release for abandoned / failed client uploads after a token was minted. */
 export async function cancelPendingClipUpload(setId: string): Promise<void> {
   await releasePendingClipUpload(setId)
+}
+
+/**
+ * Reserve N in-flight upload slots before a multi-file batch so pending count
+ * does not briefly hit 0 between sequential files (which would false-trigger
+ * auto-enqueue). Pair with clientPayload.preReserved on each Blob upload.
+ */
+export async function reservePendingClipUploads(
+  setId: string,
+  count: number
+): Promise<VideoUploadSetRecord> {
+  const n = Math.floor(count)
+  if (!Number.isFinite(n) || n < 1) {
+    throw new Error('count must be a positive integer')
+  }
+  if (n > 200) {
+    throw new Error('count is too large')
+  }
+
+  const db = getDb()
+  const [updated] = await db
+    .update(videoUploadSets)
+    .set({
+      pendingUploadCount: sql`${videoUploadSets.pendingUploadCount} + ${n}`,
+      status: 'uploading',
+      updatedAt: new Date(),
+      errorMessage: null,
+    })
+    .where(
+      and(
+        eq(videoUploadSets.id, setId),
+        inArray(videoUploadSets.status, [...UPLOAD_TOKEN_ALLOWED_STATUSES])
+      )
+    )
+    .returning()
+
+  if (!updated) {
+    throw new Error('Cannot upload clips in the current set status')
+  }
+  return mapSet(updated)
+}
+
+export async function updateVideoUploadSetMetadata(
+  setId: string,
+  input: {
+    eventName: string
+    label: string
+    eventDate: string
+  }
+): Promise<VideoUploadSetDetail> {
+  const eventName = input.eventName.trim()
+  const label = input.label.trim()
+  if (!eventName) throw new Error('eventName is required')
+  if (!label) throw new Error('label is required')
+  const eventDate = parseEventDate(input.eventDate)
+
+  const db = getDb()
+  const [set] = await db
+    .select()
+    .from(videoUploadSets)
+    .where(eq(videoUploadSets.id, setId))
+    .limit(1)
+  if (!set) throw new Error('Upload set not found')
+  if (!(METADATA_EDITABLE_STATUSES as readonly string[]).includes(set.status)) {
+    throw new Error(`Cannot edit metadata while set is ${set.status}`)
+  }
+
+  const outputFilename = buildUntrimmedOutputFilename({
+    eventName,
+    eventDate,
+    label,
+  })
+
+  const [updated] = await db
+    .update(videoUploadSets)
+    .set({
+      eventName,
+      label,
+      eventDate,
+      outputFilename,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(videoUploadSets.id, setId),
+        inArray(videoUploadSets.status, [...METADATA_EDITABLE_STATUSES])
+      )
+    )
+    .returning()
+
+  if (!updated) {
+    throw new Error('Upload set status changed; cannot edit metadata')
+  }
+
+  const clips = await listClipsForSet(setId)
+  const mapped = mapSet(updated)
+  return {
+    ...mapped,
+    displayTitle: displayTitle(mapped.eventName, mapped.label),
+    clips,
+  }
+}
+
+export async function setAutoEnqueueOnReady(
+  setId: string,
+  autoEnqueueOnReady: boolean
+): Promise<VideoUploadSetRecord> {
+  const db = getDb()
+  const [set] = await db
+    .select()
+    .from(videoUploadSets)
+    .where(eq(videoUploadSets.id, setId))
+    .limit(1)
+  if (!set) throw new Error('Upload set not found')
+  if (!(METADATA_EDITABLE_STATUSES as readonly string[]).includes(set.status)) {
+    throw new Error(`Cannot change auto-enqueue while set is ${set.status}`)
+  }
+
+  const [updated] = await db
+    .update(videoUploadSets)
+    .set({
+      autoEnqueueOnReady: Boolean(autoEnqueueOnReady),
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(videoUploadSets.id, setId),
+        inArray(videoUploadSets.status, [...METADATA_EDITABLE_STATUSES])
+      )
+    )
+    .returning()
+
+  if (!updated) {
+    throw new Error('Upload set status changed; cannot update auto-enqueue')
+  }
+  return mapSet(updated)
+}
+
+/**
+ * If auto_enqueue_on_ready is set, pending uploads are done, and clips exist,
+ * mark ready then enqueue. Safe / idempotent when already queued or conditions
+ * are not met (returns current set without throwing).
+ */
+export async function maybeAutoEnqueueVideoUploadSet(
+  setId: string
+): Promise<VideoUploadSetRecord | null> {
+  const db = getDb()
+  const [set] = await db
+    .select()
+    .from(videoUploadSets)
+    .where(eq(videoUploadSets.id, setId))
+    .limit(1)
+  if (!set) return null
+  if (!set.autoEnqueueOnReady) return mapSet(set)
+  if (set.pendingUploadCount > 0) return mapSet(set)
+  if (['queued', 'processing', 'complete'].includes(set.status)) {
+    return mapSet(set)
+  }
+
+  const clips = await listClipsForSet(setId)
+  if (clips.length === 0) return mapSet(set)
+
+  try {
+    if ((READY_ALLOWED_STATUSES as readonly string[]).includes(set.status)) {
+      await markSetReady(setId)
+    }
+    return await enqueueVideoUploadSet(setId)
+  } catch (err) {
+    // Race with manual enqueue or status change — leave set as-is.
+    console.warn(
+      '[video-tools] maybeAutoEnqueue skipped:',
+      err instanceof Error ? err.message : err
+    )
+    const [latest] = await db
+      .select()
+      .from(videoUploadSets)
+      .where(eq(videoUploadSets.id, setId))
+      .limit(1)
+    return latest ? mapSet(latest) : null
+  }
 }
 
 /** Operator recovery when pending_upload_count is stuck after abandoned uploads. */
@@ -326,6 +514,14 @@ export async function recordUploadedClip(input: {
   // Release after status writes so a later throw doesn't leave us needing a
   // second decrement in the upload webhook catch handler.
   await releasePendingClipUpload(input.setId)
+
+  // When the last in-flight upload finishes and auto-enqueue is on, queue merge.
+  // Safe mid-batch only if the client reserved all slots upfront (preReserved).
+  try {
+    await maybeAutoEnqueueVideoUploadSet(input.setId)
+  } catch {
+    // best-effort; upload registration itself succeeded
+  }
 
   return mapClip(clip)
 }
@@ -577,7 +773,10 @@ export async function completeVideoUploadSet(input: {
   if (!updated) {
     throw new Error('Set not found, not processing, or stale claim token')
   }
-  return mapSet(updated)
+
+  const mapped = mapSet(updated)
+  void notifyVideoSetTerminal(mapped, 'complete')
+  return mapped
 }
 
 export async function failVideoUploadSet(input: {
@@ -605,7 +804,11 @@ export async function failVideoUploadSet(input: {
     )
     .returning()
 
-  if (updated) return mapSet(updated)
+  if (updated) {
+    const mapped = mapSet(updated)
+    void notifyVideoSetTerminal(mapped, 'failed')
+    return mapped
+  }
 
   const [existing] = await db
     .select()
@@ -626,6 +829,61 @@ export async function failVideoUploadSet(input: {
     throw new Error('Stale claim token')
   }
   throw new Error(`Set not found or not processing (status: ${existing.status})`)
+}
+
+async function notifyVideoSetTerminal(
+  set: VideoUploadSetRecord,
+  outcome: 'complete' | 'failed'
+): Promise<void> {
+  const title =
+    set.eventName && set.label
+      ? `${displayTitle(set.eventName, set.label)}`
+      : 'Video upload set'
+  const href = `/video-tools/${set.id}`
+  const notifTitle =
+    outcome === 'complete' ? 'Video merge complete' : 'Video merge failed'
+  const notifBody =
+    outcome === 'complete'
+      ? `${title} is ready to download.`
+      : `${title} failed${set.errorMessage ? `: ${set.errorMessage}` : '.'}`
+
+  try {
+    const { createAdminNotification } = await import(
+      '@/app/lib/admin-notifications'
+    )
+    await createAdminNotification({
+      recipientEmail: set.createdByEmail,
+      title: notifTitle,
+      body: notifBody,
+      href,
+    })
+  } catch (err) {
+    console.error(
+      '[video-tools] failed to create admin notification',
+      err instanceof Error ? err.message : err
+    )
+  }
+
+  try {
+    const { sendNotifyEmail } = await import('@/app/lib/notify-email')
+    const baseUrl =
+      process.env.NEXT_PUBLIC_APP_URL?.trim() ||
+      process.env.VERCEL_PROJECT_PRODUCTION_URL?.trim() ||
+      (process.env.VERCEL_URL?.trim()
+        ? `https://${process.env.VERCEL_URL.trim()}`
+        : '')
+    const link = baseUrl ? `${baseUrl.replace(/\/$/, '')}${href}` : href
+    await sendNotifyEmail({
+      to: set.createdByEmail,
+      subject: notifTitle,
+      text: `${notifBody}\n\nOpen: ${link}`,
+    })
+  } catch (err) {
+    console.error(
+      '[video-tools] failed to send notify email',
+      err instanceof Error ? err.message : err
+    )
+  }
 }
 
 export async function updateVideoUploadSetStatus(

--- a/app/lib/video-tools/queries.ts
+++ b/app/lib/video-tools/queries.ts
@@ -22,6 +22,7 @@ function mapSet(row: typeof videoUploadSets.$inferSelect): VideoUploadSetRecord 
     mergedBlobPathname: row.mergedBlobPathname,
     outputFilename: row.outputFilename,
     pendingUploadCount: row.pendingUploadCount,
+    autoEnqueueOnReady: row.autoEnqueueOnReady,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   }

--- a/app/lib/video-tools/types.ts
+++ b/app/lib/video-tools/types.ts
@@ -38,8 +38,19 @@ export type VideoUploadSetRecord = {
   mergedBlobPathname: string | null
   outputFilename: string | null
   pendingUploadCount: number
+  autoEnqueueOnReady: boolean
   createdAt: Date
   updatedAt: Date
+}
+
+export type AdminNotificationRecord = {
+  id: string
+  recipientEmail: string
+  title: string
+  body: string
+  href: string | null
+  readAt: Date | null
+  createdAt: Date
 }
 
 export type VideoUploadSetListItem = VideoUploadSetRecord & {

--- a/app/video-tools/[id]/page.tsx
+++ b/app/video-tools/[id]/page.tsx
@@ -40,6 +40,8 @@ function statusBadgeClass(status: string): string {
   }
 }
 
+const METADATA_EDITABLE = new Set(['draft', 'uploading', 'ready', 'failed'])
+
 export default function VideoUploadSetDetailPage() {
   return (
     <Suspense
@@ -62,17 +64,30 @@ function VideoUploadSetDetailContent() {
   const [actionError, setActionError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const [uploads, setUploads] = useState<UploadProgress[]>([])
+  const [eventName, setEventName] = useState('')
+  const [label, setLabel] = useState('')
+  const [eventDate, setEventDate] = useState('')
+  const [savingMeta, setSavingMeta] = useState(false)
+  const [metaSaved, setMetaSaved] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const uploadingRef = useRef(false)
+  const metaDirtyRef = useRef(false)
 
-  const loadSet = useCallback(async () => {
+  const loadSet = useCallback(async (opts?: { syncForm?: boolean }) => {
     try {
       const res = await fetch(`/api/video-tools/sets/${setId}`)
       const data = await res.json()
       if (!res.ok) throw new Error(data.error || 'Failed to load set')
-      setSet(data.set)
+      const next = data.set as VideoUploadSetDetail
+      setSet(next)
+      if (opts?.syncForm !== false && !metaDirtyRef.current) {
+        setEventName(next.eventName)
+        setLabel(next.label)
+        setEventDate(next.eventDate)
+      }
       setError(null)
-      return data.set as VideoUploadSetDetail
+      return next
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load set')
       return null
@@ -82,7 +97,7 @@ function VideoUploadSetDetailContent() {
   }, [setId])
 
   useEffect(() => {
-    void loadSet()
+    void loadSet({ syncForm: true })
   }, [loadSet])
 
   useEffect(() => {
@@ -98,16 +113,40 @@ function VideoUploadSetDetailContent() {
     }
   }, [set?.status, loadSet, set])
 
+  useEffect(() => {
+    function onBeforeUnload(e: BeforeUnloadEvent) {
+      if (!uploadingRef.current) return
+      e.preventDefault()
+      e.returnValue = ''
+    }
+    window.addEventListener('beforeunload', onBeforeUnload)
+    return () => window.removeEventListener('beforeunload', onBeforeUnload)
+  }, [])
+
   const canUpload =
     set != null &&
     !['queued', 'processing', 'complete'].includes(set.status) &&
     !busy
 
+  const canEditMetadata =
+    set != null && METADATA_EDITABLE.has(set.status)
+
   const canStartOrRetryMerge =
     set != null &&
     set.clips.length > 0 &&
     ['ready', 'failed', 'processing'].includes(set.status) &&
-    !busy
+    !busy &&
+    !set.autoEnqueueOnReady
+
+  const metaDirty =
+    set != null &&
+    (eventName.trim() !== set.eventName ||
+      label.trim() !== set.label ||
+      eventDate !== set.eventDate)
+
+  useEffect(() => {
+    metaDirtyRef.current = metaDirty
+  }, [metaDirty])
 
   async function uploadFiles(files: FileList | File[]) {
     if (!set || !canUpload) return
@@ -120,6 +159,7 @@ function VideoUploadSetDetailContent() {
     }
 
     setBusy(true)
+    uploadingRef.current = true
     setActionError(null)
     setUploads(
       list.map((f) => ({
@@ -129,7 +169,23 @@ function VideoUploadSetDetailContent() {
       }))
     )
 
+    let reserved = false
     try {
+      const reserveRes = await fetch(
+        `/api/video-tools/sets/${set.id}/reserve-uploads`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ count: list.length }),
+        }
+      )
+      const reserveData = await reserveRes.json()
+      if (!reserveRes.ok) {
+        throw new Error(reserveData.error || 'Failed to reserve upload slots')
+      }
+      reserved = true
+      if (reserveData.set) setSet(reserveData.set)
+
       for (let i = 0; i < list.length; i++) {
         const file = list[i]
         const pathname = clipBlobPathname(set.id, file.name)
@@ -143,6 +199,7 @@ function VideoUploadSetDetailContent() {
             clientPayload: JSON.stringify({
               setId: set.id,
               originalFilename: file.name,
+              preReserved: true,
             }),
             onUploadProgress: (event) => {
               tokenMinted = true
@@ -189,9 +246,8 @@ function VideoUploadSetDetailContent() {
               idx === i ? { ...u, status: 'error', error: message } : u
             )
           )
-          // Best-effort: clear this slot if a token was minted. Safe at floor 0;
-          // operators can also use Clear stuck uploads if a count remains.
-          if (tokenMinted) {
+          // Best-effort: clear this slot if a token was minted or reserved.
+          if (tokenMinted || reserved) {
             try {
               const cancelRes = await fetch(
                 `/api/video-tools/sets/${set.id}/cancel-upload`,
@@ -207,10 +263,94 @@ function VideoUploadSetDetailContent() {
           }
         }
       }
+
+      // Client fallback: if auto-enqueue is on, ensure merge starts after the batch.
+      const after = await loadSet()
+      if (after?.autoEnqueueOnReady) {
+        try {
+          const autoRes = await fetch(`/api/video-tools/sets/${setId}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ action: 'maybe_auto_enqueue' }),
+          })
+          const autoData = await autoRes.json()
+          if (autoRes.ok && autoData.set) setSet(autoData.set)
+        } catch {
+          // best-effort
+        }
+      }
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Upload failed')
+      if (reserved) {
+        // Release any leftover reserved slots from a failed batch start.
+        try {
+          await fetch(`/api/video-tools/sets/${set.id}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ action: 'reset_pending_uploads' }),
+          })
+        } catch {
+          // best-effort
+        }
+      }
       await loadSet()
     } finally {
       setBusy(false)
+      uploadingRef.current = false
       if (fileInputRef.current) fileInputRef.current.value = ''
+    }
+  }
+
+  async function saveMetadata(e: React.FormEvent) {
+    e.preventDefault()
+    if (!canEditMetadata) return
+    setSavingMeta(true)
+    setActionError(null)
+    setMetaSaved(false)
+    try {
+      const res = await fetch(`/api/video-tools/sets/${setId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'update_metadata',
+          eventName,
+          label,
+          eventDate,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to save details')
+      setSet(data.set)
+      setEventName(data.set.eventName)
+      setLabel(data.set.label)
+      setEventDate(data.set.eventDate)
+      setMetaSaved(true)
+      metaDirtyRef.current = false
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to save details')
+    } finally {
+      setSavingMeta(false)
+    }
+  }
+
+  async function toggleAutoEnqueue(next: boolean) {
+    setActionError(null)
+    try {
+      const res = await fetch(`/api/video-tools/sets/${setId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'set_auto_enqueue',
+          autoEnqueueOnReady: next,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to update auto-start')
+      setSet(data.set)
+    } catch (err) {
+      setActionError(
+        err instanceof Error ? err.message : 'Failed to update auto-start'
+      )
     }
   }
 
@@ -258,7 +398,6 @@ function VideoUploadSetDetailContent() {
     setBusy(true)
     setActionError(null)
     try {
-      // Merge only from ready/failed/processing — require Mark ready after uploads finish.
       const res = await fetch(`/api/video-tools/sets/${setId}/enqueue`, {
         method: 'POST',
       })
@@ -357,17 +496,122 @@ function VideoUploadSetDetailContent() {
       {(set.status === 'queued' || set.status === 'processing') && (
         <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950">
           {set.status === 'queued'
-            ? 'Queued for the merge worker…'
-            : 'Worker is merging clips (this can take a while for large sets). If this seems stuck, use Retry merge to re-queue.'}
+            ? 'Queued for the merge worker. You can leave this page — you will get an in-app notification when it finishes.'
+            : 'Worker is merging clips (this can take a while for large sets). Safe to leave; you will be notified when it finishes or fails. If this seems stuck, turn off auto-start and use Retry merge.'}
         </div>
+      )}
+
+      {canEditMetadata && (
+        <section className="mt-8">
+          <h2 className="text-lg font-medium text-gray-900">Set details</h2>
+          <p className="mt-1 text-sm text-gray-600">
+            You can edit these while clips are uploading.
+          </p>
+          <form
+            onSubmit={(e) => void saveMetadata(e)}
+            className="mt-4 grid gap-4 sm:grid-cols-2"
+          >
+            <div className="sm:col-span-2">
+              <label
+                htmlFor="eventName"
+                className="block text-sm font-medium text-gray-800"
+              >
+                Event name
+              </label>
+              <input
+                id="eventName"
+                type="text"
+                required
+                value={eventName}
+                onChange={(e) => {
+                  setEventName(e.target.value)
+                  setMetaSaved(false)
+                }}
+                className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-600 focus:outline-none focus:ring-1 focus:ring-blue-600"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="label"
+                className="block text-sm font-medium text-gray-800"
+              >
+                Label (court / session)
+              </label>
+              <input
+                id="label"
+                type="text"
+                required
+                value={label}
+                onChange={(e) => {
+                  setLabel(e.target.value)
+                  setMetaSaved(false)
+                }}
+                className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-600 focus:outline-none focus:ring-1 focus:ring-blue-600"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="eventDate"
+                className="block text-sm font-medium text-gray-800"
+              >
+                Event date
+              </label>
+              <input
+                id="eventDate"
+                type="date"
+                required
+                value={eventDate}
+                onChange={(e) => {
+                  setEventDate(e.target.value)
+                  setMetaSaved(false)
+                }}
+                className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-600 focus:outline-none focus:ring-1 focus:ring-blue-600"
+              />
+            </div>
+            <div className="sm:col-span-2 flex flex-wrap items-center gap-3">
+              <button
+                type="submit"
+                disabled={savingMeta || !metaDirty}
+                className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-800 hover:bg-gray-50 disabled:opacity-60"
+              >
+                {savingMeta ? 'Saving…' : 'Save details'}
+              </button>
+              {metaSaved && !metaDirty && (
+                <span className="text-sm text-green-700">Saved</span>
+              )}
+            </div>
+          </form>
+
+          <label className="mt-6 flex items-start gap-3 text-sm text-gray-800">
+            <input
+              type="checkbox"
+              className="mt-0.5 rounded border-gray-300"
+              checked={set.autoEnqueueOnReady}
+              onChange={(e) => void toggleAutoEnqueue(e.target.checked)}
+              disabled={busy && uploads.some((u) => u.status === 'uploading')}
+            />
+            <span>
+              <span className="font-medium">
+                When uploads finish, start merge automatically
+              </span>
+              <span className="mt-0.5 block text-gray-600">
+                Keep this tab open until uploads finish. After that you can leave —
+                merge runs in the background and you will get a notification.
+              </span>
+            </span>
+          </label>
+        </section>
       )}
 
       <section className="mt-8">
         <h2 className="text-lg font-medium text-gray-900">Clips</h2>
         <p className="mt-1 text-sm text-gray-600">
-          Drop GoPro MP4s here. When all uploads are finished, click Mark ready,
-          then Start merge. Order is applied automatically (GoPro session +
-          chapter rules) when you start the merge.
+          Drop GoPro MP4s here
+          {set.autoEnqueueOnReady
+            ? '. With auto-start on, merge begins when the last upload finishes.'
+            : '. When all uploads are finished, click Mark ready, then Start merge.'}{' '}
+          Order is applied automatically (GoPro session + chapter rules) when
+          merge starts. Keep this tab open while files transfer.
         </p>
 
         {canUpload && (
@@ -469,18 +713,21 @@ function VideoUploadSetDetailContent() {
       </section>
 
       <div className="mt-8 flex flex-wrap gap-3">
-        {canUpload && set.clips.length > 0 && set.status !== 'ready' && (
-          <button
-            type="button"
-            onClick={() => void markReady()}
-            disabled={busy || set.pendingUploadCount > 0}
-            className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-800 hover:bg-gray-50 disabled:opacity-60"
-          >
-            {set.pendingUploadCount > 0
-              ? `Mark ready (${set.pendingUploadCount} uploading…)`
-              : 'Mark ready'}
-          </button>
-        )}
+        {canUpload &&
+          set.clips.length > 0 &&
+          set.status !== 'ready' &&
+          !set.autoEnqueueOnReady && (
+            <button
+              type="button"
+              onClick={() => void markReady()}
+              disabled={busy || set.pendingUploadCount > 0}
+              className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-800 hover:bg-gray-50 disabled:opacity-60"
+            >
+              {set.pendingUploadCount > 0
+                ? `Mark ready (${set.pendingUploadCount} uploading…)`
+                : 'Mark ready'}
+            </button>
+          )}
         {set.pendingUploadCount > 0 &&
           !['queued', 'processing', 'complete'].includes(set.status) && (
             <button
@@ -493,15 +740,26 @@ function VideoUploadSetDetailContent() {
             </button>
           )}
         {canStartOrRetryMerge && (
+          <button
+            type="button"
+            onClick={() => void startMerge()}
+            disabled={busy}
+            className="rounded-md bg-blue-700 px-4 py-2 text-sm font-medium text-white hover:bg-blue-800 disabled:opacity-60"
+          >
+            {set.status === 'failed' || set.status === 'processing'
+              ? 'Retry merge'
+              : 'Start merge'}
+          </button>
+        )}
+        {set.autoEnqueueOnReady &&
+          (set.status === 'failed' || set.status === 'processing') &&
+          !busy && (
             <button
               type="button"
               onClick={() => void startMerge()}
-              disabled={busy}
               className="rounded-md bg-blue-700 px-4 py-2 text-sm font-medium text-white hover:bg-blue-800 disabled:opacity-60"
             >
-              {set.status === 'failed' || set.status === 'processing'
-                ? 'Retry merge'
-                : 'Start merge'}
+              Retry merge
             </button>
           )}
       </div>

--- a/app/video-tools/[id]/page.tsx
+++ b/app/video-tools/[id]/page.tsx
@@ -135,8 +135,7 @@ function VideoUploadSetDetailContent() {
     set != null &&
     set.clips.length > 0 &&
     ['ready', 'failed', 'processing'].includes(set.status) &&
-    !busy &&
-    !set.autoEnqueueOnReady
+    !busy
 
   const metaDirty =
     set != null &&
@@ -170,6 +169,7 @@ function VideoUploadSetDetailContent() {
     )
 
     let reserved = false
+    let batchHadError = false
     try {
       const reserveRes = await fetch(
         `/api/video-tools/sets/${set.id}/reserve-uploads`,
@@ -190,7 +190,8 @@ function VideoUploadSetDetailContent() {
         const file = list[i]
         const pathname = clipBlobPathname(set.id, file.name)
 
-        let tokenMinted = false
+        let uploadCompleted = false
+        let registered = false
         try {
           const blob = await upload(pathname, file, {
             access: 'public',
@@ -202,7 +203,6 @@ function VideoUploadSetDetailContent() {
               preReserved: true,
             }),
             onUploadProgress: (event) => {
-              tokenMinted = true
               setUploads((prev) =>
                 prev.map((u, idx) =>
                   idx === i
@@ -212,7 +212,7 @@ function VideoUploadSetDetailContent() {
               )
             },
           })
-          tokenMinted = true
+          uploadCompleted = true
 
           setUploads((prev) =>
             prev.map((u, idx) =>
@@ -232,6 +232,7 @@ function VideoUploadSetDetailContent() {
           })
           const regData = await reg.json()
           if (!reg.ok) throw new Error(regData.error || 'Failed to register clip')
+          registered = true
 
           setUploads((prev) =>
             prev.map((u, idx) =>
@@ -240,14 +241,17 @@ function VideoUploadSetDetailContent() {
           )
           if (regData.set) setSet(regData.set)
         } catch (err) {
+          batchHadError = true
           const message = err instanceof Error ? err.message : 'Upload failed'
           setUploads((prev) =>
             prev.map((u, idx) =>
               idx === i ? { ...u, status: 'error', error: message } : u
             )
           )
-          // Best-effort: clear this slot if a token was minted or reserved.
-          if (tokenMinted || reserved) {
+          // Only release the reserved slot if Blob upload never finished.
+          // Once upload completes, client register and/or the Blob webhook own
+          // the pending decrement — cancel here would double-release.
+          if (!registered && !uploadCompleted && reserved) {
             try {
               const cancelRes = await fetch(
                 `/api/video-tools/sets/${set.id}/cancel-upload`,
@@ -264,9 +268,10 @@ function VideoUploadSetDetailContent() {
         }
       }
 
-      // Client fallback: if auto-enqueue is on, ensure merge starts after the batch.
+      // Only auto-enqueue after a fully successful batch so partial failures
+      // cannot start merge with an incomplete clip set.
       const after = await loadSet()
-      if (after?.autoEnqueueOnReady) {
+      if (after?.autoEnqueueOnReady && !batchHadError) {
         try {
           const autoRes = await fetch(`/api/video-tools/sets/${setId}`, {
             method: 'PATCH',
@@ -278,6 +283,10 @@ function VideoUploadSetDetailContent() {
         } catch {
           // best-effort
         }
+      } else if (batchHadError && after?.autoEnqueueOnReady) {
+        setActionError(
+          'Some uploads failed. Fix or re-upload those clips before merge starts automatically, or use Start merge when ready.'
+        )
       }
     } catch (err) {
       setActionError(err instanceof Error ? err.message : 'Upload failed')
@@ -595,8 +604,11 @@ function VideoUploadSetDetailContent() {
                 When uploads finish, start merge automatically
               </span>
               <span className="mt-0.5 block text-gray-600">
-                Keep this tab open until uploads finish. After that you can leave —
-                merge runs in the background and you will get a notification.
+                Upload all clips in one batch (or turn this on after every clip is
+                uploaded). Keep this tab open until transfers finish. After that
+                you can leave — merge runs in the background and you will get a
+                notification. Start merge stays available if auto-start does not
+                fire.
               </span>
             </span>
           </label>
@@ -608,7 +620,7 @@ function VideoUploadSetDetailContent() {
         <p className="mt-1 text-sm text-gray-600">
           Drop GoPro MP4s here
           {set.autoEnqueueOnReady
-            ? '. With auto-start on, merge begins when the last upload finishes.'
+            ? '. With auto-start on, merge begins after a fully successful upload batch — add every clip before that batch finishes, or enable auto-start after all clips are up.'
             : '. When all uploads are finished, click Mark ready, then Start merge.'}{' '}
           Order is applied automatically (GoPro session + chapter rules) when
           merge starts. Keep this tab open while files transfer.
@@ -751,17 +763,6 @@ function VideoUploadSetDetailContent() {
               : 'Start merge'}
           </button>
         )}
-        {set.autoEnqueueOnReady &&
-          (set.status === 'failed' || set.status === 'processing') &&
-          !busy && (
-            <button
-              type="button"
-              onClick={() => void startMerge()}
-              className="rounded-md bg-blue-700 px-4 py-2 text-sm font-medium text-white hover:bg-blue-800 disabled:opacity-60"
-            >
-              Retry merge
-            </button>
-          )}
       </div>
     </div>
   )

--- a/app/video-tools/page.tsx
+++ b/app/video-tools/page.tsx
@@ -59,8 +59,8 @@ function VideoToolsPageContent() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  const loadSets = useCallback(async () => {
-    setLoading(true)
+  const loadSets = useCallback(async (opts?: { quiet?: boolean }) => {
+    if (!opts?.quiet) setLoading(true)
     setError(null)
     try {
       const res = await fetch('/api/video-tools/sets')
@@ -70,13 +70,24 @@ function VideoToolsPageContent() {
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load upload sets')
     } finally {
-      setLoading(false)
+      if (!opts?.quiet) setLoading(false)
     }
   }, [])
 
   useEffect(() => {
     void loadSets()
   }, [loadSets])
+
+  useEffect(() => {
+    const hasActive = sets.some((s) =>
+      ['uploading', 'queued', 'processing'].includes(s.status)
+    )
+    if (!hasActive) return
+    const id = setInterval(() => {
+      void loadSets({ quiet: true })
+    }, 8000)
+    return () => clearInterval(id)
+  }, [sets, loadSets])
 
   return (
     <div className="mx-auto max-w-5xl p-6">
@@ -85,7 +96,8 @@ function VideoToolsPageContent() {
           <h1 className="text-2xl font-semibold text-gray-900">Video Tools</h1>
           <p className="mt-1 text-sm text-gray-600">
             Upload GoPro clips per court or session, then merge into one untrimmed
-            video. Multiple sets can run at the same time.
+            video. Turn on auto-start merge to set-and-forget after uploads; you
+            will get an in-app notification when merge finishes.
           </p>
         </div>
         <Link

--- a/drizzle/0019_video_tools_set_and_forget.sql
+++ b/drizzle/0019_video_tools_set_and_forget.sql
@@ -1,0 +1,15 @@
+ALTER TABLE "video_upload_sets" ADD COLUMN IF NOT EXISTS "auto_enqueue_on_ready" boolean DEFAULT false NOT NULL;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "admin_notifications" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"recipient_email" text NOT NULL,
+	"title" text NOT NULL,
+	"body" text NOT NULL,
+	"href" text,
+	"read_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "admin_notifications_recipient_email_idx" ON "admin_notifications" USING btree ("recipient_email");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "admin_notifications_created_at_idx" ON "admin_notifications" USING btree ("created_at");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1753815600000,
       "tag": "0018_video_tools_pending_uploads",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1753833600000,
+      "tag": "0019_video_tools_set_and_forget",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Lets operators start long GoPro uploads and walk away after transfers finish—without babysitting Mark ready / Start merge.

**Base:** `preview` (feature PRs do not target `main`).

### What changed
- **Edit metadata while uploading** — event name, label, and date are editable on the set detail page during `draft` / `uploading` / `ready` / `failed`
- **Auto-start merge** — checkbox “When uploads finish, start merge automatically.” Batch uploads reserve pending slots upfront; auto-enqueue runs only after a **fully successful** client batch (or when enabling the checkbox with pending already at zero)
- **In-app notifications** — nav **Alerts** panel (30s poll); merge complete/fail notifies the set creator with a link back to the set
- **Optional email** — if `RESEND_API_KEY` + `NOTIFY_FROM_EMAIL` are set, also emails on complete/fail
- **UX** — `beforeunload` while uploads are in progress; clearer copy that the tab must stay open during transfer; list page polls while sets are active

### Bugbot follow-ups addressed
- Do not auto-enqueue after a partial batch failure
- Do not cancel pending after Blob upload completes (avoids double-decrement with webhook)
- Keep **Start merge** available when auto-start is on
- Remove server-side enqueue on clip register so a first batch cannot block a planned second upload

### Honest limit
Closing the browser tab still aborts in-flight Blob uploads. After enqueue, merge remains backgrounded on Fly as before.

### Migration
`drizzle/0019_video_tools_set_and_forget.sql` adds `auto_enqueue_on_ready` and `admin_notifications`.

### Optional env
- `RESEND_API_KEY`
- `NOTIFY_FROM_EMAIL`
- `NEXT_PUBLIC_APP_URL` (absolute links in email)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5cec5be5-3c55-4786-994b-e4321e854d4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5cec5be5-3c55-4786-994b-e4321e854d4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

