### PR TITLE
Show unregistered local players for event outreach

### DIFF
--- a/app/api/players/__tests__/route-params.test.ts
+++ b/app/api/players/__tests__/route-params.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { parseListPlayersSearchParams } from '@/app/api/players/route'
+
+describe('parseListPlayersSearchParams', () => {
+  it('defaults eventMatch to registered when eventId is present', () => {
+    const opts = parseListPlayersSearchParams(
+      new URLSearchParams({
+        eventId: '11111111-1111-4111-8111-111111111111',
+      })
+    )
+    expect(opts.eventId).toBe('11111111-1111-4111-8111-111111111111')
+    expect(opts.eventMatch).toBe('registered')
+    expect(opts.homeLeagues).toBeNull()
+  })
+
+  it('parses eventMatch=not_registered', () => {
+    const opts = parseListPlayersSearchParams(
+      new URLSearchParams({
+        eventId: '11111111-1111-4111-8111-111111111111',
+        eventMatch: 'not_registered',
+      })
+    )
+    expect(opts.eventMatch).toBe('not_registered')
+  })
+
+  it('ignores invalid eventId values', () => {
+    const opts = parseListPlayersSearchParams(
+      new URLSearchParams({ eventId: 'not-a-uuid', eventMatch: 'not_registered' })
+    )
+    expect(opts.eventId).toBeNull()
+    expect(opts.eventMatch).toBe('not_registered')
+  })
+
+  it('parses comma-separated homeLeagues and drops invalid codes', () => {
+    const opts = parseListPlayersSearchParams(
+      new URLSearchParams({
+        homeLeagues:
+          'boston_dodgeball_league,nutmeg_dodgeball,not_a_league,philly_dodgeball',
+      })
+    )
+    expect(opts.homeLeagues).toEqual([
+      'boston_dodgeball_league',
+      'nutmeg_dodgeball',
+      'philly_dodgeball',
+    ])
+  })
+
+  it('keeps singular homeLeague alongside multi homeLeagues', () => {
+    const opts = parseListPlayersSearchParams(
+      new URLSearchParams({
+        homeLeague: 'unset',
+        homeLeagues: 'boston_dodgeball_league',
+      })
+    )
+    expect(opts.homeLeague).toBe('unset')
+    expect(opts.homeLeagues).toEqual(['boston_dodgeball_league'])
+  })
+
+  it('returns empty homeLeagues array when all codes are invalid', () => {
+    const opts = parseListPlayersSearchParams(
+      new URLSearchParams({ homeLeagues: 'nope,also_nope' })
+    )
+    expect(opts.homeLeagues).toEqual([])
+  })
+})

--- a/app/api/players/route.ts
+++ b/app/api/players/route.ts
@@ -3,63 +3,10 @@ import {
   adminUnauthorizedResponse,
   getAdminSessionFromRequest,
 } from '@/app/lib/admin-auth'
-import { listPlayers, type EventMatch } from '@/app/lib/players/queries'
+import { listPlayers } from '@/app/lib/players/queries'
+import { parseListPlayersSearchParams } from '@/app/lib/players/list-params'
 import { createPlayer } from '@/app/lib/players/mutations'
-import { isValidSkillLevel } from '@/app/lib/players/skill'
 import { isValidGender } from '@/app/lib/players/gender'
-import { isValidHomeLeague } from '@/app/lib/players/home-league'
-
-/** Parse list-players query params (exported for tests). */
-export function parseListPlayersSearchParams(searchParams: URLSearchParams): {
-  q?: string
-  skill: number | 'unset' | null
-  homeLeague: string | 'unset' | null
-  homeLeagues: string[] | null
-  eventId: string | null
-  eventMatch: EventMatch
-  includeMerged: boolean
-} {
-  const q = searchParams.get('q') ?? undefined
-  const skillParam = searchParams.get('skill')
-  const homeLeagueParam = searchParams.get('homeLeague')
-  const homeLeaguesParam = searchParams.get('homeLeagues')
-  const eventIdParam = searchParams.get('eventId')
-  const eventMatchParam = searchParams.get('eventMatch')
-  const includeMerged = searchParams.get('includeMerged') === '1'
-
-  let skill: number | 'unset' | null = null
-  if (skillParam === 'unset') skill = 'unset'
-  else if (skillParam) {
-    const n = Number(skillParam)
-    if (isValidSkillLevel(n)) skill = n
-  }
-
-  let homeLeague: string | 'unset' | null = null
-  if (homeLeagueParam === 'unset') homeLeague = 'unset'
-  else if (homeLeagueParam && isValidHomeLeague(homeLeagueParam)) {
-    homeLeague = homeLeagueParam
-  }
-
-  const homeLeagues = homeLeaguesParam
-    ? homeLeaguesParam
-        .split(',')
-        .map((s) => s.trim())
-        .filter(isValidHomeLeague)
-    : null
-
-  const eventId =
-    eventIdParam &&
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-      eventIdParam
-    )
-      ? eventIdParam
-      : null
-
-  const eventMatch: EventMatch =
-    eventMatchParam === 'not_registered' ? 'not_registered' : 'registered'
-
-  return { q, skill, homeLeague, homeLeagues, eventId, eventMatch, includeMerged }
-}
 
 export async function GET(request: NextRequest) {
   const session = getAdminSessionFromRequest(request)

--- a/app/api/players/route.ts
+++ b/app/api/players/route.ts
@@ -3,46 +3,71 @@ import {
   adminUnauthorizedResponse,
   getAdminSessionFromRequest,
 } from '@/app/lib/admin-auth'
-import { listPlayers } from '@/app/lib/players/queries'
+import { listPlayers, type EventMatch } from '@/app/lib/players/queries'
 import { createPlayer } from '@/app/lib/players/mutations'
 import { isValidSkillLevel } from '@/app/lib/players/skill'
 import { isValidGender } from '@/app/lib/players/gender'
 import { isValidHomeLeague } from '@/app/lib/players/home-league'
+
+/** Parse list-players query params (exported for tests). */
+export function parseListPlayersSearchParams(searchParams: URLSearchParams): {
+  q?: string
+  skill: number | 'unset' | null
+  homeLeague: string | 'unset' | null
+  homeLeagues: string[] | null
+  eventId: string | null
+  eventMatch: EventMatch
+  includeMerged: boolean
+} {
+  const q = searchParams.get('q') ?? undefined
+  const skillParam = searchParams.get('skill')
+  const homeLeagueParam = searchParams.get('homeLeague')
+  const homeLeaguesParam = searchParams.get('homeLeagues')
+  const eventIdParam = searchParams.get('eventId')
+  const eventMatchParam = searchParams.get('eventMatch')
+  const includeMerged = searchParams.get('includeMerged') === '1'
+
+  let skill: number | 'unset' | null = null
+  if (skillParam === 'unset') skill = 'unset'
+  else if (skillParam) {
+    const n = Number(skillParam)
+    if (isValidSkillLevel(n)) skill = n
+  }
+
+  let homeLeague: string | 'unset' | null = null
+  if (homeLeagueParam === 'unset') homeLeague = 'unset'
+  else if (homeLeagueParam && isValidHomeLeague(homeLeagueParam)) {
+    homeLeague = homeLeagueParam
+  }
+
+  const homeLeagues = homeLeaguesParam
+    ? homeLeaguesParam
+        .split(',')
+        .map((s) => s.trim())
+        .filter(isValidHomeLeague)
+    : null
+
+  const eventId =
+    eventIdParam &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      eventIdParam
+    )
+      ? eventIdParam
+      : null
+
+  const eventMatch: EventMatch =
+    eventMatchParam === 'not_registered' ? 'not_registered' : 'registered'
+
+  return { q, skill, homeLeague, homeLeagues, eventId, eventMatch, includeMerged }
+}
 
 export async function GET(request: NextRequest) {
   const session = getAdminSessionFromRequest(request)
   if (!session) return adminUnauthorizedResponse()
 
   try {
-    const { searchParams } = request.nextUrl
-    const q = searchParams.get('q') ?? undefined
-    const skillParam = searchParams.get('skill')
-    const homeLeagueParam = searchParams.get('homeLeague')
-    const eventIdParam = searchParams.get('eventId')
-    const includeMerged = searchParams.get('includeMerged') === '1'
-
-    let skill: number | 'unset' | null = null
-    if (skillParam === 'unset') skill = 'unset'
-    else if (skillParam) {
-      const n = Number(skillParam)
-      if (isValidSkillLevel(n)) skill = n
-    }
-
-    let homeLeague: string | 'unset' | null = null
-    if (homeLeagueParam === 'unset') homeLeague = 'unset'
-    else if (homeLeagueParam && isValidHomeLeague(homeLeagueParam)) {
-      homeLeague = homeLeagueParam
-    }
-
-    const eventId =
-      eventIdParam &&
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-        eventIdParam
-      )
-        ? eventIdParam
-        : null
-
-    const players = await listPlayers({ q, skill, homeLeague, eventId, includeMerged })
+    const opts = parseListPlayersSearchParams(request.nextUrl.searchParams)
+    const players = await listPlayers(opts)
     return NextResponse.json({ players })
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Failed to list players'

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -26,12 +26,18 @@ import type {
 } from '@/app/lib/events/types'
 import { genderGroup } from '@/app/lib/players/gender'
 import {
+  HOME_LEAGUES,
+  HOME_LEAGUE_CODES,
+  type HomeLeague,
+} from '@/app/lib/players/home-league'
+import {
   effectiveSkillLabel,
   effectiveSkillScore,
   skillMatrixBucketKey,
   skillMatrixColLabel,
   skillMatrixColumns,
 } from '@/app/lib/players/skill'
+import type { PlayerListItem } from '@/app/lib/players/types'
 import { SkillStyledText } from '@/app/components/SkillStyledText'
 import {
   SkillViewModeToggle,
@@ -39,6 +45,8 @@ import {
 } from '@/app/hooks/useSkillViewMode'
 import { Dialog, FieldHelp, LiveMessage, Tooltip } from '@/app/components/ui'
 import { ContactPlayersDialog } from '@/app/components/contact/ContactPlayersDialog'
+
+const DEFAULT_REACH_OUT_LEAGUE: HomeLeague = 'boston_dodgeball_league'
 
 const FOCUS_RING =
   'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600'
@@ -175,6 +183,17 @@ function EventTrackerPageContent() {
   const [teamNamesSaving, setTeamNamesSaving] = useState(false)
   const [teamsActionBusy, setTeamsActionBusy] = useState(false)
 
+  const [reachOutLeagues, setReachOutLeagues] = useState<HomeLeague[]>([
+    DEFAULT_REACH_OUT_LEAGUE,
+  ])
+  const [reachOutIncludeOthers, setReachOutIncludeOthers] = useState(false)
+  const [reachOutPlayers, setReachOutPlayers] = useState<PlayerListItem[]>([])
+  const [reachOutLoading, setReachOutLoading] = useState(false)
+  const [reachOutError, setReachOutError] = useState<string | null>(null)
+  const [reachOutCopyMessage, setReachOutCopyMessage] = useState<string | null>(
+    null
+  )
+
   const load = useCallback(async () => {
     if (!eventId) return
     setLoading(true)
@@ -216,6 +235,64 @@ function EventTrackerPageContent() {
   useEffect(() => {
     void load()
   }, [load])
+
+  const loadReachOut = useCallback(async () => {
+    if (!eventId || reachOutLeagues.length === 0) {
+      setReachOutPlayers([])
+      return
+    }
+    setReachOutLoading(true)
+    setReachOutError(null)
+    try {
+      const params = new URLSearchParams({
+        eventId,
+        eventMatch: 'not_registered',
+        homeLeagues: reachOutLeagues.join(','),
+      })
+      const res = await fetch(`/api/players?${params}`)
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to load prospects')
+      setReachOutPlayers(data.players as PlayerListItem[])
+    } catch (err) {
+      setReachOutError(
+        err instanceof Error ? err.message : 'Failed to load prospects'
+      )
+    } finally {
+      setReachOutLoading(false)
+    }
+  }, [eventId, reachOutLeagues])
+
+  useEffect(() => {
+    void loadReachOut()
+  }, [loadReachOut, registrations.length])
+
+  function toggleReachOutLeague(code: HomeLeague) {
+    setReachOutLeagues((prev) => {
+      if (prev.includes(code)) {
+        const next = prev.filter((c) => c !== code)
+        return next.length > 0 ? next : [DEFAULT_REACH_OUT_LEAGUE]
+      }
+      return [...prev, code]
+    })
+  }
+
+  async function copyReachOutEmails() {
+    const emails = reachOutPlayers
+      .map((p) => p.primaryEmail)
+      .filter((e): e is string => Boolean(e?.trim()))
+    if (emails.length === 0) {
+      setReachOutCopyMessage('No emails to copy')
+      return
+    }
+    try {
+      await navigator.clipboard.writeText(emails.join(', '))
+      setReachOutCopyMessage(
+        `Copied ${emails.length} email${emails.length === 1 ? '' : 's'}`
+      )
+    } catch {
+      setReachOutCopyMessage('Could not copy to clipboard')
+    }
+  }
 
   const hasExistingGroups = useMemo(
     () => registrations.some((r) => r.draftGroup != null),
@@ -1591,6 +1668,181 @@ function EventTrackerPageContent() {
             </table>
           </div>
         </>
+      ) : null}
+
+      {draftPhase !== 'board' ? (
+        <section className="rounded-lg border border-gray-200 bg-white p-4 space-y-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">Reach out</h2>
+              <FieldHelp>
+                Players with selected home leagues who are not registered for this
+                event.
+              </FieldHelp>
+              {!reachOutLoading && !reachOutError ? (
+                <p className="mt-1 text-sm text-gray-600">
+                  {reachOutPlayers.length} not registered
+                </p>
+              ) : null}
+            </div>
+            <button
+              type="button"
+              className={`rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800 hover:bg-gray-50 disabled:opacity-40 ${FOCUS_RING}`}
+              disabled={reachOutLoading || reachOutPlayers.length === 0}
+              onClick={() => void copyReachOutEmails()}
+            >
+              Copy emails
+            </button>
+          </div>
+
+          <div className="space-y-2">
+            <label className="flex items-center gap-2 text-sm text-gray-800">
+              <input
+                type="checkbox"
+                checked={reachOutIncludeOthers}
+                onChange={(e) => {
+                  const checked = e.target.checked
+                  setReachOutIncludeOthers(checked)
+                  if (!checked) {
+                    setReachOutLeagues([DEFAULT_REACH_OUT_LEAGUE])
+                  }
+                }}
+              />
+              Include other home leagues
+            </label>
+            {reachOutIncludeOthers ? (
+              <div className="rounded border border-gray-200 bg-gray-50 p-3 space-y-2">
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    className={`rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-800 hover:bg-gray-50 ${FOCUS_RING}`}
+                    onClick={() => setReachOutLeagues([...HOME_LEAGUE_CODES])}
+                  >
+                    All leagues
+                  </button>
+                  <button
+                    type="button"
+                    className={`rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-800 hover:bg-gray-50 ${FOCUS_RING}`}
+                    onClick={() => setReachOutLeagues([DEFAULT_REACH_OUT_LEAGUE])}
+                  >
+                    BDL only
+                  </button>
+                </div>
+                <div className="grid gap-1 sm:grid-cols-2">
+                  {HOME_LEAGUE_CODES.map((code) => (
+                    <label
+                      key={code}
+                      className="flex items-center gap-2 text-sm text-gray-800"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={reachOutLeagues.includes(code)}
+                        onChange={() => toggleReachOutLeague(code)}
+                      />
+                      {HOME_LEAGUES[code]}
+                    </label>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </div>
+
+          {reachOutCopyMessage ? (
+            <LiveMessage variant="status" className="text-sm text-green-700">
+              {reachOutCopyMessage}
+            </LiveMessage>
+          ) : null}
+          {reachOutError ? (
+            <LiveMessage variant="alert" className="text-sm text-red-600">
+              {reachOutError}
+            </LiveMessage>
+          ) : null}
+
+          <div className="overflow-x-auto rounded border border-gray-200">
+            <table className="min-w-full text-sm">
+              <caption className="sr-only">
+                Unregistered local players for outreach
+              </caption>
+              <thead className="bg-gray-50 text-left">
+                <tr>
+                  <th scope="col" className="px-3 py-2 font-medium">
+                    Name
+                  </th>
+                  <th scope="col" className="px-3 py-2 font-medium">
+                    Skill
+                  </th>
+                  <th scope="col" className="px-3 py-2 font-medium">
+                    Gender
+                  </th>
+                  <th scope="col" className="px-3 py-2 font-medium">
+                    Email
+                  </th>
+                  <th scope="col" className="px-3 py-2 font-medium">
+                    Home leagues
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {reachOutLoading ? (
+                  <tr>
+                    <td
+                      colSpan={5}
+                      className="px-3 py-6 text-center text-gray-500"
+                    >
+                      Loading…
+                    </td>
+                  </tr>
+                ) : reachOutPlayers.length === 0 ? (
+                  <tr>
+                    <td
+                      colSpan={5}
+                      className="px-3 py-6 text-center text-gray-500"
+                    >
+                      No matching players to reach out to.
+                    </td>
+                  </tr>
+                ) : (
+                  reachOutPlayers.map((p) => {
+                    const label =
+                      p.nickname || `${p.firstName} ${p.lastName}`
+                    return (
+                      <tr
+                        key={p.id}
+                        className={`border-t border-gray-100 ${genderRowClass(p.gender)}`}
+                      >
+                        <td className="px-3 py-2">
+                          <SkillStyledText
+                            score={effectiveSkillScore(p, skillViewMode)}
+                            mode={skillViewMode}
+                          >
+                            {label}
+                          </SkillStyledText>
+                          <div className="text-xs text-gray-500">
+                            {p.firstName} {p.lastName}
+                          </div>
+                        </td>
+                        <td className="px-3 py-2">
+                          {effectiveSkillScore(p, skillViewMode) != null
+                            ? effectiveSkillLabel(p, skillViewMode)
+                            : '—'}
+                        </td>
+                        <td className="px-3 py-2">{p.genderGroupLabel}</td>
+                        <td className="px-3 py-2 text-xs">
+                          {p.primaryEmail ?? '—'}
+                        </td>
+                        <td className="px-3 py-2 text-xs text-gray-700">
+                          {p.homeLeagues.length > 0
+                            ? p.homeLeagues.map((h) => h.label).join(', ')
+                            : '—'}
+                        </td>
+                      </tr>
+                    )
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
       ) : null}
 
       <Dialog

--- a/app/lib/players/__tests__/list-params.test.ts
+++ b/app/lib/players/__tests__/list-params.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { parseListPlayersSearchParams } from '@/app/api/players/route'
+import { parseListPlayersSearchParams } from '@/app/lib/players/list-params'
 
 describe('parseListPlayersSearchParams', () => {
   it('defaults eventMatch to registered when eventId is present', () => {

--- a/app/lib/players/list-params.ts
+++ b/app/lib/players/list-params.ts
@@ -1,0 +1,55 @@
+import { isValidSkillLevel } from '@/app/lib/players/skill'
+import { isValidHomeLeague } from '@/app/lib/players/home-league'
+import type { EventMatch } from '@/app/lib/players/queries'
+
+/** Parse list-players query params (kept out of the route module for Next.js route typing). */
+export function parseListPlayersSearchParams(searchParams: URLSearchParams): {
+  q?: string
+  skill: number | 'unset' | null
+  homeLeague: string | 'unset' | null
+  homeLeagues: string[] | null
+  eventId: string | null
+  eventMatch: EventMatch
+  includeMerged: boolean
+} {
+  const q = searchParams.get('q') ?? undefined
+  const skillParam = searchParams.get('skill')
+  const homeLeagueParam = searchParams.get('homeLeague')
+  const homeLeaguesParam = searchParams.get('homeLeagues')
+  const eventIdParam = searchParams.get('eventId')
+  const eventMatchParam = searchParams.get('eventMatch')
+  const includeMerged = searchParams.get('includeMerged') === '1'
+
+  let skill: number | 'unset' | null = null
+  if (skillParam === 'unset') skill = 'unset'
+  else if (skillParam) {
+    const n = Number(skillParam)
+    if (isValidSkillLevel(n)) skill = n
+  }
+
+  let homeLeague: string | 'unset' | null = null
+  if (homeLeagueParam === 'unset') homeLeague = 'unset'
+  else if (homeLeagueParam && isValidHomeLeague(homeLeagueParam)) {
+    homeLeague = homeLeagueParam
+  }
+
+  const homeLeagues = homeLeaguesParam
+    ? homeLeaguesParam
+        .split(',')
+        .map((s) => s.trim())
+        .filter(isValidHomeLeague)
+    : null
+
+  const eventId =
+    eventIdParam &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      eventIdParam
+    )
+      ? eventIdParam
+      : null
+
+  const eventMatch: EventMatch =
+    eventMatchParam === 'not_registered' ? 'not_registered' : 'registered'
+
+  return { q, skill, homeLeague, homeLeagues, eventId, eventMatch, includeMerged }
+}

--- a/app/lib/players/queries.ts
+++ b/app/lib/players/queries.ts
@@ -19,11 +19,17 @@ import { genderGroupLabel, genderLabel } from '@/app/lib/players/gender'
 import { homeLeagueLabel, homeLeagueLogoUrl, isValidHomeLeague } from '@/app/lib/players/home-league'
 import type { PlayerListItem, PlayerSnapshot } from '@/app/lib/players/types'
 
+export type EventMatch = 'registered' | 'not_registered'
+
 export async function listPlayers(opts: {
   q?: string
   skill?: number | 'unset' | null
   homeLeague?: string | 'unset' | null
+  /** When set (non-empty), OR-match any of these home leagues (overrides singular homeLeague). */
+  homeLeagues?: string[] | null
   eventId?: string | null
+  /** Defaults to `registered` when `eventId` is set. */
+  eventMatch?: EventMatch
   includeMerged?: boolean
 }): Promise<PlayerListItem[]> {
   const db = getDb()
@@ -39,7 +45,14 @@ export async function listPlayers(opts: {
     conditions.push(eq(players.skillLevel, opts.skill))
   }
 
-  if (opts.homeLeague === 'unset') {
+  const multiHomeLeagues = (opts.homeLeagues ?? []).filter(isValidHomeLeague)
+  if (multiHomeLeagues.length > 0) {
+    const matchingHomeLeagueIds = db
+      .select({ playerId: playerHomeLeagues.playerId })
+      .from(playerHomeLeagues)
+      .where(inArray(playerHomeLeagues.homeLeague, multiHomeLeagues))
+    conditions.push(inArray(players.id, matchingHomeLeagueIds))
+  } else if (opts.homeLeague === 'unset') {
     const playersWithHomeLeague = db
       .select({ playerId: playerHomeLeagues.playerId })
       .from(playerHomeLeagues)
@@ -57,7 +70,11 @@ export async function listPlayers(opts: {
       .select({ playerId: eventRegistrations.playerId })
       .from(eventRegistrations)
       .where(eq(eventRegistrations.eventId, opts.eventId))
-    conditions.push(inArray(players.id, registeredIds))
+    if (opts.eventMatch === 'not_registered') {
+      conditions.push(notInArray(players.id, registeredIds))
+    } else {
+      conditions.push(inArray(players.id, registeredIds))
+    }
   }
 
   if (opts.q?.trim()) {

--- a/app/players/__tests__/page.test.tsx
+++ b/app/players/__tests__/page.test.tsx
@@ -555,6 +555,23 @@ describe('PlayersPage tournament filters and columns', () => {
       ).toBe(true)
     })
 
+    const statusSelect = screen.getByLabelText(
+      'Filter by event registration status'
+    )
+    expect(statusSelect).toHaveValue('registered')
+    await userEvent.selectOptions(statusSelect, 'not_registered')
+
+    await waitFor(() => {
+      const urls = fetchMock.mock.calls.map((call) => String(call[0]))
+      expect(
+        urls.some(
+          (url) =>
+            url.includes('eventId=11111111-1111-4111-8111-111111111111') &&
+            url.includes('eventMatch=not_registered')
+        )
+      ).toBe(true)
+    })
+
     await userEvent.selectOptions(screen.getByLabelText('Filter by home league'), 'unset')
 
     await waitFor(() => {

--- a/app/players/page.tsx
+++ b/app/players/page.tsx
@@ -402,6 +402,9 @@ export default function PlayersPage() {
   const [skillFilter, setSkillFilter] = useState('')
   const [homeLeagueFilter, setHomeLeagueFilter] = useState<'' | 'unset' | HomeLeague>('')
   const [eventFilter, setEventFilter] = useState('')
+  const [eventMatch, setEventMatch] = useState<'registered' | 'not_registered'>(
+    'registered'
+  )
   const [events, setEvents] = useState<EventListItem[]>([])
   const [eventsStatus, setEventsStatus] = useState<'idle' | 'loading' | 'loaded' | 'error'>(
     'idle'
@@ -516,7 +519,12 @@ export default function PlayersPage() {
       if (q.trim()) params.set('q', q.trim())
       if (skillFilter) params.set('skill', skillFilter)
       if (homeLeagueFilter) params.set('homeLeague', homeLeagueFilter)
-      if (eventFilter) params.set('eventId', eventFilter)
+      if (eventFilter) {
+        params.set('eventId', eventFilter)
+        if (eventMatch === 'not_registered') {
+          params.set('eventMatch', 'not_registered')
+        }
+      }
       if (includeMerged) params.set('includeMerged', '1')
       const res = await fetch(`/api/players?${params}`)
       const data = await res.json()
@@ -527,7 +535,7 @@ export default function PlayersPage() {
     } finally {
       setLoading(false)
     }
-  }, [q, skillFilter, homeLeagueFilter, eventFilter, includeMerged])
+  }, [q, skillFilter, homeLeagueFilter, eventFilter, eventMatch, includeMerged])
 
   useEffect(() => {
     void loadPlayers()
@@ -1180,7 +1188,10 @@ export default function PlayersPage() {
             aria-label="Filter by event"
             value={eventFilter}
             onFocus={() => void loadEvents()}
-            onChange={(e) => setEventFilter(e.target.value)}
+            onChange={(e) => {
+              setEventFilter(e.target.value)
+              if (!e.target.value) setEventMatch('registered')
+            }}
             className="rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 max-w-[16rem]"
           >
             <option value="">All events</option>
@@ -1201,6 +1212,26 @@ export default function PlayersPage() {
             ))}
           </select>
         </label>
+        {eventFilter ? (
+          <label className="text-sm text-gray-900">
+            <span className="block text-gray-600 mb-1">Event status</span>
+            <select
+              aria-label="Filter by event registration status"
+              value={eventMatch}
+              onChange={(e) =>
+                setEventMatch(
+                  e.target.value === 'not_registered'
+                    ? 'not_registered'
+                    : 'registered'
+                )
+              }
+              className="rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900"
+            >
+              <option value="registered">Registered</option>
+              <option value="not_registered">Not registered</option>
+            </select>
+          </label>
+        ) : null}
         <label className="text-sm text-gray-900">
           <span className="block text-gray-600 mb-1">Home league</span>
           <select


### PR DESCRIPTION
## Summary
- Extend players list API/query with `eventMatch=not_registered` and multi `homeLeagues` filtering
- Add event detail **Reach out** section (default BDL locals not on the roster; optional other home leagues + copy emails)
- Add Registered / Not registered mode on the Players directory event filter

## Test plan
- [ ] Open an event with some registrations and confirm **Reach out** lists BDL players who are not registered
- [ ] Toggle **Include other home leagues** / All leagues and confirm the list updates
- [ ] **Copy emails** puts primary emails on the clipboard
- [ ] On `/players`, select an event → **Not registered** (+ home league) and confirm results match
- [ ] Event filter **Registered** still behaves as before
- [ ] `npm run test:run -- app/api/players/__tests__/route-params.test.ts app/players/__tests__/page.test.tsx`


Made with [Cursor](https://cursor.com)