### PR TITLE
Add global light/dark/system theme toggle

### DIFF
--- a/app/components/ThemeProvider.tsx
+++ b/app/components/ThemeProvider.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import { ThemeProvider as NextThemesProvider } from 'next-themes'
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <NextThemesProvider attribute="class" defaultTheme="system" enableSystem>
+      {children}
+    </NextThemesProvider>
+  )
+}

--- a/app/components/ThemeToggle.tsx
+++ b/app/components/ThemeToggle.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { useTheme } from 'next-themes'
+import { useEffect, useState } from 'react'
+
+const THEMES = [
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+  { value: 'system', label: 'System' },
+] as const
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted) {
+    return (
+      <label className="flex items-center gap-2">
+        <span className="sr-only">Theme</span>
+        <select
+          aria-label="Theme"
+          disabled
+          className="rounded border border-gray-500 bg-gray-700 px-2 py-1 text-sm text-gray-100"
+        >
+          <option>System</option>
+        </select>
+      </label>
+    )
+  }
+
+  return (
+    <label className="flex items-center gap-2">
+      <span className="text-gray-200">Theme</span>
+      <select
+        aria-label="Theme"
+        value={theme ?? 'system'}
+        onChange={(event) => setTheme(event.target.value)}
+        className="rounded border border-gray-500 bg-gray-700 px-2 py-1 text-sm text-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+      >
+        {THEMES.map(({ value, label }) => (
+          <option key={value} value={value}>
+            {label}
+          </option>
+        ))}
+      </select>
+    </label>
+  )
+}

--- a/app/components/TopNav.tsx
+++ b/app/components/TopNav.tsx
@@ -7,6 +7,7 @@ import { useDevMode } from '@/app/hooks/useDevMode'
 import { withDevMode } from '@/app/lib/devMode'
 import { fetchAdminSession, logoutAdminSession } from '@/app/lib/admin-client-auth'
 import BoardAppsMenu from '@/app/components/BoardAppsMenu'
+import { ThemeToggle } from '@/app/components/ThemeToggle'
 import { Tooltip } from '@/app/components/ui'
 import type { AdminNotificationRecord } from '@/app/lib/video-tools/types'
 
@@ -360,6 +361,7 @@ export default function TopNav() {
         )}
       </div>
       <div className="flex items-center gap-4 text-sm">
+        <ThemeToggle />
         <NotificationsBell enabled={Boolean(email)} devMode={devMode} />
         <BoardAppsMenu currentApp="admin" />
         {email ? (

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,9 +1,17 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 :root {
   --background: #ffffff;
   --foreground: #171717;
   color-scheme: light;
+}
+
+.dark {
+  --background: #111827;
+  --foreground: #f9fafb;
+  color-scheme: dark;
 }
 
 @theme inline {
@@ -13,6 +21,7 @@
   --font-mono: var(--font-geist-mono);
 }
 
+html,
 body {
   background: var(--background);
   color: var(--foreground);
@@ -42,8 +51,7 @@ body {
   color-scheme: light dark;
 }
 
-@media (prefers-color-scheme: dark) {
-  .team-maker {
+.dark .team-maker {
     --tm-bg: #111827;
     --tm-fg: #f9fafb;
     --tm-muted: #9ca3af;
@@ -60,6 +68,5 @@ body {
     --tm-card-wnbo-bg: #881337;
     --tm-card-wnbo-border: #fb7185;
     --tm-link: #93c5fd;
-  }
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Suspense } from "react";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import TopNav from "./components/TopNav";
+import { ThemeProvider } from "./components/ThemeProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -25,20 +26,22 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} min-h-screen antialiased bg-background text-foreground`}
       >
-        <a
-          href="#main-content"
-          className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded focus:bg-white focus:px-3 focus:py-2 focus:text-sm focus:font-medium focus:text-gray-900 focus:shadow-lg focus:outline focus:outline-2 focus:outline-blue-600"
-        >
-          Skip to content
-        </a>
-        <Suspense fallback={<nav className="bg-gray-800 p-4 h-[52px]" aria-label="Loading navigation" />}>
-          <TopNav />
-        </Suspense>
-        <main id="main-content">{children}</main>
+        <ThemeProvider>
+          <a
+            href="#main-content"
+            className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded focus:bg-white focus:px-3 focus:py-2 focus:text-sm focus:font-medium focus:text-gray-900 focus:shadow-lg focus:outline focus:outline-2 focus:outline-blue-600 dark:focus:bg-gray-800 dark:focus:text-gray-100"
+          >
+            Skip to content
+          </a>
+          <Suspense fallback={<nav className="bg-gray-800 p-4 h-[52px]" aria-label="Loading navigation" />}>
+            <TopNav />
+          </Suspense>
+          <main id="main-content">{children}</main>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@vercel/blob": "^2.4.0",
         "drizzle-orm": "^0.45.2",
         "next": "15.2.8",
+        "next-themes": "^0.4.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "resend": "^6.18.1",
@@ -7591,6 +7592,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@vercel/blob": "^2.4.0",
     "drizzle-orm": "^0.45.2",
     "next": "15.2.8",
+    "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "resend": "^6.18.1",


### PR DESCRIPTION
## Summary
- Adds app-wide theme support via `next-themes` with Light, Dark, and System options
- Fixes white page background outside team-maker by applying dark mode globally through shared CSS variables on `html`/`body`
- Moves team-maker dark tokens from OS-only `prefers-color-scheme` to the shared `.dark` class so they follow the user-selected theme

## Test plan
- [ ] Open any page and use the Theme dropdown in the top nav
- [ ] Verify Light mode uses a white page background
- [ ] Verify Dark mode uses a dark page background (no white margins outside content)
- [ ] Verify System mode follows OS preference
- [ ] On an event detail page, confirm team-maker UI still looks correct in both light and dark modes
- [ ] Refresh the page and confirm the selected theme persists


Made with [Cursor](https://cursor.com)