### PR TITLE
Make team maker production-ready for fall leagues

### DIFF
--- a/app/__tests__/event-ball-gender.test.ts
+++ b/app/__tests__/event-ball-gender.test.ts
@@ -1,10 +1,55 @@
 import { describe, expect, it } from 'vitest'
 import {
   ballTypeLabel,
+  eventFormatLabel,
   eventGenderLabel,
+  eventTypeLabel,
   isValidBallType,
+  isValidEventFormat,
   isValidEventGender,
+  isValidEventType,
+  parseEventFormat,
 } from '@/app/lib/events/types'
+
+describe('event type', () => {
+  it('accepts tournament, league, open_gym, and other', () => {
+    expect(isValidEventType('tournament')).toBe(true)
+    expect(isValidEventType('league')).toBe(true)
+    expect(isValidEventType('open_gym')).toBe(true)
+    expect(isValidEventType('other')).toBe(true)
+    expect(isValidEventType('clinic')).toBe(false)
+  })
+
+  it('labels known values and defaults unknown to Other', () => {
+    expect(eventTypeLabel('league')).toBe('League')
+    expect(eventTypeLabel('nope')).toBe('Other')
+  })
+})
+
+describe('event format', () => {
+  it('accepts byot, remix, and draft', () => {
+    expect(isValidEventFormat('byot')).toBe(true)
+    expect(isValidEventFormat('remix')).toBe(true)
+    expect(isValidEventFormat('draft')).toBe(true)
+    expect(isValidEventFormat('hybrid')).toBe(false)
+  })
+
+  it('parses empty to null and rejects invalid', () => {
+    expect(parseEventFormat(undefined)).toBeUndefined()
+    expect(parseEventFormat(null)).toBeNull()
+    expect(parseEventFormat('')).toBeNull()
+    expect(parseEventFormat('byot')).toBe('byot')
+    expect(() => parseEventFormat('hybrid')).toThrow('Invalid eventFormat')
+  })
+
+  it('labels known values and returns null for unset', () => {
+    expect(eventFormatLabel('byot')).toBe('BYOT')
+    expect(eventFormatLabel('remix')).toBe('Remix')
+    expect(eventFormatLabel('draft')).toBe('Draft')
+    expect(eventFormatLabel(null)).toBeNull()
+    expect(eventFormatLabel('nope')).toBeNull()
+  })
+})
 
 describe('event ball type', () => {
   it('accepts foam and cloth', () => {

--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -7,9 +7,11 @@ import { deleteEvent, updateEvent } from '@/app/lib/events/mutations'
 import { getEvent } from '@/app/lib/events/queries'
 import {
   ballTypeLabel,
+  eventFormatLabel,
   eventGenderLabel,
   eventTypeLabel,
   isValidBallType,
+  isValidEventFormat,
   isValidEventGender,
   isValidEventType,
 } from '@/app/lib/events/types'
@@ -30,6 +32,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
       event: {
         ...event,
         eventTypeLabel: eventTypeLabel(event.eventType),
+        eventFormatLabel: eventFormatLabel(event.eventFormat),
         ballTypeLabel: ballTypeLabel(event.ballType),
         genderLabel: eventGenderLabel(event.gender),
       },
@@ -50,6 +53,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       name?: string
       eventDate?: string
       eventType?: string | null
+      eventFormat?: string | null
       ballType?: string | null
       gender?: string | null
       notes?: string | null
@@ -65,6 +69,13 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       !isValidEventType(body.eventType)
     ) {
       return NextResponse.json({ error: 'Invalid eventType' }, { status: 400 })
+    }
+    if (
+      body.eventFormat != null &&
+      body.eventFormat !== '' &&
+      !isValidEventFormat(body.eventFormat)
+    ) {
+      return NextResponse.json({ error: 'Invalid eventFormat' }, { status: 400 })
     }
     if (
       body.ballType != null &&
@@ -123,6 +134,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       event: {
         ...event,
         eventTypeLabel: eventTypeLabel(event.eventType),
+        eventFormatLabel: eventFormatLabel(event.eventFormat),
         ballTypeLabel: ballTypeLabel(event.ballType),
         genderLabel: eventGenderLabel(event.gender),
       },

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -7,6 +7,7 @@ import { createEvent } from '@/app/lib/events/mutations'
 import { listEvents } from '@/app/lib/events/queries'
 import {
   isValidBallType,
+  isValidEventFormat,
   isValidEventGender,
   isValidEventType,
 } from '@/app/lib/events/types'
@@ -33,6 +34,7 @@ export async function POST(request: NextRequest) {
       name?: string
       eventDate?: string
       eventType?: string | null
+      eventFormat?: string | null
       ballType?: string | null
       gender?: string | null
       notes?: string | null
@@ -50,6 +52,13 @@ export async function POST(request: NextRequest) {
       !isValidEventType(body.eventType)
     ) {
       return NextResponse.json({ error: 'Invalid eventType' }, { status: 400 })
+    }
+    if (
+      body.eventFormat != null &&
+      body.eventFormat !== '' &&
+      !isValidEventFormat(body.eventFormat)
+    ) {
+      return NextResponse.json({ error: 'Invalid eventFormat' }, { status: 400 })
     }
     if (
       body.ballType != null &&
@@ -70,6 +79,7 @@ export async function POST(request: NextRequest) {
       name: body.name,
       eventDate: body.eventDate,
       eventType: body.eventType,
+      eventFormat: body.eventFormat,
       ballType: body.ballType,
       gender: body.gender,
       notes: body.notes,

--- a/app/components/events/EventDraftBoard.tsx
+++ b/app/components/events/EventDraftBoard.tsx
@@ -136,10 +136,18 @@ function DraftPlayerCard(props: {
   dragging?: boolean
   pairingEnabled?: boolean
   showHomeLeague?: boolean
+  showFaBadge?: boolean
   captainBadge?: '(C)' | '(CC)' | null
 }) {
-  const { player, skillViewMode, dragging, pairingEnabled, showHomeLeague, captainBadge } =
-    props
+  const {
+    player,
+    skillViewMode,
+    dragging,
+    pairingEnabled,
+    showHomeLeague,
+    showFaBadge,
+    captainBadge,
+  } = props
   const league = homeLeagueText(player)
   const score = effectiveSkillScore(player, skillViewMode)
   const label = effectiveSkillLabel(player, skillViewMode)
@@ -162,6 +170,15 @@ function DraftPlayerCard(props: {
           >
             <span className="ml-1 text-[10px] font-semibold uppercase tracking-wide text-amber-800">
               Locked
+            </span>
+          </Tooltip>
+        ) : showFaBadge ? (
+          <Tooltip
+            label="Free agent"
+            content="Added to this team after signup (not an original BYOT member)."
+          >
+            <span className="ml-1 text-[10px] font-semibold uppercase tracking-wide text-emerald-800">
+              FA
             </span>
           </Tooltip>
         ) : null}
@@ -233,6 +250,7 @@ function DraggablePlayer(props: {
   skillViewMode: SkillViewMode
   pairingEnabled?: boolean
   showHomeLeague?: boolean
+  showFaBadge?: boolean
   captainBadge?: '(C)' | '(CC)' | null
 }) {
   const locked = props.player.teamLocked
@@ -250,6 +268,7 @@ function DraggablePlayer(props: {
           skillViewMode={props.skillViewMode}
           pairingEnabled={props.pairingEnabled}
           showHomeLeague={props.showHomeLeague}
+          showFaBadge={props.showFaBadge}
           captainBadge={props.captainBadge}
         />
       </div>
@@ -269,6 +288,7 @@ function DraggablePlayer(props: {
         skillViewMode={props.skillViewMode}
         pairingEnabled={props.pairingEnabled}
         showHomeLeague={props.showHomeLeague}
+        showFaBadge={props.showFaBadge}
         captainBadge={props.captainBadge}
       />
     </div>
@@ -305,6 +325,8 @@ function TeamColumn(props: {
   scoreImbalanced?: boolean
   genderImbalanced?: boolean
   emphasizeUnassigned?: boolean
+  /** Split into Signup / Added free agents subsections */
+  byotSections?: boolean
   pairingEnabled?: boolean
   showHomeLeague?: boolean
   captainBadgeFor?: (player: EventRegistrationListItem) => '(C)' | '(CC)' | null
@@ -316,6 +338,29 @@ function TeamColumn(props: {
   const gender = teamGenderCounts(props.players)
   const count = props.players.length
   const average = count > 0 ? score / count : 0
+  const useByotSections = Boolean(props.byotSections && props.team != null)
+  const signupPlayers = useMemo(
+    () =>
+      useByotSections
+        ? sortPlayers(
+            props.players.filter((p) => p.teamLocked),
+            props.sort,
+            props.skillViewMode
+          )
+        : [],
+    [useByotSections, props.players, props.sort, props.skillViewMode]
+  )
+  const freeAgentPlayers = useMemo(
+    () =>
+      useByotSections
+        ? sortPlayers(
+            props.players.filter((p) => !p.teamLocked),
+            props.sort,
+            props.skillViewMode
+          )
+        : [],
+    [useByotSections, props.players, props.sort, props.skillViewMode]
+  )
   const sortedPlayers = useMemo(
     () => sortPlayers(props.players, props.sort, props.skillViewMode),
     [props.players, props.sort, props.skillViewMode]
@@ -353,6 +398,20 @@ function TeamColumn(props: {
       setCopied(false)
       scheduleReset()
     })
+  }
+
+  function renderPlayer(p: EventRegistrationListItem, showFaBadge: boolean) {
+    return (
+      <DraggablePlayer
+        key={p.id}
+        player={p}
+        skillViewMode={props.skillViewMode}
+        pairingEnabled={props.pairingEnabled}
+        showHomeLeague={props.showHomeLeague}
+        showFaBadge={showFaBadge}
+        captainBadge={props.captainBadgeFor?.(p) ?? null}
+      />
+    )
   }
 
   return (
@@ -456,16 +515,32 @@ function TeamColumn(props: {
         )}
       </div>
       <div className="flex flex-1 flex-col gap-1.5 overflow-y-auto p-2">
-        {sortedPlayers.map((p) => (
-          <DraggablePlayer
-            key={p.id}
-            player={p}
-            skillViewMode={props.skillViewMode}
-            pairingEnabled={props.pairingEnabled}
-            showHomeLeague={props.showHomeLeague}
-            captainBadge={props.captainBadgeFor?.(p) ?? null}
-          />
-        ))}
+        {useByotSections ? (
+          <>
+            <div className="space-y-1.5">
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-amber-900">
+                Signup ({signupPlayers.length})
+              </p>
+              {signupPlayers.length > 0 ? (
+                signupPlayers.map((p) => renderPlayer(p, false))
+              ) : (
+                <p className="text-[10px] text-gray-400">No locked signup players</p>
+              )}
+            </div>
+            <div className="mt-2 space-y-1.5 border-t border-gray-200 pt-2">
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-emerald-900">
+                Added free agents ({freeAgentPlayers.length})
+              </p>
+              {freeAgentPlayers.length > 0 ? (
+                freeAgentPlayers.map((p) => renderPlayer(p, true))
+              ) : (
+                <p className="text-[10px] text-gray-400">Drop free agents here</p>
+              )}
+            </div>
+          </>
+        ) : (
+          sortedPlayers.map((p) => renderPlayer(p, false))
+        )}
       </div>
     </div>
   )
@@ -1027,6 +1102,7 @@ export function EventDraftBoard(props: Props) {
                   teamStats.genderDeltas[t - 1] >
                     Math.max(1, teamStats.avgGenderDelta + 1)
                 }
+                byotSections={byotMode}
                 pairingEnabled={pairingEnabled}
                 showHomeLeague={showHomeLeague}
                 captainBadgeFor={(p) =>

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -111,8 +111,10 @@ export const events = pgTable(
     id: uuid('id').defaultRandom().primaryKey(),
     name: text('name').notNull(),
     eventDate: date('event_date').notNull(),
-    /** Canonical: tournament | open_gym | other */
+    /** Canonical: tournament | league | open_gym | other */
     eventType: text('event_type').notNull().default('tournament'),
+    /** Canonical: byot | remix | draft | null (unset; metadata only) */
+    eventFormat: text('event_format'),
     /** Canonical: foam | cloth */
     ballType: text('ball_type').notNull().default('foam'),
     /** Canonical: mixed | open | she_they */

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -24,6 +24,7 @@ import type {
   EventDraftSnapshotListItem,
   EventRegistrationListItem,
 } from '@/app/lib/events/types'
+import { EVENT_FORMATS, EVENT_TYPES } from '@/app/lib/events/types'
 import { genderGroup } from '@/app/lib/players/gender'
 import {
   HOME_LEAGUES,
@@ -57,6 +58,8 @@ type EventDetail = {
   eventDate: string
   eventType: string
   eventTypeLabel: string
+  eventFormat: string | null
+  eventFormatLabel: string | null
   ballType: string
   ballTypeLabel: string
   gender: string
@@ -304,6 +307,9 @@ function EventTrackerPageContent() {
     [registrations]
   )
 
+  const showFreeAgentTeamLabel =
+    hasByotLocked || event?.eventFormat === 'byot'
+
   /** Team count must cover every locked BYOT signup group so seats stay visible. */
   const minDraftTeamCount = useMemo(() => {
     let maxLocked = 1
@@ -452,6 +458,37 @@ function EventTrackerPageContent() {
       )
     } catch (err) {
       setFormError(err instanceof Error ? err.message : 'Failed to update pairing')
+    }
+  }
+
+  async function updateEventMeta(patch: {
+    eventType?: string
+    eventFormat?: string | null
+  }) {
+    if (!event) return
+    setFormError(null)
+    try {
+      const res = await fetch(`/api/events/${eventId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(patch),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to update event')
+      setEvent((prev) =>
+        prev
+          ? {
+              ...prev,
+              eventType: data.event.eventType,
+              eventTypeLabel: data.event.eventTypeLabel,
+              eventFormat: data.event.eventFormat ?? null,
+              eventFormatLabel: data.event.eventFormatLabel ?? null,
+            }
+          : prev
+      )
+      setMessage('Event updated')
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Failed to update event')
     }
   }
 
@@ -1069,12 +1106,48 @@ function EventTrackerPageContent() {
           </Link>
           <h1 className="text-2xl font-semibold mt-1">{event.name}</h1>
           <p className="text-sm text-gray-600">
-            {formatDisplayDate(event.eventDate)} · {event.eventTypeLabel} ·{' '}
+            {formatDisplayDate(event.eventDate)} · {event.eventTypeLabel}
+            {event.eventFormatLabel ? ` · ${event.eventFormatLabel}` : ''} ·{' '}
             {event.ballTypeLabel} · {event.genderLabel}
           </p>
           {event.notes ? (
             <p className="text-sm text-gray-600 mt-1">{event.notes}</p>
           ) : null}
+          <div className="mt-3 flex flex-wrap gap-3">
+            <label className="block text-sm">
+              <span className="text-gray-600">Type</span>
+              <select
+                className={`mt-1 block rounded border border-gray-300 px-2 py-1.5 ${FOCUS_RING}`}
+                value={event.eventType}
+                onChange={(e) => void updateEventMeta({ eventType: e.target.value })}
+              >
+                {Object.entries(EVENT_TYPES).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="block text-sm">
+              <span className="text-gray-600">Format</span>
+              <select
+                className={`mt-1 block rounded border border-gray-300 px-2 py-1.5 ${FOCUS_RING}`}
+                value={event.eventFormat ?? ''}
+                onChange={(e) =>
+                  void updateEventMeta({
+                    eventFormat: e.target.value === '' ? null : e.target.value,
+                  })
+                }
+              >
+                <option value="">Not set</option>
+                {Object.entries(EVENT_FORMATS).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
           <div className="mt-3">
             <SkillViewModeToggle mode={skillViewMode} onChange={setSkillViewMode} />
           </div>
@@ -1296,7 +1369,7 @@ function EventTrackerPageContent() {
               disabled={event.teamsLocked || teamNamesSaving}
               onClick={() => setTeamNamesDraft((prev) => [...prev, ''])}
             >
-              Add team name
+              {showFreeAgentTeamLabel ? 'Add free agent team' : 'Add team name'}
             </button>
             <button
               type="button"
@@ -1307,6 +1380,12 @@ function EventTrackerPageContent() {
               {teamNamesSaving ? 'Saving…' : 'Save team names'}
             </button>
           </div>
+          {showFreeAgentTeamLabel ? (
+            <FieldHelp>
+              Empty free-agent teams you can fill from Unassigned on the assignment
+              board.
+            </FieldHelp>
+          ) : null}
         </div>
       </section>
 
@@ -1669,6 +1748,15 @@ function EventTrackerPageContent() {
                             <span className="ml-1 text-[10px] font-semibold uppercase tracking-wide text-amber-800">
                               Locked
                             </span>
+                          ) : onTeam && showFreeAgentTeamLabel ? (
+                            <Tooltip
+                              label="Free agent"
+                              content="Added to this team after signup (not an original BYOT member)."
+                            >
+                              <span className="ml-1 text-[10px] font-semibold uppercase tracking-wide text-emerald-800">
+                                FA
+                              </span>
+                            </Tooltip>
                           ) : null}
                           {r.hasStrongPersonality ? (
                             <Tooltip

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -6,6 +6,7 @@ import { withDevMode } from '@/app/lib/devMode'
 import { useDevMode } from '@/app/hooks/useDevMode'
 import {
   BALL_TYPES,
+  EVENT_FORMATS,
   EVENT_GENDERS,
   EVENT_TYPES,
   type EventListItem,
@@ -53,6 +54,7 @@ function EventsPageContent() {
   const [name, setName] = useState('')
   const [eventDate, setEventDate] = useState('')
   const [eventType, setEventType] = useState<string>('tournament')
+  const [eventFormat, setEventFormat] = useState<string>('')
   const [ballType, setBallType] = useState<string>('foam')
   const [gender, setGender] = useState<string>('mixed')
   const [notes, setNotes] = useState('')
@@ -87,6 +89,7 @@ function EventsPageContent() {
           name,
           eventDate,
           eventType,
+          eventFormat: eventFormat || null,
           ballType,
           gender,
           notes: notes.trim() || null,
@@ -98,6 +101,7 @@ function EventsPageContent() {
       setName('')
       setEventDate('')
       setEventType('tournament')
+      setEventFormat('')
       setBallType('foam')
       setGender('mixed')
       setNotes('')
@@ -157,6 +161,7 @@ function EventsPageContent() {
                 <th scope="col" className="px-3 py-2 font-medium">Date</th>
                 <th scope="col" className="px-3 py-2 font-medium">Name</th>
                 <th scope="col" className="px-3 py-2 font-medium">Type</th>
+                <th scope="col" className="px-3 py-2 font-medium">Format</th>
                 <th scope="col" className="px-3 py-2 font-medium">Ball</th>
                 <th scope="col" className="px-3 py-2 font-medium">Gender</th>
                 <th scope="col" className="px-3 py-2 font-medium">Registrations</th>
@@ -177,6 +182,7 @@ function EventsPageContent() {
                     </Link>
                   </td>
                   <td className="px-3 py-2">{event.eventTypeLabel}</td>
+                  <td className="px-3 py-2">{event.eventFormatLabel ?? '—'}</td>
                   <td className="px-3 py-2">{event.ballTypeLabel}</td>
                   <td className="px-3 py-2">{event.genderLabel}</td>
                   <td className="px-3 py-2">{event.registrationCount}</td>
@@ -217,7 +223,7 @@ function EventsPageContent() {
               Type
               <Tooltip
                 label="About event type"
-                content="Tournament, clinic, or other gathering — used for filtering and history."
+                content="Tournament, league, open gym, or other — used for filtering and history."
               />
             </span>
             <select
@@ -226,6 +232,27 @@ function EventsPageContent() {
               onChange={(e) => setEventType(e.target.value)}
             >
               {Object.entries(EVENT_TYPES).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block text-sm">
+            <span className="inline-flex items-center gap-1.5 text-gray-600">
+              Format
+              <Tooltip
+                label="About event format"
+                content="BYOT, Remix, or Draft — labels how teams are formed. Does not change team-maker rules by itself."
+              />
+            </span>
+            <select
+              className="mt-1 w-full rounded border border-gray-300 px-3 py-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+              value={eventFormat}
+              onChange={(e) => setEventFormat(e.target.value)}
+            >
+              <option value="">Not set</option>
+              {Object.entries(EVENT_FORMATS).map(([value, label]) => (
                 <option key={value} value={value}>
                   {label}
                 </option>

--- a/app/lib/events/mutations.ts
+++ b/app/lib/events/mutations.ts
@@ -12,8 +12,10 @@ import {
   isValidEventGender,
   isValidEventType,
   parseDraftGroup,
+  parseEventFormat,
   type BallType,
   type EventDraftSnapshotListItem,
+  type EventFormat,
   type EventGender,
   type EventRecord,
   type EventType,
@@ -59,6 +61,7 @@ export async function createEvent(input: {
   name: string
   eventDate: string
   eventType?: string | null
+  eventFormat?: string | null
   ballType?: string | null
   gender?: string | null
   notes?: string | null
@@ -73,6 +76,12 @@ export async function createEvent(input: {
   if (input.eventType != null && input.eventType !== '') {
     if (!isValidEventType(input.eventType)) throw new Error('Invalid eventType')
     eventType = input.eventType
+  }
+
+  let eventFormat: EventFormat | null = null
+  if (input.eventFormat !== undefined) {
+    const parsed = parseEventFormat(input.eventFormat)
+    eventFormat = parsed === undefined ? null : parsed
   }
 
   let ballType: BallType = 'foam'
@@ -92,7 +101,16 @@ export async function createEvent(input: {
 
   const [created] = await db
     .insert(events)
-    .values({ name, eventDate, eventType, ballType, gender, notes, pairingEnabled })
+    .values({
+      name,
+      eventDate,
+      eventType,
+      eventFormat,
+      ballType,
+      gender,
+      notes,
+      pairingEnabled,
+    })
     .returning()
 
   return mapEventRecord(created)
@@ -104,6 +122,7 @@ export async function updateEvent(
     name?: string
     eventDate?: string
     eventType?: string | null
+    eventFormat?: string | null
     ballType?: string | null
     gender?: string | null
     notes?: string | null
@@ -127,6 +146,7 @@ export async function updateEvent(
     name?: string
     eventDate?: string
     eventType?: string
+    eventFormat?: string | null
     ballType?: string
     gender?: string
     notes?: string | null
@@ -153,6 +173,9 @@ export async function updateEvent(
     } else {
       updates.eventType = patch.eventType
     }
+  }
+  if (patch.eventFormat !== undefined) {
+    updates.eventFormat = parseEventFormat(patch.eventFormat) ?? null
   }
   if (patch.ballType !== undefined) {
     if (patch.ballType == null || patch.ballType === '') {

--- a/app/lib/events/queries.ts
+++ b/app/lib/events/queries.ts
@@ -9,6 +9,7 @@ import {
 } from '@/app/db/schema'
 import {
   ballTypeLabel,
+  eventFormatLabel,
   eventGenderLabel,
   eventTypeLabel,
   type EventListItem,
@@ -34,6 +35,7 @@ export async function listEvents(): Promise<EventListItem[]> {
       name: events.name,
       eventDate: events.eventDate,
       eventType: events.eventType,
+      eventFormat: events.eventFormat,
       ballType: events.ballType,
       gender: events.gender,
       notes: events.notes,
@@ -50,6 +52,8 @@ export async function listEvents(): Promise<EventListItem[]> {
     eventDate: r.eventDate,
     eventType: r.eventType,
     eventTypeLabel: eventTypeLabel(r.eventType),
+    eventFormat: r.eventFormat,
+    eventFormatLabel: eventFormatLabel(r.eventFormat),
     ballType: r.ballType,
     ballTypeLabel: ballTypeLabel(r.ballType),
     gender: r.gender,

--- a/app/lib/events/types.ts
+++ b/app/lib/events/types.ts
@@ -1,10 +1,19 @@
 export const EVENT_TYPES = {
   tournament: 'Tournament',
+  league: 'League',
   open_gym: 'Open gym',
   other: 'Other',
 } as const
 
 export type EventType = keyof typeof EVENT_TYPES
+
+export const EVENT_FORMATS = {
+  byot: 'BYOT',
+  remix: 'Remix',
+  draft: 'Draft',
+} as const
+
+export type EventFormat = keyof typeof EVENT_FORMATS
 
 export const BALL_TYPES = {
   foam: 'Foam',
@@ -32,6 +41,8 @@ export type EventRecord = {
   name: string
   eventDate: string
   eventType: string
+  /** Canonical: byot | remix | draft | null (unset) */
+  eventFormat: string | null
   ballType: string
   gender: string
   notes: string | null
@@ -49,6 +60,8 @@ export type EventListItem = {
   eventDate: string
   eventType: string
   eventTypeLabel: string
+  eventFormat: string | null
+  eventFormatLabel: string | null
   ballType: string
   ballTypeLabel: string
   gender: string
@@ -118,12 +131,40 @@ export type EventDraftSnapshotListItem = {
 }
 
 export function isValidEventType(value: unknown): value is EventType {
-  return value === 'tournament' || value === 'open_gym' || value === 'other'
+  return (
+    value === 'tournament' ||
+    value === 'league' ||
+    value === 'open_gym' ||
+    value === 'other'
+  )
 }
 
 export function eventTypeLabel(type: string | null | undefined): string {
   if (type && isValidEventType(type)) return EVENT_TYPES[type]
   return EVENT_TYPES.other
+}
+
+export function isValidEventFormat(value: unknown): value is EventFormat {
+  return value === 'byot' || value === 'remix' || value === 'draft'
+}
+
+/** Parse format from API input; empty/null clears. Undefined means omit. */
+export function parseEventFormat(
+  value: unknown
+): EventFormat | null | undefined {
+  if (value === undefined) return undefined
+  if (value === null || value === '') return null
+  if (!isValidEventFormat(value)) {
+    throw new Error('Invalid eventFormat')
+  }
+  return value
+}
+
+export function eventFormatLabel(
+  format: string | null | undefined
+): string | null {
+  if (format && isValidEventFormat(format)) return EVENT_FORMATS[format]
+  return null
 }
 
 export function isValidBallType(value: unknown): value is BallType {

--- a/drizzle/0024_event_format.sql
+++ b/drizzle/0024_event_format.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "events" ADD COLUMN IF NOT EXISTS "event_format" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1787320800000,
       "tag": "0023_event_registration_team_locked",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1787324400000,
+      "tag": "0024_event_format",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add event type `league` and nullable format metadata (`BYOT` / `Remix` / `Draft`)
- Rename “Add team name” to “Add free agent team” for BYOT events
- Split BYOT assignment-board teams into Signup vs Added free agents (with FA badges)

## Test plan
- [ ] Create a League event with format BYOT; confirm type/format show in list and detail header
- [ ] Change type/format on event detail; confirm they persist
- [ ] Import BYOT CSV; confirm locked players are excluded from Group with and appear under Signup
- [ ] Drag free agents onto a team; confirm they land under Added free agents with FA badge
- [ ] Click Add free agent team on a BYOT event; save and use on the board
- [ ] Run migration `0024_event_format` against the target DB


Made with [Cursor](https://cursor.com)