### PR TITLE
Add authenticated Playwright e2e against admin-preview

### DIFF
--- a/.github/workflows/e2e-preview.yml
+++ b/.github/workflows/e2e-preview.yml
@@ -1,0 +1,50 @@
+name: Preview e2e
+
+# Authenticated Playwright against admin-preview (minted admin_session cookie).
+# Requires GitHub secrets ADMIN_SESSION_SECRET + E2E_ADMIN_EMAIL matching Vercel Preview.
+# See bdl-packages/admin-auth/AGENTS.md.
+
+on:
+  push:
+    branches: [preview]
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-preview:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      PLAYWRIGHT_BASE_URL: https://admin-preview.bostondodgeballleague.com
+      ADMIN_SESSION_SECRET: ${{ secrets.ADMIN_SESSION_SECRET }}
+      E2E_ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+      - run: npm ci
+      - name: Require preview e2e secrets
+        run: |
+          if [ -z "$ADMIN_SESSION_SECRET" ] || [ -z "$E2E_ADMIN_EMAIL" ]; then
+            echo "::error::Set GitHub Actions secrets ADMIN_SESSION_SECRET and E2E_ADMIN_EMAIL (must match Vercel Preview)."
+            exit 1
+          fi
+      - name: Wait for stable preview
+        run: node scripts/smoke-preview.mjs --wait
+      - uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+      - run: npm run test:e2e:preview

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# BDL League Admin — agent notes
+
+## Preview Playwright auth
+
+Authenticated e2e against **stable preview** must mint the `admin_session` cookie — do **not** automate Google login or rely on local `getDevBypassAdminSession` (that only applies when `NODE_ENV=development`).
+
+- Stable host: `https://admin-preview.bostondodgeballleague.com`
+- Run: `npm run test:e2e:preview` (config: `playwright.preview.config.ts`)
+- Helper: `e2e/helpers/admin-session.ts`
+- CI: `.github/workflows/e2e-preview.yml` on push to `preview` (secrets: `ADMIN_SESSION_SECRET`, `E2E_ADMIN_EMAIL`)
+- Auth env / OAuth redirect URIs: [`.cursor/players-and-auth-runbook.md`](.cursor/players-and-auth-runbook.md)
+- Full per-repo checklist: [`bdl-packages/admin-auth/AGENTS.md`](https://github.com/jsartin513/bdl-packages/blob/main/admin-auth/AGENTS.md)
+
+HTTP **preview smoke** (`npm run smoke:preview`) still checks unauthenticated redirects; Playwright covers authenticated gated routes.

--- a/e2e/admin-preview.spec.ts
+++ b/e2e/admin-preview.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test';
+import { applyAdminSession, requirePreviewAdminCredentials } from './helpers/admin-session';
+
+test.describe('league admin on stable preview', () => {
+  test.beforeEach(async ({ context }) => {
+    const creds = requirePreviewAdminCredentials();
+    const baseUrl = test.info().project.use.baseURL;
+    if (!baseUrl) throw new Error('PLAYWRIGHT_BASE_URL / baseURL is required');
+    await applyAdminSession(context, baseUrl, creds.email, creds.secret);
+  });
+
+  test('session api accepts minted cookie', async ({ context }) => {
+    const creds = requirePreviewAdminCredentials();
+    const response = await context.request.get('/api/admin/session');
+    expect(response.ok()).toBeTruthy();
+    const body = (await response.json()) as { authenticated?: boolean; email?: string };
+    expect(body.authenticated).toBe(true);
+    expect(body.email?.toLowerCase()).toBe(creds.email.toLowerCase());
+  });
+
+  test('players page loads without login redirect', async ({ page }) => {
+    await page.goto('/players');
+    await expect(page).toHaveURL(/\/players/);
+    await expect(page.getByRole('heading', { name: 'Players' })).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.getByRole('link', { name: 'Sign in with Google' })).toHaveCount(0);
+  });
+});

--- a/e2e/helpers/admin-session.ts
+++ b/e2e/helpers/admin-session.ts
@@ -1,0 +1,58 @@
+import { createHmac } from 'node:crypto';
+import type { BrowserContext } from '@playwright/test';
+
+const ADMIN_SESSION_COOKIE = 'admin_session';
+
+export function createAdminSessionToken(email: string, secret: string): string {
+  const payload = {
+    email: email.toLowerCase(),
+    exp: Math.floor(Date.now() / 1000) + 60 * 60 * 12,
+  };
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const signature = createHmac('sha256', secret).update(encodedPayload).digest('base64url');
+  return `${encodedPayload}.${signature}`;
+}
+
+export async function applyAdminSession(
+  context: BrowserContext,
+  baseUrl: string,
+  email: string,
+  secret: string
+): Promise<boolean> {
+  const token = createAdminSessionToken(email, secret);
+  const { hostname, protocol } = new URL(baseUrl);
+
+  await context.addCookies([
+    {
+      name: ADMIN_SESSION_COOKIE,
+      value: token,
+      domain: hostname,
+      path: '/',
+      httpOnly: true,
+      secure: protocol === 'https:',
+      sameSite: 'Lax',
+    },
+  ]);
+
+  return true;
+}
+
+export function getDemoAdminCredentials(): { email: string; secret: string } | null {
+  const secret = process.env.ADMIN_SESSION_SECRET?.trim() ?? process.env.DEMO_ADMIN_SESSION_SECRET?.trim();
+  const email =
+    process.env.E2E_ADMIN_EMAIL?.trim() ??
+    process.env.DEMO_ADMIN_EMAIL?.trim() ??
+    process.env.ADMIN_DEMO_EMAIL?.trim();
+  if (!secret || !email) return null;
+  return { email, secret };
+}
+
+export function requirePreviewAdminCredentials(): { email: string; secret: string } {
+  const creds = getDemoAdminCredentials();
+  if (!creds) {
+    throw new Error(
+      'Set ADMIN_SESSION_SECRET and E2E_ADMIN_EMAIL (must match Vercel Preview) for preview e2e.'
+    );
+  }
+  return creds;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@playwright/test": "^1.62.1",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.1",
@@ -2528,6 +2529,22 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
@@ -7936,6 +7953,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "smoke:preview": "node scripts/smoke-preview.mjs",
+    "test:e2e:preview": "playwright test --config=playwright.preview.config.ts",
     "worker:video-merge": "node workers/video-merge/index.mjs"
   },
   "engines": {
@@ -41,6 +42,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.62.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",

--- a/playwright.preview.config.ts
+++ b/playwright.preview.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL =
+  process.env.PLAYWRIGHT_BASE_URL?.replace(/\/$/, '') ||
+  'https://admin-preview.bostondodgeballleague.com';
+
+/**
+ * Authenticated e2e against the stable preview host.
+ * Mint admin_session via e2e/helpers/admin-session.ts — do not automate Google.
+ * See bdl-packages/admin-auth/AGENTS.md.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: '**/admin-preview.spec.ts',
+  fullyParallel: true,
+  reporter: 'list',
+  timeout: 60_000,
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});


### PR DESCRIPTION
## Summary
- Add Playwright preview config/spec that mints admin_session (no Google automation)
- CI waits for smoke health then runs test:e2e:preview

## Test plan
- [ ] Confirm GitHub secrets `ADMIN_SESSION_SECRET` and `E2E_ADMIN_EMAIL` are set
- [ ] Confirm Vercel Preview `ADMIN_SESSION_SECRET` / `ADMIN_ALLOWED_EMAILS` include the e2e email
- [ ] After merge to `preview`, run **Preview e2e** workflow (or wait for push trigger)
- [ ] Open a gated admin URL in the Playwright run and confirm no Google redirect


Made with [Cursor](https://cursor.com)