### PR TITLE
Alert on watched admin login attempts

### DIFF
--- a/app/api/admin/google/callback/route.ts
+++ b/app/api/admin/google/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import {
+  alertWatchedAdminLoginAttempt,
   clearAdminOAuthStateCookie,
   isAllowedAdminEmail,
   readAdminOAuthState,
@@ -78,7 +79,9 @@ export async function GET(request: NextRequest) {
     return adminErrorRedirect(request, 'invalid_google_identity')
   }
 
-  if (!isAllowedAdminEmail(email)) {
+  const allowed = isAllowedAdminEmail(email)
+  void alertWatchedAdminLoginAttempt(email, { app: 'bdl-admin', allowed })
+  if (!allowed) {
     return adminErrorRedirect(request, 'email_not_allowed')
   }
 

--- a/app/lib/admin-auth.ts
+++ b/app/lib/admin-auth.ts
@@ -221,6 +221,92 @@ export function isAllowedAdminEmail(email: string): boolean {
   return whitelist.has(email.toLowerCase())
 }
 
+const DEFAULT_LOGIN_WATCH_EMAILS = ['lburleson@gmail.com']
+const DEFAULT_LOGIN_ALERT_TO = 'jdoherty513@gmail.com'
+
+function adminLoginWatchEmails(): Set<string> {
+  const raw = process.env.ADMIN_LOGIN_WATCH_EMAILS?.trim()
+  const list = raw
+    ? raw
+        .split(',')
+        .map((item) => item.trim().toLowerCase())
+        .filter(Boolean)
+    : DEFAULT_LOGIN_WATCH_EMAILS
+  return new Set(list)
+}
+
+export function isWatchedAdminLoginEmail(email: string): boolean {
+  return adminLoginWatchEmails().has(email.trim().toLowerCase())
+}
+
+function adminLoginAlertFrom(): string | null {
+  const from =
+    process.env.ADMIN_LOGIN_ALERT_FROM?.trim() ||
+    process.env.NOTIFY_FROM_EMAIL?.trim() ||
+    process.env.ORDER_RECEIPT_FROM?.trim() ||
+    process.env.CONTACT_EMAIL_FROM?.trim()
+  return from || null
+}
+
+/** Log + email (Resend) when a watched address hits Google admin login. */
+export async function alertWatchedAdminLoginAttempt(
+  email: string,
+  details: { app: string; allowed: boolean }
+): Promise<void> {
+  const normalized = email.trim().toLowerCase()
+  if (!isWatchedAdminLoginEmail(normalized)) return
+
+  const to = process.env.ADMIN_LOGIN_ALERT_TO?.trim() || DEFAULT_LOGIN_ALERT_TO
+  const host = process.env.NEXT_PUBLIC_APP_URL?.trim() || details.app
+  const subject = `[BDL Admin] Login attempt by ${normalized}`
+  const text = [
+    'Watched admin login attempt',
+    `Email: ${normalized}`,
+    `App: ${details.app}`,
+    `Host: ${host}`,
+    `Allowed: ${details.allowed}`,
+    `Time: ${new Date().toISOString()}`,
+    `VERCEL_ENV: ${process.env.VERCEL_ENV ?? 'unknown'}`,
+  ].join('\n')
+
+  console.error('[admin-auth] WATCHED_LOGIN_ATTEMPT', {
+    email: normalized,
+    app: details.app,
+    allowed: details.allowed,
+    alertTo: to,
+  })
+
+  const apiKey = process.env.RESEND_API_KEY?.trim()
+  const from = adminLoginAlertFrom()
+  if (!apiKey || !from) {
+    console.error(
+      '[admin-auth] WATCHED_LOGIN_ATTEMPT email skipped (RESEND_API_KEY or from address not configured)'
+    )
+    return
+  }
+
+  try {
+    const res = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ from, to: [to], subject, text }),
+    })
+    if (!res.ok) {
+      const body = await res.text().catch(() => '')
+      console.error(
+        '[admin-auth] WATCHED_LOGIN_ATTEMPT email failed',
+        res.status,
+        body.slice(0, 300)
+      )
+    }
+  } catch (err) {
+    console.error('[admin-auth] WATCHED_LOGIN_ATTEMPT email error', err)
+  }
+}
+
 export function adminUnauthorizedResponse() {
   return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 }


### PR DESCRIPTION
## Summary
- When `lburleson@gmail.com` completes Google admin OAuth, log `WATCHED_LOGIN_ATTEMPT` and email `jdoherty513@gmail.com` via Resend (when configured).
- Still denies access if the email is not on `ADMIN_ALLOWED_EMAILS`.
- Overrides available via `ADMIN_LOGIN_WATCH_EMAILS`, `ADMIN_LOGIN_ALERT_TO`, and `ADMIN_LOGIN_ALERT_FROM`.

## Test plan
- [ ] Confirm Vercel has `RESEND_API_KEY`, `ADMIN_LOGIN_ALERT_FROM`, and `ADMIN_LOGIN_ALERT_TO` for Production/Preview
- [ ] After deploy, attempt Google login with the watched address (or temporarily add a test address to the watch list)
- [ ] Verify email arrives at `jdoherty513@gmail.com` and runtime logs show `WATCHED_LOGIN_ATTEMPT`
- [ ] Verify allowlisted admins can still sign in normally

Made with [Cursor](https://cursor.com)