### PR TITLE
Promote preview: admin login return path validation

### DIFF
--- a/app/__tests__/admin-google-callback.test.ts
+++ b/app/__tests__/admin-google-callback.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+const adminAuth = vi.hoisted(() => ({
+  alertWatchedAdminLoginAttempt: vi.fn().mockResolvedValue(undefined),
+  clearAdminOAuthStateCookie: vi.fn(),
+  isAllowedAdminEmail: vi.fn(() => true),
+  readAdminOAuthState: vi.fn(() => 'expected-state'),
+  setAdminSessionCookie: vi.fn(() => true),
+}))
+
+vi.mock('@/app/lib/admin-auth', () => adminAuth)
+
+import { GET } from '@/app/api/admin/google/callback/route'
+
+describe('admin Google callback', () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    vi.stubEnv('ADMIN_GOOGLE_CLIENT_ID', 'google-client-id')
+    vi.stubEnv('ADMIN_GOOGLE_CLIENT_SECRET', 'google-client-secret')
+    vi.stubGlobal('fetch', fetchMock)
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ id_token: 'google-id-token' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          aud: 'google-client-id',
+          email: 'admin@example.com',
+          email_verified: 'true',
+        }),
+      })
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('keeps a decoded return-path cookie on the request origin', async () => {
+    const requestUrl =
+      'https://admin.example.com/api/admin/google/callback?state=expected-state&code=code'
+    const request = {
+      url: requestUrl,
+      nextUrl: new URL(requestUrl),
+      cookies: {
+        get: (name: string) =>
+          name === 'admin_oauth_next'
+            ? { name, value: '/\\example.com' }
+            : undefined,
+      },
+    } as unknown as NextRequest
+
+    const response = await GET(request)
+
+    expect(response.headers.get('location')).toBe(
+      'https://admin.example.com/schedules'
+    )
+  })
+})

--- a/app/__tests__/admin-login-next.test.tsx
+++ b/app/__tests__/admin-login-next.test.tsx
@@ -1,0 +1,42 @@
+import { render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const login = vi.hoisted(() => ({
+  fetchAdminSession: vi.fn(),
+  nextValue: '/\\example.com',
+  replace: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: login.replace }),
+  useSearchParams: () => ({
+    get: (key: string) => (key === 'next' ? login.nextValue : null),
+  }),
+}))
+
+vi.mock('@/app/lib/admin-client-auth', () => ({
+  fetchAdminSession: login.fetchAdminSession,
+}))
+
+import LoginPage from '@/app/login/page'
+
+describe('admin login return path', () => {
+  beforeEach(() => {
+    login.nextValue = '/\\example.com'
+    login.fetchAdminSession.mockResolvedValue({ email: 'admin@example.com' })
+    document.cookie = 'admin_oauth_next=; path=/; max-age=0'
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uses the safe fallback for the session redirect and OAuth cookie', async () => {
+    render(<LoginPage />)
+
+    await waitFor(() => {
+      expect(login.replace).toHaveBeenCalledWith('/schedules')
+      expect(document.cookie).toContain('admin_oauth_next=%2Fschedules')
+    })
+  })
+})

--- a/app/__tests__/admin-next.test.ts
+++ b/app/__tests__/admin-next.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_ADMIN_NEXT_PATH,
+  safeAdminNextPath,
+} from '@/app/lib/admin-next'
+
+describe('safeAdminNextPath', () => {
+  it.each([
+    ['/', '/'],
+    ['/players', '/players'],
+    ['/players?dev=1', '/players?dev=1'],
+    ['/events/123?tab=draft#teams', '/events/123?tab=draft#teams'],
+    ['/events/../players', '/players'],
+    ['/%2f%2fexample.com', '/%2f%2fexample.com'],
+    ['/%5cexample.com', '/%5cexample.com'],
+    ['/players/Zoë?tab=notes#bio', '/players/Zo%C3%AB?tab=notes#bio'],
+  ])('keeps app-relative destinations: %s', (value, expected) => {
+    expect(safeAdminNextPath(value)).toBe(expected)
+  })
+
+  it.each([
+    null,
+    undefined,
+    '',
+    'players',
+    'https://example.com',
+    '//example.com',
+    '//admin.invalid/path',
+    '///example.com',
+    '/\\example.com',
+    '/\\admin.invalid/path',
+    '/safe/..//example.com',
+    '/safe/%2e%2e//example.com',
+    '/.//example.com',
+    '/\t/example.com',
+    '/\r/example.com',
+    '/players\n/settings',
+    '/players\u007f/settings',
+  ])('falls back for an unsafe destination: %s', (value) => {
+    expect(safeAdminNextPath(value)).toBe(DEFAULT_ADMIN_NEXT_PATH)
+  })
+
+  it.each([
+    '/players',
+    '/players?next=//example.com',
+    '/events/../players',
+  ])('always resolves on the app origin: %s', (value) => {
+    const destination = safeAdminNextPath(value)
+    expect(new URL(destination, 'https://admin.example.com').origin).toBe(
+      'https://admin.example.com'
+    )
+  })
+})

--- a/app/api/admin/google/callback/route.ts
+++ b/app/api/admin/google/callback/route.ts
@@ -6,6 +6,7 @@ import {
   readAdminOAuthState,
   setAdminSessionCookie,
 } from '@/app/lib/admin-auth'
+import { safeAdminNextPath } from '@/app/lib/admin-next'
 
 function adminBaseUrl(request: NextRequest): URL {
   const appUrl = process.env.NEXT_PUBLIC_APP_URL?.trim()
@@ -86,10 +87,7 @@ export async function GET(request: NextRequest) {
   }
 
   const nextParam = request.cookies.get('admin_oauth_next')?.value
-  const destination =
-    nextParam && nextParam.startsWith('/') && !nextParam.startsWith('//')
-      ? nextParam
-      : '/schedules'
+  const destination = safeAdminNextPath(nextParam)
 
   const response = NextResponse.redirect(new URL(destination, request.url))
   clearAdminOAuthStateCookie(response)

--- a/app/components/ThemeProvider.tsx
+++ b/app/components/ThemeProvider.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import { ThemeProvider as NextThemesProvider } from 'next-themes'
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <NextThemesProvider attribute="class" defaultTheme="system" enableSystem>
+      {children}
+    </NextThemesProvider>
+  )
+}

--- a/app/components/ThemeToggle.tsx
+++ b/app/components/ThemeToggle.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { useTheme } from 'next-themes'
+import { useEffect, useState } from 'react'
+
+const THEMES = [
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+  { value: 'system', label: 'System' },
+] as const
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted) {
+    return (
+      <label className="flex items-center gap-2">
+        <span className="sr-only">Theme</span>
+        <select
+          aria-label="Theme"
+          disabled
+          className="rounded border border-gray-500 bg-gray-700 px-2 py-1 text-sm text-gray-100"
+        >
+          <option>System</option>
+        </select>
+      </label>
+    )
+  }
+
+  return (
+    <label className="flex items-center gap-2">
+      <span className="text-gray-200">Theme</span>
+      <select
+        aria-label="Theme"
+        value={theme ?? 'system'}
+        onChange={(event) => setTheme(event.target.value)}
+        className="rounded border border-gray-500 bg-gray-700 px-2 py-1 text-sm text-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+      >
+        {THEMES.map(({ value, label }) => (
+          <option key={value} value={value}>
+            {label}
+          </option>
+        ))}
+      </select>
+    </label>
+  )
+}

--- a/app/components/TopNav.tsx
+++ b/app/components/TopNav.tsx
@@ -7,6 +7,7 @@ import { useDevMode } from '@/app/hooks/useDevMode'
 import { withDevMode } from '@/app/lib/devMode'
 import { fetchAdminSession, logoutAdminSession } from '@/app/lib/admin-client-auth'
 import BoardAppsMenu from '@/app/components/BoardAppsMenu'
+import { ThemeToggle } from '@/app/components/ThemeToggle'
 import { Tooltip } from '@/app/components/ui'
 import type { AdminNotificationRecord } from '@/app/lib/video-tools/types'
 
@@ -360,6 +361,7 @@ export default function TopNav() {
         )}
       </div>
       <div className="flex items-center gap-4 text-sm">
+        <ThemeToggle />
         <NotificationsBell enabled={Boolean(email)} devMode={devMode} />
         <BoardAppsMenu currentApp="admin" />
         {email ? (

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,9 +1,17 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 :root {
   --background: #ffffff;
   --foreground: #171717;
   color-scheme: light;
+}
+
+.dark {
+  --background: #111827;
+  --foreground: #f9fafb;
+  color-scheme: dark;
 }
 
 @theme inline {
@@ -13,6 +21,7 @@
   --font-mono: var(--font-geist-mono);
 }
 
+html,
 body {
   background: var(--background);
   color: var(--foreground);
@@ -42,8 +51,7 @@ body {
   color-scheme: light dark;
 }
 
-@media (prefers-color-scheme: dark) {
-  .team-maker {
+.dark .team-maker {
     --tm-bg: #111827;
     --tm-fg: #f9fafb;
     --tm-muted: #9ca3af;
@@ -60,6 +68,5 @@ body {
     --tm-card-wnbo-bg: #881337;
     --tm-card-wnbo-border: #fb7185;
     --tm-link: #93c5fd;
-  }
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Suspense } from "react";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import TopNav from "./components/TopNav";
+import { ThemeProvider } from "./components/ThemeProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -25,20 +26,22 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} min-h-screen antialiased bg-background text-foreground`}
       >
-        <a
-          href="#main-content"
-          className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded focus:bg-white focus:px-3 focus:py-2 focus:text-sm focus:font-medium focus:text-gray-900 focus:shadow-lg focus:outline focus:outline-2 focus:outline-blue-600"
-        >
-          Skip to content
-        </a>
-        <Suspense fallback={<nav className="bg-gray-800 p-4 h-[52px]" aria-label="Loading navigation" />}>
-          <TopNav />
-        </Suspense>
-        <main id="main-content">{children}</main>
+        <ThemeProvider>
+          <a
+            href="#main-content"
+            className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded focus:bg-white focus:px-3 focus:py-2 focus:text-sm focus:font-medium focus:text-gray-900 focus:shadow-lg focus:outline focus:outline-2 focus:outline-blue-600 dark:focus:bg-gray-800 dark:focus:text-gray-100"
+          >
+            Skip to content
+          </a>
+          <Suspense fallback={<nav className="bg-gray-800 p-4 h-[52px]" aria-label="Loading navigation" />}>
+            <TopNav />
+          </Suspense>
+          <main id="main-content">{children}</main>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/lib/admin-next.ts
+++ b/app/lib/admin-next.ts
@@ -1,0 +1,29 @@
+export const DEFAULT_ADMIN_NEXT_PATH = '/schedules'
+
+const ADMIN_NEXT_BASE = 'https://admin.invalid'
+const UNSAFE_ADMIN_NEXT_CHARACTERS = /[\\\u0000-\u001f\u007f]/
+
+export function safeAdminNextPath(value: string | null | undefined): string {
+  if (
+    !value ||
+    !value.startsWith('/') ||
+    value.startsWith('//') ||
+    UNSAFE_ADMIN_NEXT_CHARACTERS.test(value)
+  ) {
+    return DEFAULT_ADMIN_NEXT_PATH
+  }
+
+  try {
+    const url = new URL(value, ADMIN_NEXT_BASE)
+    if (url.origin !== ADMIN_NEXT_BASE) return DEFAULT_ADMIN_NEXT_PATH
+
+    const destination = `${url.pathname}${url.search}${url.hash}`
+    if (!destination.startsWith('/') || destination.startsWith('//')) {
+      return DEFAULT_ADMIN_NEXT_PATH
+    }
+
+    return destination
+  } catch {
+    return DEFAULT_ADMIN_NEXT_PATH
+  }
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { fetchAdminSession } from '@/app/lib/admin-client-auth'
+import { safeAdminNextPath } from '@/app/lib/admin-next'
 import { LiveMessage } from '@/app/components/ui'
 
 function adminErrorMessage(error: string | null): string | null {
@@ -20,19 +21,17 @@ function LoginContent() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const errorMessage = adminErrorMessage(searchParams.get('error'))
-  const next = searchParams.get('next') || '/schedules'
+  const next = safeAdminNextPath(searchParams.get('next'))
 
   useEffect(() => {
     void fetchAdminSession().then((session) => {
-      if (session) router.replace(next.startsWith('/') ? next : '/schedules')
+      if (session) router.replace(next)
     })
   }, [router, next])
 
   useEffect(() => {
-    if (next && next.startsWith('/') && !next.startsWith('//')) {
-      const secure = location.protocol === 'https:' ? '; secure' : ''
-      document.cookie = `admin_oauth_next=${encodeURIComponent(next)}; path=/; max-age=600; samesite=lax${secure}`
-    }
+    const secure = location.protocol === 'https:' ? '; secure' : ''
+    document.cookie = `admin_oauth_next=${encodeURIComponent(next)}; path=/; max-age=600; samesite=lax${secure}`
   }, [next])
 
   const loginHref = '/api/admin/google/login'

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@vercel/blob": "^2.4.0",
         "drizzle-orm": "^0.45.2",
         "next": "15.2.8",
+        "next-themes": "^0.4.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "resend": "^6.18.1",
@@ -7591,6 +7592,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@vercel/blob": "^2.4.0",
     "drizzle-orm": "^0.45.2",
     "next": "15.2.8",
+    "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "resend": "^6.18.1",


### PR DESCRIPTION
## Summary
- Promote [#140](https://github.com/jsartin513/bdl-admin/pull/140) from preview to production
- Validate admin login `next` return paths so protocol-relative, backslash, and control-character destinations fall back to `/schedules`
- Cover `safeAdminNextPath`, the login page cookie/redirect, and the Google OAuth callback

## Test plan
- [ ] Confirm preview deploy login still returns to in-app paths after Google OAuth
- [ ] Main merge gate (`from-preview` + preview smoke) is green
- [ ] Spot-check login with a safe `?next=/players` and an unsafe `?next=//example.com` after merge


Made with [Cursor](https://cursor.com)