### PR TITLE
Validate admin login return paths

### DIFF
--- a/app/__tests__/admin-google-callback.test.ts
+++ b/app/__tests__/admin-google-callback.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+const adminAuth = vi.hoisted(() => ({
+  alertWatchedAdminLoginAttempt: vi.fn().mockResolvedValue(undefined),
+  clearAdminOAuthStateCookie: vi.fn(),
+  isAllowedAdminEmail: vi.fn(() => true),
+  readAdminOAuthState: vi.fn(() => 'expected-state'),
+  setAdminSessionCookie: vi.fn(() => true),
+}))
+
+vi.mock('@/app/lib/admin-auth', () => adminAuth)
+
+import { GET } from '@/app/api/admin/google/callback/route'
+
+describe('admin Google callback', () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    vi.stubEnv('ADMIN_GOOGLE_CLIENT_ID', 'google-client-id')
+    vi.stubEnv('ADMIN_GOOGLE_CLIENT_SECRET', 'google-client-secret')
+    vi.stubGlobal('fetch', fetchMock)
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ id_token: 'google-id-token' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          aud: 'google-client-id',
+          email: 'admin@example.com',
+          email_verified: 'true',
+        }),
+      })
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('keeps a decoded return-path cookie on the request origin', async () => {
+    const requestUrl =
+      'https://admin.example.com/api/admin/google/callback?state=expected-state&code=code'
+    const request = {
+      url: requestUrl,
+      nextUrl: new URL(requestUrl),
+      cookies: {
+        get: (name: string) =>
+          name === 'admin_oauth_next'
+            ? { name, value: '/\\example.com' }
+            : undefined,
+      },
+    } as unknown as NextRequest
+
+    const response = await GET(request)
+
+    expect(response.headers.get('location')).toBe(
+      'https://admin.example.com/schedules'
+    )
+  })
+})

--- a/app/__tests__/admin-login-next.test.tsx
+++ b/app/__tests__/admin-login-next.test.tsx
@@ -1,0 +1,42 @@
+import { render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const login = vi.hoisted(() => ({
+  fetchAdminSession: vi.fn(),
+  nextValue: '/\\example.com',
+  replace: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: login.replace }),
+  useSearchParams: () => ({
+    get: (key: string) => (key === 'next' ? login.nextValue : null),
+  }),
+}))
+
+vi.mock('@/app/lib/admin-client-auth', () => ({
+  fetchAdminSession: login.fetchAdminSession,
+}))
+
+import LoginPage from '@/app/login/page'
+
+describe('admin login return path', () => {
+  beforeEach(() => {
+    login.nextValue = '/\\example.com'
+    login.fetchAdminSession.mockResolvedValue({ email: 'admin@example.com' })
+    document.cookie = 'admin_oauth_next=; path=/; max-age=0'
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uses the safe fallback for the session redirect and OAuth cookie', async () => {
+    render(<LoginPage />)
+
+    await waitFor(() => {
+      expect(login.replace).toHaveBeenCalledWith('/schedules')
+      expect(document.cookie).toContain('admin_oauth_next=%2Fschedules')
+    })
+  })
+})

--- a/app/__tests__/admin-next.test.ts
+++ b/app/__tests__/admin-next.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_ADMIN_NEXT_PATH,
+  safeAdminNextPath,
+} from '@/app/lib/admin-next'
+
+describe('safeAdminNextPath', () => {
+  it.each([
+    ['/', '/'],
+    ['/players', '/players'],
+    ['/players?dev=1', '/players?dev=1'],
+    ['/events/123?tab=draft#teams', '/events/123?tab=draft#teams'],
+    ['/events/../players', '/players'],
+    ['/%2f%2fexample.com', '/%2f%2fexample.com'],
+    ['/%5cexample.com', '/%5cexample.com'],
+    ['/players/Zoë?tab=notes#bio', '/players/Zo%C3%AB?tab=notes#bio'],
+  ])('keeps app-relative destinations: %s', (value, expected) => {
+    expect(safeAdminNextPath(value)).toBe(expected)
+  })
+
+  it.each([
+    null,
+    undefined,
+    '',
+    'players',
+    'https://example.com',
+    '//example.com',
+    '//admin.invalid/path',
+    '///example.com',
+    '/\\example.com',
+    '/\\admin.invalid/path',
+    '/safe/..//example.com',
+    '/safe/%2e%2e//example.com',
+    '/.//example.com',
+    '/\t/example.com',
+    '/\r/example.com',
+    '/players\n/settings',
+    '/players\u007f/settings',
+  ])('falls back for an unsafe destination: %s', (value) => {
+    expect(safeAdminNextPath(value)).toBe(DEFAULT_ADMIN_NEXT_PATH)
+  })
+
+  it.each([
+    '/players',
+    '/players?next=//example.com',
+    '/events/../players',
+  ])('always resolves on the app origin: %s', (value) => {
+    const destination = safeAdminNextPath(value)
+    expect(new URL(destination, 'https://admin.example.com').origin).toBe(
+      'https://admin.example.com'
+    )
+  })
+})

--- a/app/api/admin/google/callback/route.ts
+++ b/app/api/admin/google/callback/route.ts
@@ -6,6 +6,7 @@ import {
   readAdminOAuthState,
   setAdminSessionCookie,
 } from '@/app/lib/admin-auth'
+import { safeAdminNextPath } from '@/app/lib/admin-next'
 
 function adminBaseUrl(request: NextRequest): URL {
   const appUrl = process.env.NEXT_PUBLIC_APP_URL?.trim()
@@ -86,10 +87,7 @@ export async function GET(request: NextRequest) {
   }
 
   const nextParam = request.cookies.get('admin_oauth_next')?.value
-  const destination =
-    nextParam && nextParam.startsWith('/') && !nextParam.startsWith('//')
-      ? nextParam
-      : '/schedules'
+  const destination = safeAdminNextPath(nextParam)
 
   const response = NextResponse.redirect(new URL(destination, request.url))
   clearAdminOAuthStateCookie(response)

--- a/app/lib/admin-next.ts
+++ b/app/lib/admin-next.ts
@@ -1,0 +1,29 @@
+export const DEFAULT_ADMIN_NEXT_PATH = '/schedules'
+
+const ADMIN_NEXT_BASE = 'https://admin.invalid'
+const UNSAFE_ADMIN_NEXT_CHARACTERS = /[\\\u0000-\u001f\u007f]/
+
+export function safeAdminNextPath(value: string | null | undefined): string {
+  if (
+    !value ||
+    !value.startsWith('/') ||
+    value.startsWith('//') ||
+    UNSAFE_ADMIN_NEXT_CHARACTERS.test(value)
+  ) {
+    return DEFAULT_ADMIN_NEXT_PATH
+  }
+
+  try {
+    const url = new URL(value, ADMIN_NEXT_BASE)
+    if (url.origin !== ADMIN_NEXT_BASE) return DEFAULT_ADMIN_NEXT_PATH
+
+    const destination = `${url.pathname}${url.search}${url.hash}`
+    if (!destination.startsWith('/') || destination.startsWith('//')) {
+      return DEFAULT_ADMIN_NEXT_PATH
+    }
+
+    return destination
+  } catch {
+    return DEFAULT_ADMIN_NEXT_PATH
+  }
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { fetchAdminSession } from '@/app/lib/admin-client-auth'
+import { safeAdminNextPath } from '@/app/lib/admin-next'
 import { LiveMessage } from '@/app/components/ui'
 
 function adminErrorMessage(error: string | null): string | null {
@@ -20,19 +21,17 @@ function LoginContent() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const errorMessage = adminErrorMessage(searchParams.get('error'))
-  const next = searchParams.get('next') || '/schedules'
+  const next = safeAdminNextPath(searchParams.get('next'))
 
   useEffect(() => {
     void fetchAdminSession().then((session) => {
-      if (session) router.replace(next.startsWith('/') ? next : '/schedules')
+      if (session) router.replace(next)
     })
   }, [router, next])
 
   useEffect(() => {
-    if (next && next.startsWith('/') && !next.startsWith('//')) {
-      const secure = location.protocol === 'https:' ? '; secure' : ''
-      document.cookie = `admin_oauth_next=${encodeURIComponent(next)}; path=/; max-age=600; samesite=lax${secure}`
-    }
+    const secure = location.protocol === 'https:' ? '; secure' : ''
+    document.cookie = `admin_oauth_next=${encodeURIComponent(next)}; path=/; max-age=600; samesite=lax${secure}`
   }, [next])
 
   const loginHref = '/api/admin/google/login'


### PR DESCRIPTION
## Base branch

- Feature / fix PR targeting `preview`.

## Summary

- preserve the existing post-login deep-link behavior for app-relative paths
- use one return-path validator in both the login page and Google OAuth callback
- fall back to `/schedules` when a destination does not stay on the app origin
- add focused coverage for normal deep links, browser-normalized edge cases, and both redirect consumers

The existing login flow preserves the page an admin was trying to reach across Google sign-in. This keeps that useful behavior intact while making same-origin handling consistent at both redirect points.

## Test plan

- [x] `npm run lint`
- [x] `npm run test:run` (256 tests)
- [x] `npm run build` with Node 20
- [ ] Confirm admin-preview deploys and `/players` + `/events` load after sign-in
- [ ] Confirm signing in with `?next=/players?dev=1` returns to that page
